### PR TITLE
feat: dashboard cleanup — branding, cost formatting, teams extraction

### DIFF
--- a/packages/web/src/__tests__/navigation.test.ts
+++ b/packages/web/src/__tests__/navigation.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  BASE_NAV_GROUPS,
+  ADMIN_NAV_GROUP,
+  getNavGroups,
+  ROUTE_LABELS,
+  breadcrumbsFromPathname,
+} from "@/lib/navigation";
+
+// ---------------------------------------------------------------------------
+// Sidebar navigation structure
+// ---------------------------------------------------------------------------
+
+describe("sidebar navigation", () => {
+  describe("BASE_NAV_GROUPS", () => {
+    it("should have three groups: Overview, Analytics, Settings", () => {
+      const labels = BASE_NAV_GROUPS.map((g) => g.label);
+      expect(labels).toEqual(["Overview", "Analytics", "Settings"]);
+    });
+
+    it("should not have a group called Account", () => {
+      const labels = BASE_NAV_GROUPS.map((g) => g.label);
+      expect(labels).not.toContain("Account");
+    });
+
+    it("Settings group should contain Teams before General", () => {
+      const settingsGroup = BASE_NAV_GROUPS.find((g) => g.label === "Settings");
+      expect(settingsGroup).toBeDefined();
+      const items = settingsGroup!.items.map((i) => i.label);
+      expect(items).toEqual(["Teams", "General"]);
+    });
+
+    it("Teams should link to /teams", () => {
+      const settingsGroup = BASE_NAV_GROUPS.find((g) => g.label === "Settings")!;
+      const teamsItem = settingsGroup.items.find((i) => i.label === "Teams");
+      expect(teamsItem).toBeDefined();
+      expect(teamsItem!.href).toBe("/teams");
+    });
+
+    it("General should link to /settings", () => {
+      const settingsGroup = BASE_NAV_GROUPS.find((g) => g.label === "Settings")!;
+      const generalItem = settingsGroup.items.find((i) => i.label === "General");
+      expect(generalItem).toBeDefined();
+      expect(generalItem!.href).toBe("/settings");
+    });
+
+    it("should contain all expected nav items across groups", () => {
+      const allHrefs = BASE_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.href));
+      expect(allHrefs).toContain("/");
+      expect(allHrefs).toContain("/leaderboard");
+      expect(allHrefs).toContain("/details");
+      expect(allHrefs).toContain("/sessions");
+      expect(allHrefs).toContain("/apps");
+      expect(allHrefs).toContain("/models");
+      expect(allHrefs).toContain("/teams");
+      expect(allHrefs).toContain("/settings");
+    });
+
+    it("should have no duplicate hrefs", () => {
+      const allHrefs = BASE_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.href));
+      expect(new Set(allHrefs).size).toBe(allHrefs.length);
+    });
+  });
+
+  describe("getNavGroups", () => {
+    it("should return base groups for non-admin users", () => {
+      const groups = getNavGroups(false);
+      expect(groups).toEqual(BASE_NAV_GROUPS);
+      expect(groups).toHaveLength(3);
+    });
+
+    it("should append Admin group for admin users", () => {
+      const groups = getNavGroups(true);
+      expect(groups).toHaveLength(4);
+      expect(groups[3]!.label).toBe("Admin");
+      expect(groups[3]).toEqual(ADMIN_NAV_GROUP);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route labels & breadcrumbs
+// ---------------------------------------------------------------------------
+
+describe("route labels", () => {
+  it("should map settings to General", () => {
+    expect(ROUTE_LABELS["settings"]).toBe("General");
+  });
+
+  it("should map teams to Teams", () => {
+    expect(ROUTE_LABELS["teams"]).toBe("Teams");
+  });
+
+  it("should include all expected routes", () => {
+    expect(ROUTE_LABELS).toEqual({
+      settings: "General",
+      teams: "Teams",
+      details: "Daily Usage",
+      apps: "By App",
+      models: "By Model",
+      leaderboard: "Leaderboard",
+    });
+  });
+});
+
+describe("breadcrumbsFromPathname", () => {
+  it("should return Home for root path", () => {
+    expect(breadcrumbsFromPathname("/")).toEqual([{ label: "Home", href: "/" }]);
+  });
+
+  it("should return breadcrumbs for /settings", () => {
+    const crumbs = breadcrumbsFromPathname("/settings");
+    expect(crumbs).toEqual([
+      { label: "Home", href: "/" },
+      { label: "General" },
+    ]);
+  });
+
+  it("should return breadcrumbs for /teams", () => {
+    const crumbs = breadcrumbsFromPathname("/teams");
+    expect(crumbs).toEqual([
+      { label: "Home", href: "/" },
+      { label: "Teams" },
+    ]);
+  });
+
+  it("should return breadcrumbs for nested routes", () => {
+    const crumbs = breadcrumbsFromPathname("/admin/pricing");
+    expect(crumbs).toEqual([
+      { label: "Home", href: "/" },
+      { label: "admin", href: "/admin" },
+      { label: "pricing" },
+    ]);
+  });
+
+  it("should use route label for known segments", () => {
+    const crumbs = breadcrumbsFromPathname("/details");
+    expect(crumbs).toEqual([
+      { label: "Home", href: "/" },
+      { label: "Daily Usage" },
+    ]);
+  });
+
+  it("should truncate unknown segment labels to 8 chars", () => {
+    const crumbs = breadcrumbsFromPathname("/longersegmentname");
+    expect(crumbs[1]!.label).toBe("longerse");
+  });
+});

--- a/packages/web/src/__tests__/pricing.test.ts
+++ b/packages/web/src/__tests__/pricing.test.ts
@@ -151,9 +151,11 @@ describe("pricing", () => {
       expect(formatCost(99.99)).toBe("$99.99");
     });
 
-    it("should format large costs without decimals", () => {
+    it("should format large costs with thousand separators and no decimals", () => {
       expect(formatCost(100)).toBe("$100");
-      expect(formatCost(1234.56)).toBe("$1235");
+      expect(formatCost(1234.56)).toBe("$1,235");
+      expect(formatCost(12345.67)).toBe("$12,346");
+      expect(formatCost(1234567.89)).toBe("$1,234,568");
     });
   });
 

--- a/packages/web/src/app/(dashboard)/settings/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/page.tsx
@@ -4,12 +4,6 @@ import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import {
   User,
-  Users,
-  Plus,
-  LogIn,
-  Copy,
-  Check,
-  Trash2,
   ExternalLink,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -25,43 +19,6 @@ interface UserSettings {
   slug: string | null;
 }
 
-interface Team {
-  id: string;
-  name: string;
-  slug: string;
-  invite_code: string;
-  created_by: string;
-  member_count: number;
-}
-
-// ---------------------------------------------------------------------------
-// CopyButton
-// ---------------------------------------------------------------------------
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <button
-      onClick={handleCopy}
-      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-      title="Copy to clipboard"
-    >
-      {copied ? (
-        <Check className="h-3.5 w-3.5 text-success" strokeWidth={1.5} />
-      ) : (
-        <Copy className="h-3.5 w-3.5" strokeWidth={1.5} />
-      )}
-    </button>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Settings Page
 // ---------------------------------------------------------------------------
@@ -75,16 +32,6 @@ export default function SettingsPage() {
   const [slug, setSlug] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
-
-  // Teams state
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [showCreateTeam, setShowCreateTeam] = useState(false);
-  const [newTeamName, setNewTeamName] = useState("");
-  const [creatingTeam, setCreatingTeam] = useState(false);
-  const [showJoinTeam, setShowJoinTeam] = useState(false);
-  const [inviteCode, setInviteCode] = useState("");
-  const [joiningTeam, setJoiningTeam] = useState(false);
-  const [teamMessage, setTeamMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
   const userName = session?.user?.name ?? "User";
   const userEmail = session?.user?.email ?? "";
@@ -108,22 +55,9 @@ export default function SettingsPage() {
     }
   }, []);
 
-  const fetchTeams = useCallback(async () => {
-    try {
-      const res = await fetch("/api/teams");
-      if (res.ok) {
-        const data = await res.json();
-        setTeams(data.teams ?? []);
-      }
-    } catch {
-      // Silently fail
-    }
-  }, []);
-
   useEffect(() => {
     fetchSettings();
-    fetchTeams();
-  }, [fetchSettings, fetchTeams]);
+  }, [fetchSettings]);
 
   // ---------------------------------------------------------------------------
   // Save settings
@@ -173,101 +107,6 @@ export default function SettingsPage() {
   };
 
   // ---------------------------------------------------------------------------
-  // Create team
-  // ---------------------------------------------------------------------------
-
-  const handleCreateTeam = async () => {
-    if (!newTeamName.trim()) return;
-    setCreatingTeam(true);
-    setTeamMessage(null);
-
-    try {
-      const res = await fetch("/api/teams", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newTeamName.trim() }),
-      });
-
-      if (res.ok) {
-        setNewTeamName("");
-        setShowCreateTeam(false);
-        setTeamMessage({ type: "success", text: "Team created!" });
-        fetchTeams();
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setTeamMessage({
-          type: "error",
-          text: (data as { error?: string }).error ?? "Failed to create team.",
-        });
-      }
-    } catch {
-      setTeamMessage({ type: "error", text: "Network error." });
-    } finally {
-      setCreatingTeam(false);
-    }
-  };
-
-  // ---------------------------------------------------------------------------
-  // Join team
-  // ---------------------------------------------------------------------------
-
-  const handleJoinTeam = async () => {
-    if (!inviteCode.trim()) return;
-    setJoiningTeam(true);
-    setTeamMessage(null);
-
-    try {
-      const res = await fetch("/api/teams/join", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ invite_code: inviteCode.trim() }),
-      });
-
-      if (res.ok) {
-        setInviteCode("");
-        setShowJoinTeam(false);
-        setTeamMessage({ type: "success", text: "Joined team!" });
-        fetchTeams();
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setTeamMessage({
-          type: "error",
-          text: (data as { error?: string }).error ?? "Failed to join team.",
-        });
-      }
-    } catch {
-      setTeamMessage({ type: "error", text: "Network error." });
-    } finally {
-      setJoiningTeam(false);
-    }
-  };
-
-  // ---------------------------------------------------------------------------
-  // Leave team
-  // ---------------------------------------------------------------------------
-
-  const handleLeaveTeam = async (teamId: string) => {
-    if (!confirm("Are you sure you want to leave this team?")) return;
-    setTeamMessage(null);
-
-    try {
-      const res = await fetch(`/api/teams/${teamId}`, { method: "DELETE" });
-      if (res.ok) {
-        setTeamMessage({ type: "success", text: "Left team." });
-        fetchTeams();
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setTeamMessage({
-          type: "error",
-          text: (data as { error?: string }).error ?? "Failed to leave team.",
-        });
-      }
-    } catch {
-      setTeamMessage({ type: "error", text: "Network error." });
-    }
-  };
-
-  // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
 
