### PR TITLE
fix: smooth dashboard resize and sidebar logo

### DIFF
--- a/packages/web/src/components/dashboard/cache-rate-chart.tsx
+++ b/packages/web/src/components/dashboard/cache-rate-chart.tsx
@@ -6,7 +6,6 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
   ReferenceLine,
 } from "recharts";
@@ -14,6 +13,7 @@ import { cn } from "@/lib/utils";
 import { formatTokens } from "@/lib/utils";
 import { chart, chartAxis } from "@/lib/palette";
 import type { DailyCacheRate } from "@/lib/cost-helpers";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -128,7 +128,7 @@ export function CacheRateChart({ data, className }: CacheRateChartProps) {
       </div>
 
       <div className="h-[200px] md:h-[240px]">
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <LineChart
             data={data}
             margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
@@ -170,7 +170,7 @@ export function CacheRateChart({ data, className }: CacheRateChartProps) {
               activeDot={{ r: 4, fill: chart.jade }}
             />
           </LineChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/cost-per-token-chart.tsx
+++ b/packages/web/src/components/dashboard/cost-per-token-chart.tsx
@@ -6,7 +6,6 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
   Cell,
 } from "recharts";
@@ -16,6 +15,7 @@ import { chartAxis, chartPositive, chartNegative, CHART_COLORS } from "@/lib/pal
 import { shortModel } from "@/lib/model-helpers";
 import { sourceLabel } from "@/hooks/use-usage-data";
 import type { ModelCostEfficiency } from "@/lib/cost-helpers";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // Color scale: green (cheap) → amber (mid) → red (expensive)
 const colorCheap = chartPositive;
@@ -158,7 +158,7 @@ export function CostPerTokenChart({
       </div>
 
       <div style={{ height: chartHeight }}>
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <BarChart
             data={chartData}
             layout="vertical"
@@ -201,7 +201,7 @@ export function CostPerTokenChart({
               })}
             </Bar>
           </BarChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/cost-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/cost-trend-chart.tsx
@@ -6,13 +6,13 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
 import { cn } from "@/lib/utils";
 import { formatCost } from "@/lib/pricing";
 import { chart, chartAxis, CHART_COLORS, chartMuted } from "@/lib/palette";
 import type { DailyCostPoint } from "@/lib/cost-helpers";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // Stable color references
 const colorOutput = CHART_COLORS[1]!;
@@ -152,7 +152,7 @@ export function CostTrendChart({ data, className }: CostTrendChartProps) {
       </div>
 
       <div className="h-[240px] md:h-[280px]">
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <AreaChart
             data={data}
             margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
@@ -217,7 +217,7 @@ export function CostTrendChart({ data, className }: CostTrendChartProps) {
               fill="url(#gradCostCached)"
             />
           </AreaChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/dashboard-responsive-container.tsx
+++ b/packages/web/src/components/dashboard/dashboard-responsive-container.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { ResponsiveContainer as RechartsResponsiveContainer } from "recharts";
+
+const CHART_RESIZE_DEBOUNCE_MS = 180;
+
+type DashboardResponsiveContainerProps = ComponentProps<
+  typeof RechartsResponsiveContainer
+>;
+
+export function DashboardResponsiveContainer({
+  debounce = CHART_RESIZE_DEBOUNCE_MS,
+  ...props
+}: DashboardResponsiveContainerProps) {
+  return <RechartsResponsiveContainer debounce={debounce} {...props} />;
+}

--- a/packages/web/src/components/dashboard/io-ratio-chart.tsx
+++ b/packages/web/src/components/dashboard/io-ratio-chart.tsx
@@ -4,12 +4,12 @@ import {
   PieChart,
   Pie,
   Tooltip,
-  ResponsiveContainer,
   Cell,
 } from "recharts";
 import { cn } from "@/lib/utils";
 import { formatTokens } from "@/lib/utils";
 import { chart } from "@/lib/palette";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -117,7 +117,7 @@ export function IoRatioChart({
 
       <div className="flex flex-col items-center">
         <div className="relative h-[180px] w-[180px]">
-          <ResponsiveContainer width="100%" height="100%">
+          <DashboardResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
                 data={chartData}
@@ -135,7 +135,7 @@ export function IoRatioChart({
               </Pie>
               <Tooltip content={<IoTooltip />} />
             </PieChart>
-          </ResponsiveContainer>
+          </DashboardResponsiveContainer>
           {/* Center label showing I/O ratio */}
           <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
             <span className="text-lg font-semibold text-foreground">

--- a/packages/web/src/components/dashboard/message-stats-chart.tsx
+++ b/packages/web/src/components/dashboard/message-stats-chart.tsx
@@ -6,12 +6,12 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
 import { cn } from "@/lib/utils";
 import { chartAxis, CHART_COLORS } from "@/lib/palette";
 import type { MessageDailyStat } from "@/lib/session-helpers";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -131,7 +131,7 @@ export function MessageStatsChart({ data, className }: MessageStatsChartProps) {
       </div>
 
       <div className="h-[240px] md:h-[280px]">
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <BarChart
             data={data}
             margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
@@ -169,7 +169,7 @@ export function MessageStatsChart({ data, className }: MessageStatsChartProps) {
               radius={[4, 4, 0, 0]}
             />
           </BarChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/model-breakdown-chart.tsx
+++ b/packages/web/src/components/dashboard/model-breakdown-chart.tsx
@@ -6,7 +6,6 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
 import { cn } from "@/lib/utils";
@@ -15,6 +14,7 @@ import { chart, chartAxis, CHART_COLORS } from "@/lib/palette";
 import { shortModel } from "@/lib/model-helpers";
 import type { ModelAggregate } from "@/hooks/use-usage-data";
 import { sourceLabel } from "@/hooks/use-usage-data";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // Safe color references
 const colorOutput = CHART_COLORS[1]!;
@@ -152,7 +152,7 @@ export function ModelBreakdownChart({
       </div>
 
       <div style={{ height: chartHeight }}>
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <BarChart
             data={chartData}
             layout="vertical"
@@ -199,7 +199,7 @@ export function ModelBreakdownChart({
               radius={[0, 4, 4, 0]}
             />
           </BarChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/model-evolution-chart.tsx
+++ b/packages/web/src/components/dashboard/model-evolution-chart.tsx
@@ -7,13 +7,13 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
 import { cn } from "@/lib/utils";
 import { chartAxis, CHART_COLORS } from "@/lib/palette";
 import { shortModel } from "@/lib/model-helpers";
 import type { ModelEra } from "@/lib/model-helpers";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -166,7 +166,7 @@ export function ModelEvolutionChart({
       </div>
 
       <div className="h-[240px] md:h-[280px]">
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <AreaChart
             data={chartData}
             margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
@@ -231,7 +231,7 @@ export function ModelEvolutionChart({
               />
             ))}
           </AreaChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/source-donut-chart.tsx
+++ b/packages/web/src/components/dashboard/source-donut-chart.tsx
@@ -4,13 +4,13 @@ import {
   PieChart,
   Pie,
   Tooltip,
-  ResponsiveContainer,
   Cell,
 } from "recharts";
 import { cn } from "@/lib/utils";
 import { formatTokens } from "@/lib/utils";
 import { CHART_COLORS } from "@/lib/palette";
 import type { SourceAggregate } from "@/hooks/use-usage-data";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -95,7 +95,7 @@ export function SourceDonutChart({ data, className }: SourceDonutChartProps) {
 
       <div className="flex flex-1 flex-col items-center">
         <div className="flex-1 w-full max-w-[220px] min-h-[140px]">
-          <ResponsiveContainer width="100%" height="100%">
+          <DashboardResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
                 data={chartData}
@@ -113,7 +113,7 @@ export function SourceDonutChart({ data, className }: SourceDonutChartProps) {
               </Pie>
               <Tooltip content={<DonutTooltip />} />
             </PieChart>
-          </ResponsiveContainer>
+          </DashboardResponsiveContainer>
         </div>
 
         {/* Legend */}

--- a/packages/web/src/components/dashboard/source-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/source-trend-chart.tsx
@@ -7,13 +7,13 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
 import { cn, formatTokens } from "@/lib/utils";
 import { chartAxis, CHART_COLORS } from "@/lib/palette";
 import { sourceLabel } from "@/hooks/use-usage-data";
 import type { SourceTrendPoint } from "@/lib/usage-helpers";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -191,7 +191,7 @@ export function SourceTrendChart({ data, className }: SourceTrendChartProps) {
       </div>
 
       <div className="h-[240px] md:h-[280px]">
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <LineChart
             data={chartData}
             margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
@@ -231,7 +231,7 @@ export function SourceTrendChart({ data, className }: SourceTrendChartProps) {
               />
             ))}
           </LineChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/usage-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/usage-trend-chart.tsx
@@ -6,13 +6,13 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
 import { cn } from "@/lib/utils";
 import { formatTokens } from "@/lib/utils";
 import { chart, chartAxis, CHART_COLORS } from "@/lib/palette";
 import type { DailyPoint } from "@/hooks/use-usage-data";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // Safe color references (CHART_COLORS is guaranteed 8 elements)
 const colorOutput = CHART_COLORS[1]!;
@@ -138,7 +138,7 @@ export function UsageTrendChart({ data, className }: UsageTrendChartProps) {
       </div>
 
       <div className="h-[240px] md:h-[280px]">
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <AreaChart
             data={data}
             margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
@@ -219,7 +219,7 @@ export function UsageTrendChart({ data, className }: UsageTrendChartProps) {
               fill="url(#gradCached)"
             />
           </AreaChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/weekday-weekend-chart.tsx
+++ b/packages/web/src/components/dashboard/weekday-weekend-chart.tsx
@@ -6,7 +6,6 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
 import { cn } from "@/lib/utils";
@@ -14,6 +13,7 @@ import { formatTokens } from "@/lib/utils";
 import { formatCost } from "@/lib/pricing";
 import { chart, chartAxis, chartMuted } from "@/lib/palette";
 import type { WeekdayWeekendStats } from "@/lib/usage-helpers";
+import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -133,7 +133,7 @@ export function WeekdayWeekendChart({
       </div>
 
       <div className="h-[180px] w-full">
-        <ResponsiveContainer width="100%" height="100%">
+        <DashboardResponsiveContainer width="100%" height="100%">
           <BarChart data={data} barGap={4} barCategoryGap="30%">
             <CartesianGrid
               strokeDasharray="3 3"
@@ -179,7 +179,7 @@ export function WeekdayWeekendChart({
               radius={[4, 4, 0, 0]}
             />
           </BarChart>
-        </ResponsiveContainer>
+        </DashboardResponsiveContainer>
       </div>
 
       {/* Legend */}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession, signOut } from "next-auth/react";
-import Image from "next/image";
 import type { ElementType } from "react";
 import {
   LayoutDashboard,
@@ -29,6 +28,7 @@ import {
   type NavGroupDef,
 } from "@/lib/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
   TooltipContent,
@@ -187,8 +187,9 @@ export function Sidebar() {
           /* -- Collapsed (icon-only) view -- */
           <div className="flex h-screen w-[68px] flex-col items-center">
             {/* Logo */}
-            <div className="flex h-14 w-full items-center justify-start pl-5 pr-3">
-              <Image
+            <div className="flex h-14 w-full items-center justify-start pl-6 pr-3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
                 src="/logo-24.png"
                 alt="Pew"
                 width={24}
@@ -279,7 +280,8 @@ export function Sidebar() {
             <div className="px-3 h-14 flex items-center">
               <div className="flex w-full items-center justify-between px-3">
                 <div className="flex items-center gap-3">
-                  <Image
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
                     src="/logo-24.png"
                     alt="Pew"
                     width={24}
@@ -289,9 +291,12 @@ export function Sidebar() {
                   <span className="text-lg font-bold tracking-tighter">
                     pew
                   </span>
-                  <span className="rounded-full bg-accent px-2 py-0.5 text-[10px] font-medium text-muted-foreground font-mono leading-none">
+                  <Badge
+                    variant="secondary"
+                    className="px-1.5 py-0 text-[10px] font-normal text-muted-foreground"
+                  >
                     v{APP_VERSION}
-                  </span>
+                  </Badge>
                 </div>
                 <button
                   onClick={toggle}


### PR DESCRIPTION
## Summary
- add a debounced Recharts responsive container for dashboard charts during sidebar width animation
- switch dashboard chart components to the shared responsive container
- align sidebar logo/header rendering with surety to prevent logo jitter while collapsing and expanding

## Testing
- git diff --check
- `bun run --cwd packages/web typecheck` *(fails in this worktree because frontend deps/types like next/react/vitest are currently unavailable, unrelated to this change)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar version badge styling with a new badge component for improved visual consistency.

* **Refactor**
  * Enhanced dashboard chart responsiveness across multiple charts (cache rate, cost analysis, usage trends, model breakdown, IO ratio, and message statistics) with optimized layout containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->