### PR TITLE
fix: rename daily messages labels from User/Assistant to Human/Agent

### DIFF
--- a/packages/web/src/components/dashboard/message-stats-chart.tsx
+++ b/packages/web/src/components/dashboard/message-stats-chart.tsx
@@ -55,8 +55,8 @@ function ChartTooltip({
   if (!active || !payload?.length) return null;
 
   const labels: Record<string, string> = {
-    user: "User",
-    assistant: "Assistant",
+    user: "Human",
+    assistant: "Agent",
   };
 
   return (
@@ -87,7 +87,7 @@ function ChartTooltip({
 // ---------------------------------------------------------------------------
 
 /**
- * Stacked bar chart showing daily user vs assistant message counts.
+ * Stacked bar chart showing daily human vs agent message counts.
  */
 export function MessageStatsChart({ data, className }: MessageStatsChartProps) {
   if (!data.length) {
@@ -116,8 +116,8 @@ export function MessageStatsChart({ data, className }: MessageStatsChartProps) {
         </p>
         <div className="flex items-center gap-4">
           {[
-            { key: "user", label: "User", color: colorUser },
-            { key: "assistant", label: "Assistant", color: colorAssistant },
+            { key: "user", label: "Human", color: colorUser },
+            { key: "assistant", label: "Agent", color: colorAssistant },
           ].map(({ key, label, color }) => (
             <div key={key} className="flex items-center gap-1.5">
               <div


### PR DESCRIPTION
## Summary
- Rename "User" → "Human" and "Assistant" → "Agent" in the Daily Messages stacked bar chart on the Sessions page
- Changes are UI-only (tooltip labels, legend labels, JSDoc comment) — no data keys, DB columns, or API fields affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chart display terminology from "User/Assistant" to "Human/Agent" for tooltip and legend labels in the message statistics chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->