@@ -275,9 +114,9 @@ export default function SettingsPage() {
     <div className="max-w-3xl space-y-8">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold font-display">Settings</h1>
+        <h1 className="text-2xl font-bold font-display">General</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Account settings, leaderboard nickname, and team management.
+          Account settings and public profile.
         </p>
       </div>
 
@@ -384,159 +223,6 @@ export default function SettingsPage() {
             )}
           </div>
         </div>
-      </section>
-
-      <Separator />
-
-      {/* Teams Section */}
-      <section>
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="flex items-center gap-2 text-sm font-medium text-foreground">
-            <Users className="h-4 w-4" strokeWidth={1.5} />
-            Teams
-          </h2>
-          <div className="flex gap-2">
-            <button
-              onClick={() => {
-                setShowJoinTeam(!showJoinTeam);
-                setShowCreateTeam(false);
-              }}
-              className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-            >
-              <LogIn className="h-3.5 w-3.5" strokeWidth={1.5} />
-              Join
-            </button>
-            <button
-              onClick={() => {
-                setShowCreateTeam(!showCreateTeam);
-                setShowJoinTeam(false);
-              }}
-              className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-            >
-              <Plus className="h-3.5 w-3.5" strokeWidth={1.5} />
-              Create
-            </button>
-          </div>
-        </div>
-
-        {/* Team message */}
-        {teamMessage && (
-          <div
-            className={cn(
-              "rounded-lg p-3 text-xs mb-3",
-              teamMessage.type === "success"
-                ? "bg-success/10 text-success"
-                : "bg-destructive/10 text-destructive",
-            )}
-          >
-            {teamMessage.text}
-          </div>
-        )}
-
-        {/* Create team form */}
-        {showCreateTeam && (
-          <div className="rounded-xl bg-secondary p-4 mb-3">
-            <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-              Team Name
-            </label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={newTeamName}
-                onChange={(e) => setNewTeamName(e.target.value)}
-                placeholder="My Team"
-                maxLength={64}
-                className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring/20 transition-shadow min-w-0"
-                onKeyDown={(e) => e.key === "Enter" && handleCreateTeam()}
-              />
-              <button
-                onClick={handleCreateTeam}
-                disabled={creatingTeam || !newTeamName.trim()}
-                className={cn(
-                  "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors shrink-0",
-                  (creatingTeam || !newTeamName.trim()) && "opacity-50 cursor-not-allowed",
-                )}
-              >
-                {creatingTeam ? "Creating..." : "Create"}
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Join team form */}
-        {showJoinTeam && (
-          <div className="rounded-xl bg-secondary p-4 mb-3">
-            <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-              Invite Code
-            </label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={inviteCode}
-                onChange={(e) => setInviteCode(e.target.value)}
-                placeholder="e.g. abc12345"
-                maxLength={32}
-                className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring/20 transition-shadow min-w-0"
-                onKeyDown={(e) => e.key === "Enter" && handleJoinTeam()}
-              />
-              <button
-                onClick={handleJoinTeam}
-                disabled={joiningTeam || !inviteCode.trim()}
-                className={cn(
-                  "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors shrink-0",
-                  (joiningTeam || !inviteCode.trim()) && "opacity-50 cursor-not-allowed",
-                )}
-              >
-                {joiningTeam ? "Joining..." : "Join"}
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Teams list */}
-        {teams.length === 0 ? (
-          <div className="rounded-xl bg-secondary p-6 text-center text-sm text-muted-foreground">
-            You&apos;re not in any teams yet. Create one or join with an invite code.
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {teams.map((team) => (
-              <div
-                key={team.id}
-                className="rounded-xl bg-secondary p-4"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent text-muted-foreground shrink-0">
-                    <Users className="h-4 w-4" strokeWidth={1.5} />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-foreground truncate">{team.name}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {team.member_count} member{team.member_count !== 1 ? "s" : ""}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-1 shrink-0">
-                    {/* Invite code */}
-                    <div className="hidden sm:flex items-center gap-1 rounded-md bg-accent px-2 py-1">
-                      <code className="text-[10px] font-mono text-muted-foreground">
-                        {team.invite_code}
-                      </code>
-                      <CopyButton text={team.invite_code} />
-                    </div>
-                    {/* Leave button */}
-                    <button
-                      onClick={() => handleLeaveTeam(team.id)}
-                      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-                      title="Leave team"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" strokeWidth={1.5} />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
       </section>
     </div>
   );

--- a/packages/web/src/app/(dashboard)/teams/page.tsx
+++ b/packages/web/src/app/(dashboard)/teams/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Users,
+  Plus,
+  LogIn,
+  Copy,
+  Check,
+  Trash2,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Team {
+  id: string;
+  name: string;
+  slug: string;
+  invite_code: string;
+  created_by: string;
+  member_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// CopyButton
+// ---------------------------------------------------------------------------
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+      title="Copy to clipboard"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-success" strokeWidth={1.5} />
+      ) : (
+        <Copy className="h-3.5 w-3.5" strokeWidth={1.5} />
+      )}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Teams Page
+// ---------------------------------------------------------------------------
+
+export default function TeamsPage() {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [showCreateTeam, setShowCreateTeam] = useState(false);
+  const [newTeamName, setNewTeamName] = useState("");
+  const [creatingTeam, setCreatingTeam] = useState(false);
+  const [showJoinTeam, setShowJoinTeam] = useState(false);
+  const [inviteCode, setInviteCode] = useState("");
+  const [joiningTeam, setJoiningTeam] = useState(false);
+  const [teamMessage, setTeamMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Fetch teams
+  // ---------------------------------------------------------------------------
+
+  const fetchTeams = useCallback(async () => {
+    try {
+      const res = await fetch("/api/teams");
+      if (res.ok) {
+        const data = await res.json();
+        setTeams(data.teams ?? []);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTeams();
+  }, [fetchTeams]);
+
+  // ---------------------------------------------------------------------------
+  // Create team
+  // ---------------------------------------------------------------------------
+
+  const handleCreateTeam = async () => {
+    if (!newTeamName.trim()) return;
+    setCreatingTeam(true);
+    setTeamMessage(null);
+
+    try {
+      const res = await fetch("/api/teams", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newTeamName.trim() }),
+      });
+
+      if (res.ok) {
+        setNewTeamName("");
+        setShowCreateTeam(false);
+        setTeamMessage({ type: "success", text: "Team created!" });
+        fetchTeams();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setTeamMessage({
+          type: "error",
+          text: (data as { error?: string }).error ?? "Failed to create team.",
+        });
+      }
+    } catch {
+      setTeamMessage({ type: "error", text: "Network error." });
+    } finally {
+      setCreatingTeam(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Join team
+  // ---------------------------------------------------------------------------
+
+  const handleJoinTeam = async () => {
+    if (!inviteCode.trim()) return;
+    setJoiningTeam(true);
+    setTeamMessage(null);
+
+    try {
+      const res = await fetch("/api/teams/join", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ invite_code: inviteCode.trim() }),
+      });
+
+      if (res.ok) {
+        setInviteCode("");
+        setShowJoinTeam(false);
+        setTeamMessage({ type: "success", text: "Joined team!" });
+        fetchTeams();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setTeamMessage({
+          type: "error",
+          text: (data as { error?: string }).error ?? "Failed to join team.",
+        });
+      }
+    } catch {
+      setTeamMessage({ type: "error", text: "Network error." });
+    } finally {
+      setJoiningTeam(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Leave team
+  // ---------------------------------------------------------------------------
+
+  const handleLeaveTeam = async (teamId: string) => {
+    if (!confirm("Are you sure you want to leave this team?")) return;
+    setTeamMessage(null);
+
+    try {
+      const res = await fetch(`/api/teams/${teamId}`, { method: "DELETE" });
+      if (res.ok) {
+        setTeamMessage({ type: "success", text: "Left team." });
+        fetchTeams();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setTeamMessage({
+          type: "error",
+          text: (data as { error?: string }).error ?? "Failed to leave team.",
+        });
+      }
+    } catch {
+      setTeamMessage({ type: "error", text: "Network error." });
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="max-w-3xl space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold font-display">Teams</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Create or join teams to share usage data with your group.
+        </p>
+      </div>
+
+      {/* Teams Section */}
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <Users className="h-4 w-4" strokeWidth={1.5} />
+            Your Teams
+          </h2>
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                setShowJoinTeam(!showJoinTeam);
+                setShowCreateTeam(false);
+              }}
+              className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+            >
+              <LogIn className="h-3.5 w-3.5" strokeWidth={1.5} />
+              Join
+            </button>
+            <button
+              onClick={() => {
+                setShowCreateTeam(!showCreateTeam);
+                setShowJoinTeam(false);
+              }}
+              className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              <Plus className="h-3.5 w-3.5" strokeWidth={1.5} />
+              Create
+            </button>
+          </div>
+        </div>
+
+        {/* Team message */}
+        {teamMessage && (
+          <div
+            className={cn(
+              "rounded-lg p-3 text-xs mb-3",
+              teamMessage.type === "success"
+                ? "bg-success/10 text-success"
+                : "bg-destructive/10 text-destructive",
+            )}
+          >
+            {teamMessage.text}
+          </div>
+        )}
+
+        {/* Create team form */}
+        {showCreateTeam && (
+          <div className="rounded-xl bg-secondary p-4 mb-3">
+            <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+              Team Name
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={newTeamName}
+                onChange={(e) => setNewTeamName(e.target.value)}
+                placeholder="My Team"
+                maxLength={64}
+                className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring/20 transition-shadow min-w-0"
+                onKeyDown={(e) => e.key === "Enter" && handleCreateTeam()}
+              />
+              <button
+                onClick={handleCreateTeam}
+                disabled={creatingTeam || !newTeamName.trim()}
+                className={cn(
+                  "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors shrink-0",
+                  (creatingTeam || !newTeamName.trim()) && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                {creatingTeam ? "Creating..." : "Create"}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Join team form */}
+        {showJoinTeam && (
+          <div className="rounded-xl bg-secondary p-4 mb-3">
+            <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+              Invite Code
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={inviteCode}
+                onChange={(e) => setInviteCode(e.target.value)}
+                placeholder="e.g. abc12345"
+                maxLength={32}
+                className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring/20 transition-shadow min-w-0"
+                onKeyDown={(e) => e.key === "Enter" && handleJoinTeam()}
+              />
+              <button
+                onClick={handleJoinTeam}
+                disabled={joiningTeam || !inviteCode.trim()}
+                className={cn(
+                  "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors shrink-0",
+                  (joiningTeam || !inviteCode.trim()) && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                {joiningTeam ? "Joining..." : "Join"}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Teams list */}
+        {teams.length === 0 ? (
+          <div className="rounded-xl bg-secondary p-6 text-center text-sm text-muted-foreground">
+            You&apos;re not in any teams yet. Create one or join with an invite code.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {teams.map((team) => (
+              <div
+                key={team.id}
+                className="rounded-xl bg-secondary p-4"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent text-muted-foreground shrink-0">
+                    <Users className="h-4 w-4" strokeWidth={1.5} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-foreground truncate">{team.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {team.member_count} member{team.member_count !== 1 ? "s" : ""}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    {/* Invite code */}
+                    <div className="hidden sm:flex items-center gap-1 rounded-md bg-accent px-2 py-1">
+                      <code className="text-[10px] font-mono text-muted-foreground">
+                        {team.invite_code}
+                      </code>
+                      <CopyButton text={team.invite_code} />
+                    </div>
+                    {/* Leave button */}
+                    <button
+                      onClick={() => handleLeaveTeam(team.id)}
+                      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                      title="Leave team"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" strokeWidth={1.5} />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -18,10 +18,10 @@ export const metadata: Metadata = {
   metadataBase: new URL(
     process.env.NEXTAUTH_URL ?? "https://pew.md"
   ),
-  title: "Pew Dashboard",
+  title: "pew - AI token usage tracker",
   description: "Track and visualize token usage from your AI coding tools",
   openGraph: {
-    title: "Pew Dashboard",
+    title: "pew - AI token usage tracker",
     description: "Track and visualize token usage from your AI coding tools",
     type: "website",
   },

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -116,7 +116,7 @@ function LoginContent() {
               <Image src="/logo-80.png" alt="Pew" width={80} height={80} />
             </div>
 
-            <p className="mt-5 text-lg font-semibold text-foreground">AI Token Usage Tracker</p>
+            <p className="mt-5 text-lg font-semibold text-foreground">AI token usage tracker</p>
             <p className="mt-1 text-xs text-muted-foreground">Sign in to view your dashboard</p>
 
             {/* Error message */}

--- a/packages/web/src/app/u/[slug]/page.tsx
+++ b/packages/web/src/app/u/[slug]/page.tsx
@@ -29,10 +29,10 @@ export async function generateMetadata({
   const displayName = user?.name ?? slug;
 
   return {
-    title: `${displayName} — Pew`,
+    title: `${displayName} — pew`,
     description: `Public AI coding tool usage profile for ${displayName}`,
     openGraph: {
-      title: `${displayName} — Pew`,
+      title: `${displayName} — pew`,
       description: `See how ${displayName} uses AI coding tools`,
     },
   };

--- a/packages/web/src/app/u/[slug]/profile-view.tsx
+++ b/packages/web/src/app/u/[slug]/profile-view.tsx
@@ -79,8 +79,8 @@ export function PublicProfileView({ slug }: PublicProfileViewProps) {
             className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
           >
             <ArrowLeft className="h-4 w-4" />
-            Back to Pew
-          </Link>
+            Back to pew
+83:           </Link>
         </div>
       </div>
     );
@@ -97,7 +97,7 @@ export function PublicProfileView({ slug }: PublicProfileViewProps) {
             className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
           >
             <ArrowLeft className="h-4 w-4" />
-            Back to Pew
+            Back to pew
           </Link>
         </div>
       </div>
@@ -242,9 +242,9 @@ export function PublicProfileView({ slug }: PublicProfileViewProps) {
           <p className="text-xs text-muted-foreground">
             Powered by{" "}
             <Link href="/" className="text-primary hover:underline">
-              Pew
+              pew
             </Link>{" "}
-            — Track your AI coding tool usage
+            — AI token usage tracker
           </p>
         </footer>
       </main>

--- a/packages/web/src/components/layout/app-shell.tsx
+++ b/packages/web/src/components/layout/app-shell.tsx
@@ -14,7 +14,8 @@ import { useIsMobile } from "@/hooks/use-mobile";
 // ---------------------------------------------------------------------------
 
 const ROUTE_LABELS: Record<string, string> = {
-  settings: "Settings",
+  settings: "General",
+  teams: "Teams",
   details: "Daily Usage",
   apps: "By App",
   models: "By Model",

--- a/packages/web/src/components/layout/app-shell.tsx
+++ b/packages/web/src/components/layout/app-shell.tsx
@@ -8,35 +8,10 @@ import { SidebarProvider, useSidebar } from "./sidebar-context";
 import { ThemeToggle } from "./theme-toggle";
 import { Breadcrumbs } from "./breadcrumbs";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { breadcrumbsFromPathname } from "@/lib/navigation";
 
-// ---------------------------------------------------------------------------
-// URL-based breadcrumb generation
-// ---------------------------------------------------------------------------
-
-const ROUTE_LABELS: Record<string, string> = {
-  settings: "General",
-  teams: "Teams",
-  details: "Daily Usage",
-  apps: "By App",
-  models: "By Model",
-  leaderboard: "Leaderboard",
-};
-
-function breadcrumbsFromPathname(pathname: string) {
-  const segments = pathname.split("/").filter(Boolean);
-  const items: { label: string; href?: string }[] = [{ label: "Home", href: "/" }];
-
-  let href = "";
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i]!;
-    href += `/${seg}`;
-    const isLast = i === segments.length - 1;
-    const label = ROUTE_LABELS[seg] ?? seg.slice(0, 8);
-    items.push(isLast ? { label } : { label, href });
-  }
-
-  return items;
-}
+// Re-export for tests that already import from here
+export { ROUTE_LABELS, breadcrumbsFromPathname } from "@/lib/navigation";
 
 // ---------------------------------------------------------------------------
 // AppShell

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession, signOut } from "next-auth/react";
 import Image from "next/image";
+import type { ElementType } from "react";
 import {
   LayoutDashboard,
   Settings,
@@ -21,6 +22,11 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { APP_VERSION } from "@/lib/version";
+import {
+  BASE_NAV_GROUPS as NAV_GROUP_DEFS,
+  ADMIN_NAV_GROUP as ADMIN_GROUP_DEF,
+  type NavGroupDef,
+} from "@/lib/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Tooltip,
@@ -33,13 +39,25 @@ import { useAdmin } from "@/hooks/use-admin";
 import { useSidebar } from "./sidebar-context";
 
 // ---------------------------------------------------------------------------
-// Navigation data model
+// Map icon names to Lucide components
 // ---------------------------------------------------------------------------
+
+const ICON_MAP: Record<string, ElementType> = {
+  LayoutDashboard,
+  Settings,
+  Trophy,
+  CalendarDays,
+  MessagesSquare,
+  AppWindow,
+  Cpu,
+  Users,
+  DollarSign,
+};
 
 interface NavItem {
   href: string;
   label: string;
-  icon: React.ElementType;
+  icon: ElementType;
 }
 
 interface NavGroup {
@@ -48,45 +66,21 @@ interface NavGroup {
   defaultOpen?: boolean;
 }
 
-const BASE_NAV_GROUPS: NavGroup[] = [
-  {
-    label: "Overview",
-    defaultOpen: true,
-    items: [
-      { href: "/", label: "Dashboard", icon: LayoutDashboard },
-      { href: "/leaderboard", label: "Leaderboard", icon: Trophy },
-    ],
-  },
-  {
-    label: "Analytics",
-    defaultOpen: true,
-    items: [
-      { href: "/details", label: "Daily Usage", icon: CalendarDays },
-      { href: "/sessions", label: "Sessions", icon: MessagesSquare },
-      { href: "/apps", label: "By App", icon: AppWindow },
-      { href: "/models", label: "By Model", icon: Cpu },
-    ],
-  },
-  {
-    label: "Settings",
-    defaultOpen: true,
-    items: [
-      { href: "/teams", label: "Teams", icon: Users },
-      { href: "/settings", label: "General", icon: Settings },
-    ],
-  },
-];
-
-const ADMIN_NAV_GROUP: NavGroup = {
-  label: "Admin",
-  defaultOpen: true,
-  items: [
-    { href: "/admin/pricing", label: "Token Pricing", icon: DollarSign },
-  ],
-};
+function resolveNavGroup(def: NavGroupDef): NavGroup {
+  return {
+    label: def.label,
+    defaultOpen: def.defaultOpen,
+    items: def.items.map((item) => ({
+      href: item.href,
+      label: item.label,
+      icon: ICON_MAP[item.icon] ?? Settings,
+    })),
+  };
+}
 
 function getNavGroups(isAdmin: boolean): NavGroup[] {
-  return isAdmin ? [...BASE_NAV_GROUPS, ADMIN_NAV_GROUP] : BASE_NAV_GROUPS;
+  const base = NAV_GROUP_DEFS.map(resolveNavGroup);
+  return isAdmin ? [...base, resolveNavGroup(ADMIN_GROUP_DEF)] : base;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   MessagesSquare,
   ChevronUp,
   DollarSign,
+  Users,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { APP_VERSION } from "@/lib/version";
@@ -67,9 +68,12 @@ const BASE_NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: "Account",
+    label: "Settings",
     defaultOpen: true,
-    items: [{ href: "/settings", label: "Settings", icon: Settings }],
+    items: [
+      { href: "/teams", label: "Teams", icon: Users },
+      { href: "/settings", label: "General", icon: Settings },
+    ],
   },
 ];
 

--- a/packages/web/src/lib/navigation.ts
+++ b/packages/web/src/lib/navigation.ts
@@ -1,0 +1,97 @@
+/**
+ * Navigation configuration for the dashboard.
+ *
+ * Pure data — no React dependency.
+ * Imported by sidebar.tsx (adds icons) and tests.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NavItemDef {
+  href: string;
+  label: string;
+  /** Lucide icon name for lookup in sidebar.tsx */
+  icon: string;
+}
+
+export interface NavGroupDef {
+  label: string;
+  items: NavItemDef[];
+  defaultOpen?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Navigation groups
+// ---------------------------------------------------------------------------
+
+export const BASE_NAV_GROUPS: NavGroupDef[] = [
+  {
+    label: "Overview",
+    defaultOpen: true,
+    items: [
+      { href: "/", label: "Dashboard", icon: "LayoutDashboard" },
+      { href: "/leaderboard", label: "Leaderboard", icon: "Trophy" },
+    ],
+  },
+  {
+    label: "Analytics",
+    defaultOpen: true,
+    items: [
+      { href: "/details", label: "Daily Usage", icon: "CalendarDays" },
+      { href: "/sessions", label: "Sessions", icon: "MessagesSquare" },
+      { href: "/apps", label: "By App", icon: "AppWindow" },
+      { href: "/models", label: "By Model", icon: "Cpu" },
+    ],
+  },
+  {
+    label: "Settings",
+    defaultOpen: true,
+    items: [
+      { href: "/teams", label: "Teams", icon: "Users" },
+      { href: "/settings", label: "General", icon: "Settings" },
+    ],
+  },
+];
+
+export const ADMIN_NAV_GROUP: NavGroupDef = {
+  label: "Admin",
+  defaultOpen: true,
+  items: [
+    { href: "/admin/pricing", label: "Token Pricing", icon: "DollarSign" },
+  ],
+};
+
+export function getNavGroups(isAdmin: boolean): NavGroupDef[] {
+  return isAdmin ? [...BASE_NAV_GROUPS, ADMIN_NAV_GROUP] : BASE_NAV_GROUPS;
+}
+
+// ---------------------------------------------------------------------------
+// Route labels (used for breadcrumbs in app-shell)
+// ---------------------------------------------------------------------------
+
+export const ROUTE_LABELS: Record<string, string> = {
+  settings: "General",
+  teams: "Teams",
+  details: "Daily Usage",
+  apps: "By App",
+  models: "By Model",
+  leaderboard: "Leaderboard",
+};
+
+export function breadcrumbsFromPathname(pathname: string) {
+  const segments = pathname.split("/").filter(Boolean);
+  const items: { label: string; href?: string }[] = [{ label: "Home", href: "/" }];
+
+  let href = "";
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!;
+    href += `/${seg}`;
+    const isLast = i === segments.length - 1;
+    const label = ROUTE_LABELS[seg] ?? seg.slice(0, 8);
+    items.push(isLast ? { label } : { label, href });
+  }
+
+  return items;
+}

--- a/packages/web/src/lib/pricing.ts
+++ b/packages/web/src/lib/pricing.ts
@@ -232,12 +232,12 @@ export function estimateCost(
 }
 
 /**
- * Format USD cost with appropriate precision.
+ * Format USD cost with appropriate precision and thousand separators.
  */
 export function formatCost(cost: number): string {
   if (cost === 0) return "$0.00";
   if (cost < 0.01) return `$${cost.toFixed(4)}`;
   if (cost < 1) return `$${cost.toFixed(2)}`;
   if (cost < 100) return `$${cost.toFixed(2)}`;
-  return `$${cost.toFixed(0)}`;
+  return `$${cost.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
 }


### PR DESCRIPTION
## Summary

- **Branding**: Renamed product title from "Pew Dashboard" to "pew - AI token usage tracker" across all pages (layout metadata, OG tags, login page, public profile pages)
- **Cost formatting**: Added thousand separators to `formatCost()` — e.g. `$1,234` instead of `$1234` for amounts ≥ $100
- **Teams extraction**: Moved Teams management from the monolithic Settings page to a dedicated `/teams` route
- **Sidebar refactor**: Renamed "Account" group to "Settings", renamed "Settings" nav item to "General", added "Teams" nav item above "General"
- **Navigation config**: Extracted pure navigation data to `lib/navigation.ts` (no React dependency) for clean testability
- **Tests**: Added 18 navigation structure tests + updated pricing tests for thousand separator formatting (52 total, all passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated Teams management page with create, join, and leave team functionality.

* **Bug Fixes**
  * Improved cost formatting with thousand separators for better readability.

* **Style**
  * Updated branding throughout the app to "pew - AI token usage tracker."
  * Simplified General settings page with streamlined UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->