### PR TITLE
refactor: extract shared utilities from parsers

### DIFF
--- a/packages/cli/src/__tests__/opencode-parser.test.ts
+++ b/packages/cli/src/__tests__/opencode-parser.test.ts
@@ -5,8 +5,8 @@ import { join } from "node:path";
 import {
   parseOpenCodeFile,
   normalizeOpenCodeTokens,
-  coerceEpochMs,
 } from "../parsers/opencode.js";
+import { coerceEpochMs } from "../utils/time.js";
 
 /** Helper: create an OpenCode message JSON */
 function opencodeMsg(overrides: Record<string, unknown> = {}): string {

--- a/packages/cli/src/parsers/claude.ts
+++ b/packages/cli/src/parsers/claude.ts
@@ -2,6 +2,7 @@ import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import type { Source, TokenDelta } from "@pew/core";
+import { isAllZero, toNonNegInt } from "../utils/token-delta.js";
 
 /** A parsed token delta with metadata for bucket aggregation */
 export interface ParsedDelta {
@@ -15,13 +16,6 @@ export interface ParsedDelta {
 export interface ClaudeFileResult {
   deltas: ParsedDelta[];
   endOffset: number;
-}
-
-/** Coerce to non-negative integer, returning 0 for invalid values */
-function toNonNegInt(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.floor(n);
 }
 
 /**
@@ -42,16 +36,6 @@ export function normalizeClaudeUsage(u: Record<string, unknown>): TokenDelta {
     outputTokens: toNonNegInt(u?.output_tokens),
     reasoningOutputTokens: 0,
   };
-}
-
-/** Check if a TokenDelta is all zeros */
-function isAllZero(delta: TokenDelta): boolean {
-  return (
-    delta.inputTokens === 0 &&
-    delta.cachedInputTokens === 0 &&
-    delta.outputTokens === 0 &&
-    delta.reasoningOutputTokens === 0
-  );
 }
 
 /**

--- a/packages/cli/src/parsers/codex.ts
+++ b/packages/cli/src/parsers/codex.ts
@@ -16,6 +16,7 @@ import { stat } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import type { Source, TokenDelta } from "@pew/core";
 import type { ParsedDelta } from "./claude.js";
+import { isAllZero, toNonNegInt } from "../utils/token-delta.js";
 
 /** Result of parsing a single Codex JSONL rollout file */
 export interface CodexFileResult {
@@ -25,23 +26,6 @@ export interface CodexFileResult {
   lastTotals: TokenDelta | null;
   /** Last seen model identifier */
   lastModel: string | null;
-}
-
-/** Check if a TokenDelta is all zeros */
-function isAllZero(d: TokenDelta): boolean {
-  return (
-    d.inputTokens === 0 &&
-    d.cachedInputTokens === 0 &&
-    d.outputTokens === 0 &&
-    d.reasoningOutputTokens === 0
-  );
-}
-
-/** Coerce to non-negative integer */
-function toNonNegInt(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.floor(n);
 }
 
 /**

--- a/packages/cli/src/parsers/gemini.ts
+++ b/packages/cli/src/parsers/gemini.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import type { Source, TokenDelta } from "@pew/core";
 import type { ParsedDelta } from "./claude.js";
+import { isAllZero, toNonNegInt } from "../utils/token-delta.js";
 
 /** Result of parsing a Gemini session JSON file */
 export interface GeminiFileResult {
@@ -8,13 +9,6 @@ export interface GeminiFileResult {
   lastIndex: number;
   lastTotals: TokenDelta | null;
   lastModel: string | null;
-}
-
-/** Coerce to non-negative integer */
-function toNonNegInt(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.floor(n);
 }
 
 /**
@@ -37,16 +31,6 @@ export function normalizeGeminiTokens(
     outputTokens: toNonNegInt(tokens.output) + toNonNegInt(tokens.tool),
     reasoningOutputTokens: toNonNegInt(tokens.thoughts),
   };
-}
-
-/** Check if a TokenDelta is all zeros */
-function isAllZero(d: TokenDelta): boolean {
-  return (
-    d.inputTokens === 0 &&
-    d.cachedInputTokens === 0 &&
-    d.outputTokens === 0 &&
-    d.reasoningOutputTokens === 0
-  );
 }
 
 /** Compute total from a TokenDelta (for reset detection) */

--- a/packages/cli/src/parsers/openclaw.ts
+++ b/packages/cli/src/parsers/openclaw.ts
@@ -3,21 +3,12 @@ import { stat } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import type { Source, TokenDelta } from "@pew/core";
 import type { ParsedDelta } from "./claude.js";
+import { isAllZero, toNonNegInt } from "../utils/token-delta.js";
 
 /** Result of parsing an OpenClaw JSONL session file */
 export interface OpenClawFileResult {
   deltas: ParsedDelta[];
   endOffset: number;
-}
-
-/** Check if a TokenDelta is all zeros */
-function isAllZero(d: TokenDelta): boolean {
-  return (
-    d.inputTokens === 0 &&
-    d.cachedInputTokens === 0 &&
-    d.outputTokens === 0 &&
-    d.reasoningOutputTokens === 0
-  );
 }
 
 /**
@@ -80,10 +71,9 @@ export async function parseOpenClawFile(opts: {
         typeof msg.model === "string" ? msg.model.trim() : "unknown";
 
       const tokens: TokenDelta = {
-        inputTokens: Number(usage.input || 0),
-        cachedInputTokens:
-          Number(usage.cacheRead || 0) + Number(usage.cacheWrite || 0),
-        outputTokens: Number(usage.output || 0),
+        inputTokens: toNonNegInt(usage.input),
+        cachedInputTokens: toNonNegInt(usage.cacheRead) + toNonNegInt(usage.cacheWrite),
+        outputTokens: toNonNegInt(usage.output),
         reasoningOutputTokens: 0,
       };
 

--- a/packages/cli/src/parsers/opencode-session.ts
+++ b/packages/cli/src/parsers/opencode-session.ts
@@ -8,17 +8,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join, basename } from "node:path";
 import type { SessionSnapshot, Source } from "@pew/core";
-
-/**
- * Coerce an epoch value to milliseconds.
- * Values < 1e12 are treated as seconds and multiplied by 1000.
- */
-function coerceEpochMs(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n <= 0) return 0;
-  if (n < 1e12) return Math.floor(n * 1000);
-  return Math.floor(n);
-}
+import { coerceEpochMs } from "../utils/time.js";
 
 /**
  * Collect session snapshots from an OpenCode session directory.

--- a/packages/cli/src/parsers/opencode-sqlite-session.ts
+++ b/packages/cli/src/parsers/opencode-sqlite-session.ts
@@ -8,6 +8,7 @@
 
 import type { SessionSnapshot, Source } from "@pew/core";
 import { hashProjectRef } from "../utils/hash-project-ref.js";
+import { coerceEpochMs } from "../utils/time.js";
 
 /** Row shape from the session table */
 export interface SessionRow {
@@ -24,17 +25,6 @@ export interface SessionMessageRow {
   role: string;
   time_created: number;
   data: string;
-}
-
-/**
- * Coerce an epoch value to milliseconds.
- * Values < 1e12 are treated as seconds and multiplied by 1000.
- */
-function coerceEpochMs(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n <= 0) return 0;
-  if (n < 1e12) return Math.floor(n * 1000);
-  return Math.floor(n);
 }
 
 /**

--- a/packages/cli/src/parsers/opencode-sqlite.ts
+++ b/packages/cli/src/parsers/opencode-sqlite.ts
@@ -1,7 +1,9 @@
 import { stat } from "node:fs/promises";
 import type { Source } from "@pew/core";
 import type { ParsedDelta } from "./claude.js";
-import { normalizeOpenCodeTokens, coerceEpochMs } from "./opencode.js";
+import { normalizeOpenCodeTokens } from "./opencode.js";
+import { isAllZero } from "../utils/token-delta.js";
+import { coerceEpochMs } from "../utils/time.js";
 
 /** Result of parsing OpenCode SQLite database */
 export interface OpenCodeSqliteResult {
@@ -32,21 +34,6 @@ export interface MessageRow {
  * to handle same-millisecond boundary dedup.
  */
 export type QueryMessagesFn = (lastTimeCreated: number) => MessageRow[];
-
-/** Check if a TokenDelta is all zeros */
-function isAllZero(d: {
-  inputTokens: number;
-  cachedInputTokens: number;
-  outputTokens: number;
-  reasoningOutputTokens: number;
-}): boolean {
-  return (
-    d.inputTokens === 0 &&
-    d.cachedInputTokens === 0 &&
-    d.outputTokens === 0 &&
-    d.reasoningOutputTokens === 0
-  );
-}
 
 /**
  * Parse message rows from OpenCode's SQLite database for token usage records.

--- a/packages/cli/src/parsers/opencode.ts
+++ b/packages/cli/src/parsers/opencode.ts
@@ -2,30 +2,14 @@ import { readFile } from "node:fs/promises";
 import type { Source, TokenDelta } from "@pew/core";
 import type { ParsedDelta } from "./claude.js";
 import { diffTotals } from "./gemini.js";
+import { isAllZero, toNonNegInt } from "../utils/token-delta.js";
+import { coerceEpochMs } from "../utils/time.js";
 
 /** Result of parsing a single OpenCode message file */
 export interface OpenCodeFileResult {
   delta: ParsedDelta | null;
   messageKey: string | null;
   lastTotals: TokenDelta | null;
-}
-
-/** Coerce to non-negative integer */
-function toNonNegInt(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.floor(n);
-}
-
-/**
- * Coerce an epoch value to milliseconds.
- * Values < 1e12 are treated as seconds and multiplied by 1000.
- */
-export function coerceEpochMs(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n <= 0) return 0;
-  if (n < 1e12) return Math.floor(n * 1000);
-  return Math.floor(n);
 }
 
 /**
@@ -52,16 +36,6 @@ export function normalizeOpenCodeTokens(
     outputTokens: toNonNegInt(tokens.output),
     reasoningOutputTokens: toNonNegInt(tokens.reasoning),
   };
-}
-
-/** Check if a TokenDelta is all zeros */
-function isAllZero(d: TokenDelta): boolean {
-  return (
-    d.inputTokens === 0 &&
-    d.cachedInputTokens === 0 &&
-    d.outputTokens === 0 &&
-    d.reasoningOutputTokens === 0
-  );
 }
 
 /**

--- a/packages/cli/src/parsers/vscode-copilot.ts
+++ b/packages/cli/src/parsers/vscode-copilot.ts
@@ -25,6 +25,7 @@ import { stat } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import type { Source, TokenDelta } from "@pew/core";
 import type { ParsedDelta } from "./claude.js";
+import { toNonNegInt } from "../utils/token-delta.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -72,13 +73,6 @@ export interface VscodeCopilotFileResult {
 /** Strip "copilot/" prefix from model IDs (e.g. "copilot/claude-opus-4.6" → "claude-opus-4.6") */
 function normalizeModelId(raw: string): string {
   return raw.startsWith("copilot/") ? raw.slice(8) : raw;
-}
-
-/** Coerce to non-negative integer, returning 0 for invalid values */
-function toNonNegInt(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.floor(n);
 }
 
 /** Extract modelId and timestamp from a request object */

--- a/packages/cli/src/utils/time.ts
+++ b/packages/cli/src/utils/time.ts
@@ -1,0 +1,10 @@
+/**
+ * Coerce an epoch value to milliseconds.
+ * Values < 1e12 are treated as seconds and multiplied by 1000.
+ */
+export function coerceEpochMs(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  if (n < 1e12) return Math.floor(n * 1000);
+  return Math.floor(n);
+}

--- a/packages/cli/src/utils/token-delta.ts
+++ b/packages/cli/src/utils/token-delta.ts
@@ -1,0 +1,18 @@
+import type { TokenDelta } from "@pew/core";
+
+/** Coerce to non-negative integer, returning 0 for invalid values */
+export function toNonNegInt(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+/** Check if a TokenDelta is all zeros */
+export function isAllZero(delta: TokenDelta): boolean {
+  return (
+    delta.inputTokens === 0 &&
+    delta.cachedInputTokens === 0 &&
+    delta.outputTokens === 0 &&
+    delta.reasoningOutputTokens === 0
+  );
+}


### PR DESCRIPTION
## Summary

- Create `utils/token-delta.ts` with `isAllZero()` and `toNonNegInt()` functions
- Create `utils/time.ts` with `coerceEpochMs()` function
- Update all parsers to use shared utilities instead of duplicated local definitions
- Fix `openclaw.ts` to use `toNonNegInt()` for safer type coercion (was using `Number(x || 0)`)

## Changes

| File | Changes |
|------|---------|
| `claude.ts` | Use shared `toNonNegInt()`, `isAllZero()` |
| `codex.ts` | Use shared `toNonNegInt()`, `isAllZero()` |
| `gemini.ts` | Use shared `toNonNegInt()`, `isAllZero()` |
| `openclaw.ts` | Use shared `toNonNegInt()`, `isAllZero()` |
| `opencode.ts` | Use shared `toNonNegInt()`, `isAllZero()`, `coerceEpochMs()` |
| `opencode-sqlite.ts` | Use shared `isAllZero()` |
| `opencode-session.ts` | Use shared `coerceEpochMs()` |
| `opencode-sqlite-session.ts` | Use shared `coerceEpochMs()` |
| `vscode-copilot.ts` | Use shared `toNonNegInt()` |

## Stats

- **-139 lines** of duplicated code removed
- **+44 lines** of new shared utilities added
- **Net -95 lines** of code

## Test Plan

- [x] All 1763 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Note**: Please merge with **Create a merge commit** (not squash) to preserve the atomic commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session collection API for OpenCode that enables reading session directories, extracting session metadata, tracking user and assistant messages, calculating session duration, and generating unique session identifiers with comprehensive error handling.

* **Refactor**
  * Improved code organization by consolidating shared utility functions across parsers for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->