### PR TITLE
fix: unify token tooltip order in dashboard charts

### DIFF
--- a/packages/web/src/components/dashboard/cost-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/cost-trend-chart.tsx
@@ -69,32 +69,38 @@ function CostTooltip({
     cachedCost: "Cached",
   };
 
-  // Compute total from visible payload entries
   const total = payload.reduce((sum, e) => sum + e.value, 0);
+  const orderedKeys = ["inputCost", "outputCost", "cachedCost"] as const;
 
   return (
     <div className="rounded-[var(--radius-widget)] border border-border bg-card p-2.5 shadow-sm">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
+      <p className="mb-1 text-xs font-medium text-foreground">
         {label ? fmtDate(label) : ""}
       </p>
-      {payload.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {labels[entry.dataKey] ?? entry.dataKey}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {formatCost(entry.value)}
-          </span>
-        </div>
-      ))}
-      <div className="mt-1.5 border-t border-border pt-1.5 flex items-center justify-between text-xs">
+      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
         <span className="text-muted-foreground">Total</span>
-        <span className="font-medium text-foreground">{formatCost(total)}</span>
+        <span className="ml-auto font-medium text-foreground">
+          {formatCost(total)}
+        </span>
       </div>
+      {orderedKeys.map((key) => {
+        const entry = payload.find((e) => e.dataKey === key);
+        if (!entry) return null;
+        return (
+          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
+            <div
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="text-muted-foreground">
+              {labels[entry.dataKey] ?? entry.dataKey}
+            </span>
+            <span className="ml-auto font-medium text-foreground">
+              {formatCost(entry.value)}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/components/dashboard/device-breakdown-chart.tsx
+++ b/packages/web/src/components/dashboard/device-breakdown-chart.tsx
@@ -54,29 +54,37 @@ function DeviceBreakdownTooltip({
   };
 
   const deviceData = payload[0]?.payload;
+  const total = deviceData?.total_tokens ?? 0;
+
+  const orderedKeys = ["input_tokens", "output_tokens", "cached_input_tokens"] as const;
 
   return (
     <div className="rounded-[var(--radius-widget)] border border-border bg-card p-2.5 shadow-sm">
       <p className="mb-0.5 text-xs font-medium text-foreground">{label}</p>
-      {deviceData && (
-        <p className="mb-1.5 text-xs text-muted-foreground">
-          {formatTokens(deviceData.total_tokens)} total
-        </p>
-      )}
-      {payload.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {labels[entry.dataKey] ?? entry.dataKey}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {formatTokens(entry.value)}
-          </span>
-        </div>
-      ))}
+      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground">Total</span>
+        <span className="ml-auto font-medium text-foreground">
+          {formatTokens(total)}
+        </span>
+      </div>
+      {orderedKeys.map((key) => {
+        const entry = payload.find((e) => e.dataKey === key);
+        if (!entry) return null;
+        return (
+          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
+            <div
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="text-muted-foreground">
+              {labels[entry.dataKey] ?? entry.dataKey}
+            </span>
+            <span className="ml-auto font-medium text-foreground">
+              {formatTokens(entry.value)}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/components/dashboard/model-breakdown-chart.tsx
+++ b/packages/web/src/components/dashboard/model-breakdown-chart.tsx
@@ -56,6 +56,9 @@ function ModelTooltip({
   };
 
   const modelData = payload[0]?.payload;
+  const total = modelData?.total ?? 0;
+
+  const orderedKeys = ["input", "output", "cached"] as const;
 
   return (
     <div className="rounded-[var(--radius-widget)] border border-border bg-card p-2.5 shadow-sm">
@@ -63,24 +66,34 @@ function ModelTooltip({
         {label}
       </p>
       {modelData && (
-        <p className="mb-1.5 text-xs text-muted-foreground">
+        <p className="mb-1 text-xs text-muted-foreground">
           {modelData.sourceLabel} &middot; {formatTokens(modelData.total)} total
         </p>
       )}
-      {payload.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {labels[entry.dataKey] ?? entry.dataKey}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {formatTokens(entry.value)}
-          </span>
-        </div>
-      ))}
+      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground">Total</span>
+        <span className="ml-auto font-medium text-foreground">
+          {formatTokens(total)}
+        </span>
+      </div>
+      {orderedKeys.map((key) => {
+        const entry = payload.find((e) => e.dataKey === key);
+        if (!entry) return null;
+        return (
+          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
+            <div
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="text-muted-foreground">
+              {labels[entry.dataKey] ?? entry.dataKey}
+            </span>
+            <span className="ml-auto font-medium text-foreground">
+              {formatTokens(entry.value)}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/components/dashboard/recent-bar-chart.tsx
+++ b/packages/web/src/components/dashboard/recent-bar-chart.tsx
@@ -73,38 +73,44 @@ function ChartTooltip({
 }) {
   if (!active || !payload?.length) return null;
 
-  const total = payload.reduce((sum, e) => sum + e.value, 0);
-
   const labels: Record<string, string> = {
     input: "Input",
     output: "Output",
   };
+
+  const total = payload.reduce((sum, e) => sum + e.value, 0);
+
+  const orderedKeys = ["input", "output"] as const;
 
   return (
     <div className="rounded-[var(--radius-widget)] border border-border bg-card p-2.5 shadow-sm">
       <p className="mb-1.5 text-xs font-medium text-foreground">
         {label ? fmtSlotFull(label) : ""}
       </p>
-      {payload.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {labels[entry.dataKey] ?? entry.dataKey}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {formatTokens(entry.value)}
-          </span>
-        </div>
-      ))}
-      <div className="mt-1 border-t border-border/50 pt-1 flex items-center gap-2 text-xs">
+      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
         <span className="text-muted-foreground">Total</span>
         <span className="ml-auto font-medium text-foreground">
           {formatTokens(total)}
         </span>
       </div>
+      {orderedKeys.map((key) => {
+        const entry = payload.find((e) => e.dataKey === key);
+        if (!entry) return null;
+        return (
+          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
+            <div
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="text-muted-foreground">
+              {labels[entry.dataKey] ?? entry.dataKey}
+            </span>
+            <span className="ml-auto font-medium text-foreground">
+              {formatTokens(entry.value)}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/components/dashboard/usage-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/usage-trend-chart.tsx
@@ -62,25 +62,38 @@ function ChartTooltip({
     cached: "Cached",
   };
 
+  const total = payload.reduce((sum, e) => sum + e.value, 0);
+  const orderedKeys = ["input", "output", "cached"] as const;
+
   return (
     <div className="rounded-[var(--radius-widget)] border border-border bg-card p-2.5 shadow-sm">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
+      <p className="mb-1 text-xs font-medium text-foreground">
         {label ? fmtDate(label) : ""}
       </p>
-      {payload.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {labels[entry.dataKey] ?? entry.dataKey}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {formatTokens(entry.value)}
-          </span>
-        </div>
-      ))}
+      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground">Total</span>
+        <span className="ml-auto font-medium text-foreground">
+          {formatTokens(total)}
+        </span>
+      </div>
+      {orderedKeys.map((key) => {
+        const entry = payload.find((e) => e.dataKey === key);
+        if (!entry) return null;
+        return (
+          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
+            <div
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="text-muted-foreground">
+              {labels[entry.dataKey] ?? entry.dataKey}
+            </span>
+            <span className="ml-auto font-medium text-foreground">
+              {formatTokens(entry.value)}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 统一 dashboard 图表 tooltip 显示顺序：Total → Input → Output → Cached
- 修改 5 个组件：recent-bar-chart, device-breakdown-chart, model-breakdown-chart, usage-trend-chart, cost-trend-chart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized dashboard chart tooltips across multiple views to display total values prominently at the top, followed by individual metrics in a consistent, fixed order. This improvement applies to cost trend, device breakdown, model breakdown, recent activity, and usage trend charts, enhancing readability and providing visual consistency throughout the analytics dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->