### PR TITLE
feat: add GitHub Copilot CLI as 7th supported source

### DIFF
--- a/packages/cli/src/__tests__/copilot-cli-parser.test.ts
+++ b/packages/cli/src/__tests__/copilot-cli-parser.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseCopilotCliFile } from "../parsers/copilot-cli.js";
+
+/** Build a realistic process log snippet with an assistant_usage block */
+function buildLogWithUsage(overrides: {
+  model?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  created_at?: string;
+  kind?: string;
+} = {}): string {
+  const {
+    model = "claude-opus-4.6",
+    input_tokens = 56706,
+    output_tokens = 1155,
+    cache_read_tokens = 0,
+    cache_write_tokens = 0,
+    created_at = "2026-03-16T10:40:00.959Z",
+    kind = "assistant_usage",
+  } = overrides;
+
+  return [
+    `2026-03-16T10:40:00.873Z [INFO] CompactionProcessor: Utilization 27.5% (46283/168000 tokens) below threshold 80%`,
+    `2026-03-16T10:40:00.959Z [INFO] [Telemetry] cli.telemetry:`,
+    `{`,
+    `  "kind": "${kind}",`,
+    `  "properties": {`,
+    `    "event_id": "068db2fe-4b7f-4f88-b2fd-450259a23239",`,
+    `    "model": "${model}",`,
+    `    "copilot_pid": "26207"`,
+    `  },`,
+    `  "metrics": {`,
+    `    "input_tokens": ${input_tokens},`,
+    `    "input_tokens_uncached": ${input_tokens - cache_read_tokens},`,
+    `    "output_tokens": ${output_tokens},`,
+    `    "cache_read_tokens": ${cache_read_tokens},`,
+    `    "cache_write_tokens": ${cache_write_tokens},`,
+    `    "cost": 3,`,
+    `    "duration": 14468`,
+    `  },`,
+    `  "session_id": "ff76b1b9-dafb-4001-bf5f-568ed00e242e",`,
+    `  "created_at": "${created_at}"`,
+    `}`,
+    `2026-03-16T10:40:00.960Z [DEBUG] Sending telemetry event: copilot-cli/cli.telemetry (kind: ${kind})`,
+  ].join("\n") + "\n";
+}
+
+describe("parseCopilotCliFile", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "pew-copilot-cli-parser-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns empty deltas and startOffset for missing file", async () => {
+    const result = await parseCopilotCliFile({
+      filePath: join(tempDir, "nonexistent.log"),
+      startOffset: 0,
+    });
+    expect(result.deltas).toHaveLength(0);
+    expect(result.endOffset).toBe(0);
+  });
+
+  it("returns endOffset equal to startOffset when file unchanged", async () => {
+    const filePath = join(tempDir, "process-123.log");
+    const content = buildLogWithUsage();
+    await writeFile(filePath, content);
+
+    const result = await parseCopilotCliFile({
+      filePath,
+      startOffset: content.length,
+    });
+    expect(result.deltas).toHaveLength(0);
+    expect(result.endOffset).toBe(content.length);
+  });
+
+  it("extracts one delta from a single assistant_usage block", async () => {
+    const filePath = join(tempDir, "process-123.log");
+    const content = buildLogWithUsage({
+      model: "claude-opus-4.6",
+      input_tokens: 56706,
+      output_tokens: 1155,
+      cache_read_tokens: 0,
+      created_at: "2026-03-16T10:40:00.959Z",
+    });
+    await writeFile(filePath, content);
+
+    const result = await parseCopilotCliFile({ filePath, startOffset: 0 });
+
+    expect(result.deltas).toHaveLength(1);
+    const delta = result.deltas[0]!;
+    expect(delta.source).toBe("copilot-cli");
+    expect(delta.model).toBe("claude-opus-4.6");
+    expect(delta.timestamp).toBe("2026-03-16T10:40:00.959Z");
+    expect(delta.tokens.inputTokens).toBe(56706);
+    expect(delta.tokens.outputTokens).toBe(1155);
+    expect(delta.tokens.cachedInputTokens).toBe(0);
+    expect(delta.tokens.reasoningOutputTokens).toBe(0);
+  });
+
+  it("extracts cached tokens correctly", async () => {
+    const filePath = join(tempDir, "process-cache.log");
+    const content = buildLogWithUsage({
+      input_tokens: 66561,
+      output_tokens: 491,
+      cache_read_tokens: 55976,
+    });
+    await writeFile(filePath, content);
+
+    const result = await parseCopilotCliFile({ filePath, startOffset: 0 });
+
+    expect(result.deltas).toHaveLength(1);
+    const delta = result.deltas[0]!;
+    expect(delta.tokens.inputTokens).toBe(66561);
+    expect(delta.tokens.cachedInputTokens).toBe(55976);
+    expect(delta.tokens.outputTokens).toBe(491);
+  });
+
+  it("extracts multiple usage blocks from one file", async () => {
+    const filePath = join(tempDir, "process-multi.log");
+    const block1 = buildLogWithUsage({
+      model: "claude-opus-4.6",
+      input_tokens: 1000,
+      output_tokens: 100,
+      created_at: "2026-03-16T10:40:00.000Z",
+    });
+    const block2 = buildLogWithUsage({
+      model: "gpt-5-mini",
+      input_tokens: 500,
+      output_tokens: 50,
+      created_at: "2026-03-16T10:41:00.000Z",
+    });
+    await writeFile(filePath, block1 + block2);
+
+    const result = await parseCopilotCliFile({ filePath, startOffset: 0 });
+
+    expect(result.deltas).toHaveLength(2);
+    expect(result.deltas[0]!.model).toBe("claude-opus-4.6");
+    expect(result.deltas[1]!.model).toBe("gpt-5-mini");
+  });
+
+  it("skips non-assistant_usage telemetry events", async () => {
+    const filePath = join(tempDir, "process-skip.log");
+    const content = buildLogWithUsage({ kind: "session_usage_info" });
+    await writeFile(filePath, content);
+
+    const result = await parseCopilotCliFile({ filePath, startOffset: 0 });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("skips events with all-zero tokens", async () => {
+    const filePath = join(tempDir, "process-zeros.log");
+    const content = buildLogWithUsage({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+    });
+    await writeFile(filePath, content);
+
+    const result = await parseCopilotCliFile({ filePath, startOffset: 0 });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("resumes from byte offset (only parses new content)", async () => {
+    const filePath = join(tempDir, "process-resume.log");
+    const block1 = buildLogWithUsage({
+      input_tokens: 1000,
+      output_tokens: 100,
+      created_at: "2026-03-16T10:40:00.000Z",
+    });
+    await writeFile(filePath, block1);
+
+    // First parse — gets block1
+    const r1 = await parseCopilotCliFile({ filePath, startOffset: 0 });
+    expect(r1.deltas).toHaveLength(1);
+    const endOffset = r1.endOffset;
+
+    // Append block2
+    const block2 = buildLogWithUsage({
+      input_tokens: 2000,
+      output_tokens: 200,
+      created_at: "2026-03-16T10:41:00.000Z",
+    });
+    await writeFile(filePath, block1 + block2);
+
+    // Resume from endOffset — only gets block2
+    const r2 = await parseCopilotCliFile({ filePath, startOffset: endOffset });
+    expect(r2.deltas).toHaveLength(1);
+    expect(r2.deltas[0]!.tokens.inputTokens).toBe(2000);
+  });
+
+  it("endOffset equals file size after parsing", async () => {
+    const filePath = join(tempDir, "process-eof.log");
+    const content = buildLogWithUsage();
+    await writeFile(filePath, content);
+
+    const result = await parseCopilotCliFile({ filePath, startOffset: 0 });
+    expect(result.endOffset).toBe(content.length);
+  });
+});

--- a/packages/cli/src/__tests__/drivers/registry.test.ts
+++ b/packages/cli/src/__tests__/drivers/registry.test.ts
@@ -58,7 +58,13 @@ describe("createTokenDrivers", () => {
     expect(fileDrivers).toHaveLength(0);
   });
 
-  it("returns all 6 file drivers when all dirs are set", () => {
+  it("includes copilot-cli file driver when copilotCliLogsDir is set", () => {
+    const { fileDrivers } = createTokenDrivers({ copilotCliLogsDir: "/tmp/copilot/logs" });
+    expect(fileDrivers).toHaveLength(1);
+    expect(fileDrivers[0].source).toBe("copilot-cli");
+  });
+
+  it("returns all 7 file drivers when all dirs are set", () => {
     const { fileDrivers, dbDrivers } = createTokenDrivers({
       claudeDir: "/tmp/claude",
       geminiDir: "/tmp/gemini",
@@ -66,10 +72,11 @@ describe("createTokenDrivers", () => {
       openclawDir: "/tmp/openclaw",
       codexSessionsDir: "/tmp/codex",
       vscodeCopilotDirs: ["/tmp/vsc"],
+      copilotCliLogsDir: "/tmp/copilot/logs",
     });
-    expect(fileDrivers).toHaveLength(6);
+    expect(fileDrivers).toHaveLength(7);
     const sources = fileDrivers.map((d) => d.source);
-    expect(sources).toEqual(["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "vscode-copilot"]);
+    expect(sources).toEqual(["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "vscode-copilot", "copilot-cli"]);
     expect(dbDrivers).toHaveLength(0);
   });
 

--- a/packages/cli/src/__tests__/drivers/token/copilot-cli-token-driver.test.ts
+++ b/packages/cli/src/__tests__/drivers/token/copilot-cli-token-driver.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { copilotCliTokenDriver } from "../../../drivers/token/copilot-cli-token-driver.js";
+import type { ByteOffsetCursor } from "@pew/core";
+import type { SyncContext, FileFingerprint } from "../../../drivers/types.js";
+
+function buildUsageBlock(input_tokens = 1000, output_tokens = 100): string {
+  return [
+    `2026-03-16T10:40:00.959Z [INFO] [Telemetry] cli.telemetry:`,
+    `{`,
+    `  "kind": "assistant_usage",`,
+    `  "properties": { "model": "claude-opus-4.6" },`,
+    `  "metrics": {`,
+    `    "input_tokens": ${input_tokens},`,
+    `    "output_tokens": ${output_tokens},`,
+    `    "cache_read_tokens": 0,`,
+    `    "cache_write_tokens": 0`,
+    `  },`,
+    `  "created_at": "2026-03-16T10:40:00.959Z"`,
+    `}`,
+    `2026-03-16T10:40:00.960Z [DEBUG] Done`,
+  ].join("\n") + "\n";
+}
+
+describe("copilotCliTokenDriver", () => {
+  let tempDir: string;
+  const ctx: SyncContext = {};
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "pew-copilot-driver-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("has correct kind and source", () => {
+    expect(copilotCliTokenDriver.kind).toBe("file");
+    expect(copilotCliTokenDriver.source).toBe("copilot-cli");
+  });
+
+  describe("discover", () => {
+    it("returns [] when copilotCliLogsDir is not set", async () => {
+      const files = await copilotCliTokenDriver.discover({}, ctx);
+      expect(files).toEqual([]);
+    });
+
+    it("discovers process-*.log files under copilotCliLogsDir", async () => {
+      await writeFile(join(tempDir, "process-123-456.log"), buildUsageBlock());
+      await writeFile(join(tempDir, "process-789-012.log"), buildUsageBlock());
+      await writeFile(join(tempDir, "other.txt"), "ignore");
+
+      const files = await copilotCliTokenDriver.discover(
+        { copilotCliLogsDir: tempDir },
+        ctx,
+      );
+      expect(files).toHaveLength(2);
+      expect(files.every((f) => f.endsWith(".log"))).toBe(true);
+    });
+  });
+
+  describe("shouldSkip", () => {
+    const fingerprint: FileFingerprint = {
+      inode: 100,
+      mtimeMs: 1709827200000,
+      size: 4096,
+    };
+
+    it("returns false when cursor is undefined", () => {
+      expect(copilotCliTokenDriver.shouldSkip(undefined, fingerprint)).toBe(false);
+    });
+
+    it("returns true when file is unchanged", () => {
+      const cursor: ByteOffsetCursor = {
+        inode: 100,
+        mtimeMs: 1709827200000,
+        size: 4096,
+        offset: 500,
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
+      expect(copilotCliTokenDriver.shouldSkip(cursor, fingerprint)).toBe(true);
+    });
+
+    it("returns false when size differs", () => {
+      const cursor: ByteOffsetCursor = {
+        inode: 100,
+        mtimeMs: 1709827200000,
+        size: 2048,
+        offset: 500,
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
+      expect(copilotCliTokenDriver.shouldSkip(cursor, fingerprint)).toBe(false);
+    });
+  });
+
+  describe("resumeState", () => {
+    const fingerprint: FileFingerprint = {
+      inode: 100,
+      mtimeMs: 1709827200000,
+      size: 4096,
+    };
+
+    it("returns offset 0 when no cursor", () => {
+      const state = copilotCliTokenDriver.resumeState(undefined, fingerprint);
+      expect(state).toEqual({ kind: "byte-offset", startOffset: 0 });
+    });
+
+    it("returns stored offset when inode matches", () => {
+      const cursor: ByteOffsetCursor = {
+        inode: 100,
+        mtimeMs: 1709827200000,
+        size: 4096,
+        offset: 500,
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
+      const state = copilotCliTokenDriver.resumeState(cursor, fingerprint);
+      expect(state).toEqual({ kind: "byte-offset", startOffset: 500 });
+    });
+
+    it("resets offset to 0 when inode differs", () => {
+      const cursor: ByteOffsetCursor = {
+        inode: 999,
+        mtimeMs: 1709827200000,
+        size: 4096,
+        offset: 500,
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
+      const state = copilotCliTokenDriver.resumeState(cursor, fingerprint);
+      expect(state).toEqual({ kind: "byte-offset", startOffset: 0 });
+    });
+  });
+
+  describe("parse + buildCursor", () => {
+    it("parses log file and builds cursor with endOffset", async () => {
+      const filePath = join(tempDir, "process-123.log");
+      const content = buildUsageBlock(5000, 800);
+      await writeFile(filePath, content);
+
+      const resume = { kind: "byte-offset" as const, startOffset: 0 };
+      const result = await copilotCliTokenDriver.parse(filePath, resume);
+
+      expect(result.deltas).toHaveLength(1);
+      expect(result.deltas[0]!.source).toBe("copilot-cli");
+      expect(result.deltas[0]!.tokens.inputTokens).toBe(5000);
+      expect(result.deltas[0]!.tokens.outputTokens).toBe(800);
+
+      const fingerprint: FileFingerprint = {
+        inode: 100,
+        mtimeMs: Date.now(),
+        size: content.length,
+      };
+      const cursor = copilotCliTokenDriver.buildCursor(fingerprint, result);
+      expect(cursor.inode).toBe(100);
+      expect(cursor.offset).toBeGreaterThan(0);
+      expect(cursor.updatedAt).toBeDefined();
+    });
+
+    it("resumes parsing from byte offset", async () => {
+      const filePath = join(tempDir, "process-resume.log");
+      const block1 = buildUsageBlock(1000, 100);
+      await writeFile(filePath, block1);
+
+      const r1 = await copilotCliTokenDriver.parse(filePath, {
+        kind: "byte-offset",
+        startOffset: 0,
+      });
+      expect(r1.deltas).toHaveLength(1);
+
+      const endOffset = (r1 as unknown as { endOffset: number }).endOffset;
+
+      const block2 = buildUsageBlock(2000, 200);
+      await writeFile(filePath, block1 + block2);
+
+      const r2 = await copilotCliTokenDriver.parse(filePath, {
+        kind: "byte-offset",
+        startOffset: endOffset,
+      });
+      expect(r2.deltas).toHaveLength(1);
+      expect(r2.deltas[0]!.tokens.inputTokens).toBe(2000);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/paths.test.ts
+++ b/packages/cli/src/__tests__/paths.test.ts
@@ -43,7 +43,12 @@ describe("resolveDefaultPaths", () => {
     expect(paths.vscodeCopilotDirs[1]).toContain("Code - Insiders");
   });
 
-  it("should return exactly 10 path properties", () => {
+  it("should resolve copilotCliLogsDir to ~/.copilot/logs", () => {
+    const paths = resolveDefaultPaths("/fakehome");
+    expect(paths.copilotCliLogsDir).toBe(join("/fakehome", ".copilot", "logs"));
+  });
+
+  it("should return exactly 11 path properties", () => {
     const keys = [
       "stateDir",
       "binDir",
@@ -55,6 +60,7 @@ describe("resolveDefaultPaths", () => {
       "openCodeDbPath",
       "openclawDir",
       "vscodeCopilotDirs",
+      "copilotCliLogsDir",
     ];
     const paths = resolveDefaultPaths("/fakehome");
     expect(Object.keys(paths)).toHaveLength(keys.length);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -173,6 +173,7 @@ const syncCommand = defineCommand({
       openMessageDb,
       openclawDir: paths.openclawDir,
       vscodeCopilotDirs: paths.vscodeCopilotDirs,
+      copilotCliLogsDir: paths.copilotCliLogsDir,
       onCorruptLine: handleCorruptLine,
       onProgress(event) {
         logSyncProgress(event);
@@ -291,6 +292,7 @@ const statusCommand = defineCommand({
         openCodeMessageDir: paths.openCodeMessageDir,
         openclawDir: paths.openclawDir,
         vscodeCopilotDirs: paths.vscodeCopilotDirs,
+        copilotCliLogsDir: paths.copilotCliLogsDir,
       },
       notifierStatuses,
       onCorruptLine: handleCorruptLine,
@@ -452,6 +454,7 @@ const notifyCommand = defineCommand({
       openSessionDb: openSessionDb2,
       openclawDir: paths.openclawDir,
       vscodeCopilotDirs: paths.vscodeCopilotDirs,
+      copilotCliLogsDir: paths.copilotCliLogsDir,
       version: CLI_VERSION,
     });
 

--- a/packages/cli/src/commands/notify.ts
+++ b/packages/cli/src/commands/notify.ts
@@ -42,6 +42,7 @@ export async function executeNotify(
           openMessageDb: opts.openMessageDb,
           openclawDir: opts.openclawDir,
           vscodeCopilotDirs: opts.vscodeCopilotDirs,
+          copilotCliLogsDir: opts.copilotCliLogsDir,
         });
         cycle.tokenSync = {
           totalDeltas: tokenResult.totalDeltas,

--- a/packages/cli/src/commands/session-sync.ts
+++ b/packages/cli/src/commands/session-sync.ts
@@ -137,6 +137,9 @@ function sourceKey(source: Source): keyof SessionSyncResult["sources"] {
     case "openclaw": return "openclaw";
     case "codex": return "codex";
     case "vscode-copilot": return "vscodeCopilot";
+    case "copilot-cli":
+      // No session tracking for GitHub Copilot CLI
+      throw new Error(`Unexpected source in session sync: copilot-cli`);
   }
 }
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -11,6 +11,7 @@ export interface SourceDirs {
   openCodeMessageDir: string;
   openclawDir: string;
   vscodeCopilotDirs: string[];
+  copilotCliLogsDir: string;
 }
 
 /** Status summary for display */
@@ -42,6 +43,7 @@ function classifySource(filePath: string, dirs: SourceDirs): string {
   for (const dir of dirs.vscodeCopilotDirs) {
     if (filePath.startsWith(dir)) return "vscode-copilot";
   }
+  if (filePath.startsWith(dirs.copilotCliLogsDir)) return "copilot-cli";
   return "unknown";
 }
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -40,6 +40,8 @@ export interface SyncOptions {
   openclawDir?: string;
   /** Override: VSCode Copilot base directories (stable + insiders) */
   vscodeCopilotDirs?: string[];
+  /** Override: GitHub Copilot CLI logs directory (~/.copilot/logs) */
+  copilotCliLogsDir?: string;
   /** Progress callback */
   onProgress?: (event: ProgressEvent) => void;
   /** Callback invoked when a corrupted JSONL line is found in the queue */
@@ -66,6 +68,7 @@ export interface SyncResult {
     opencode: number;
     openclaw: number;
     vscodeCopilot: number;
+    copilotCli: number;
   };
   /** Total files scanned per source */
   filesScanned: {
@@ -75,6 +78,7 @@ export interface SyncResult {
     opencode: number;
     openclaw: number;
     vscodeCopilot: number;
+    copilotCli: number;
   };
 }
 
@@ -95,6 +99,7 @@ function sourceKey(source: Source): keyof SyncResult["sources"] {
     case "openclaw": return "openclaw";
     case "codex": return "codex";
     case "vscode-copilot": return "vscodeCopilot";
+    case "copilot-cli": return "copilotCli";
   }
 }
 
@@ -176,8 +181,8 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
   let replayDetected = false;
 
   const allDeltas: ParsedDelta[] = [];
-  const sourceCounts = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0 };
-  const filesScanned = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0 };
+  const sourceCounts = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0, copilotCli: 0 };
+  const filesScanned = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0, copilotCli: 0 };
 
   // Collect all discovered file paths (across all drivers) for knownFilePaths
   const discoveredFiles = new Set<string>();
@@ -197,6 +202,7 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
     openCodeDbPath: opts.openCodeDbPath,
     openclawDir: opts.openclawDir,
     vscodeCopilotDirs: opts.vscodeCopilotDirs,
+    copilotCliLogsDir: opts.copilotCliLogsDir,
   };
 
   // ---------- Phase 1: File-based drivers (generic loop) ----------

--- a/packages/cli/src/discovery/sources.ts
+++ b/packages/cli/src/discovery/sources.ts
@@ -157,6 +157,18 @@ export async function discoverCodexFiles(
 }
 
 /**
+ * Discover GitHub Copilot CLI process log files.
+ * Path pattern: ~/.copilot/logs/process-*.log
+ */
+export async function discoverCopilotCliFiles(
+  logsDir: string,
+): Promise<string[]> {
+  return collectFiles(logsDir, (name) =>
+    name.startsWith("process-") && name.endsWith(".log"),
+  );
+}
+
+/**
  * Discover VSCode Copilot Chat session JSONL files.
  *
  * Scans multiple base directories (stable + insiders), each containing:

--- a/packages/cli/src/drivers/registry.ts
+++ b/packages/cli/src/drivers/registry.ts
@@ -24,6 +24,7 @@ import { openCodeJsonTokenDriver } from "./token/opencode-json-token-driver.js";
 import { openClawTokenDriver } from "./token/openclaw-token-driver.js";
 import { codexTokenDriver } from "./token/codex-token-driver.js";
 import { vscodeCopilotTokenDriver } from "./token/vscode-copilot-token-driver.js";
+import { copilotCliTokenDriver } from "./token/copilot-cli-token-driver.js";
 import {
   createOpenCodeSqliteTokenDriver,
   type OpenCodeSqliteTokenDriverOpts,
@@ -57,6 +58,7 @@ export interface TokenDriverRegistryOpts {
   openclawDir?: string;
   codexSessionsDir?: string;
   vscodeCopilotDirs?: string[];
+  copilotCliLogsDir?: string;
   openCodeDbPath?: string;
   openMessageDb?: OpenCodeSqliteTokenDriverOpts["openMessageDb"];
 }
@@ -93,6 +95,9 @@ export function createTokenDrivers(opts: TokenDriverRegistryOpts): TokenDriverSe
   }
   if (opts.vscodeCopilotDirs && opts.vscodeCopilotDirs.length > 0) {
     fileDrivers.push(vscodeCopilotTokenDriver);
+  }
+  if (opts.copilotCliLogsDir) {
+    fileDrivers.push(copilotCliTokenDriver);
   }
   if (opts.openCodeDbPath && opts.openMessageDb) {
     dbDrivers.push(

--- a/packages/cli/src/drivers/token/copilot-cli-token-driver.ts
+++ b/packages/cli/src/drivers/token/copilot-cli-token-driver.ts
@@ -1,0 +1,70 @@
+/**
+ * GitHub Copilot CLI file token driver.
+ *
+ * Strategy: Byte-offset streaming of process log files.
+ * Skip gate: fileUnchanged() (inode + mtimeMs + size).
+ * Parser: parseCopilotCliFile({ filePath, startOffset })
+ *
+ * Data location: ~/.copilot/logs/process-*.log
+ * Each file is a structured text log with embedded telemetry JSON blocks.
+ * The `assistant_usage` event contains per-request token breakdowns.
+ */
+
+import type { ByteOffsetCursor } from "@pew/core";
+import { discoverCopilotCliFiles } from "../../discovery/sources.js";
+import { parseCopilotCliFile } from "../../parsers/copilot-cli.js";
+import { fileUnchanged } from "../../utils/file-changed.js";
+import type {
+  FileTokenDriver,
+  DiscoverOpts,
+  SyncContext,
+  FileFingerprint,
+  ResumeState,
+  TokenParseResult,
+  ByteOffsetResumeState,
+} from "../types.js";
+
+interface CopilotCliParseResult extends TokenParseResult {
+  endOffset: number;
+}
+
+export const copilotCliTokenDriver: FileTokenDriver<ByteOffsetCursor> = {
+  kind: "file",
+  source: "copilot-cli",
+
+  async discover(opts: DiscoverOpts, _ctx: SyncContext): Promise<string[]> {
+    if (!opts.copilotCliLogsDir) return [];
+    return discoverCopilotCliFiles(opts.copilotCliLogsDir);
+  },
+
+  shouldSkip(cursor: ByteOffsetCursor | undefined, fingerprint: FileFingerprint): boolean {
+    return fileUnchanged(cursor, fingerprint);
+  },
+
+  resumeState(cursor: ByteOffsetCursor | undefined, fingerprint: FileFingerprint): ByteOffsetResumeState {
+    const startOffset =
+      cursor && cursor.inode === fingerprint.inode ? (cursor.offset ?? 0) : 0;
+    return { kind: "byte-offset", startOffset };
+  },
+
+  async parse(filePath: string, resume: ResumeState): Promise<CopilotCliParseResult> {
+    const r = resume as ByteOffsetResumeState;
+    const result = await parseCopilotCliFile({ filePath, startOffset: r.startOffset });
+    return { deltas: result.deltas, endOffset: result.endOffset };
+  },
+
+  buildCursor(
+    fingerprint: FileFingerprint,
+    result: TokenParseResult,
+    _prev?: ByteOffsetCursor,
+  ): ByteOffsetCursor {
+    const r = result as CopilotCliParseResult;
+    return {
+      inode: fingerprint.inode,
+      mtimeMs: fingerprint.mtimeMs,
+      size: fingerprint.size,
+      offset: r.endOffset,
+      updatedAt: new Date().toISOString(),
+    };
+  },
+};

--- a/packages/cli/src/drivers/types.ts
+++ b/packages/cli/src/drivers/types.ts
@@ -70,6 +70,7 @@ export interface DiscoverOpts {
   openCodeDbPath?: string;
   openclawDir?: string;
   vscodeCopilotDirs?: string[];
+  copilotCliLogsDir?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/parsers/copilot-cli.ts
+++ b/packages/cli/src/parsers/copilot-cli.ts
@@ -1,0 +1,140 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import type { TokenDelta } from "@pew/core";
+import { isAllZero, toNonNegInt } from "../utils/token-delta.js";
+import type { ParsedDelta } from "./claude.js";
+
+/** Result of parsing a single GitHub Copilot CLI process log file */
+export interface CopilotCliFileResult {
+  deltas: ParsedDelta[];
+  endOffset: number;
+}
+
+/**
+ * Parse a GitHub Copilot CLI process log file incrementally from a byte offset.
+ *
+ * Log format: Each telemetry block starts with a line containing
+ * `[Telemetry] cli.telemetry:` followed by a multi-line JSON object.
+ * We extract `assistant_usage` events which carry per-request token counts.
+ *
+ * Token fields:
+ *   metrics.input_tokens      → inputTokens (total, includes cached)
+ *   metrics.cache_read_tokens → cachedInputTokens
+ *   metrics.output_tokens     → outputTokens
+ */
+export async function parseCopilotCliFile(opts: {
+  filePath: string;
+  startOffset: number;
+}): Promise<CopilotCliFileResult> {
+  const { filePath, startOffset } = opts;
+  const deltas: ParsedDelta[] = [];
+
+  const st = await stat(filePath).catch(() => null);
+  if (!st || !st.isFile()) return { deltas, endOffset: startOffset };
+
+  const endOffset = st.size;
+  if (startOffset >= endOffset) return { deltas, endOffset };
+
+  const stream = createReadStream(filePath, {
+    start: startOffset,
+    encoding: "utf8",
+  });
+
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+  // Timestamp pattern that starts a new log line
+  const LOG_LINE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+  const TELEMETRY_MARKER = "[Telemetry] cli.telemetry:";
+
+  let collectingJson = false;
+  let jsonLines: string[] = [];
+  let braceDepth = 0;
+
+  function flushJson(): void {
+    if (jsonLines.length === 0) return;
+    try {
+      const raw = jsonLines.join("\n");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (parsed.kind === "assistant_usage") {
+        const delta = extractUsageDelta(parsed);
+        if (delta) deltas.push(delta);
+      }
+    } catch {
+      // Malformed JSON block — skip
+    }
+    jsonLines = [];
+    braceDepth = 0;
+  }
+
+  for await (const line of rl) {
+    if (LOG_LINE_RE.test(line)) {
+      // New log line — flush any in-progress JSON block first
+      if (collectingJson) {
+        flushJson();
+        collectingJson = false;
+      }
+
+      if (line.includes(TELEMETRY_MARKER)) {
+        collectingJson = true;
+        // The JSON starts on the next line
+      }
+      continue;
+    }
+
+    if (collectingJson) {
+      jsonLines.push(line);
+
+      // Track brace depth to detect end of top-level JSON object
+      for (const ch of line) {
+        if (ch === "{") braceDepth++;
+        else if (ch === "}") braceDepth--;
+      }
+
+      if (braceDepth === 0 && jsonLines.length > 0) {
+        flushJson();
+        collectingJson = false;
+      }
+    }
+  }
+
+  // Flush any trailing block (file ends mid-telemetry)
+  if (collectingJson && jsonLines.length > 0) {
+    flushJson();
+  }
+
+  return { deltas, endOffset };
+}
+
+/**
+ * Extract a ParsedDelta from an `assistant_usage` telemetry event.
+ * Returns null if the event has no usable token data.
+ */
+function extractUsageDelta(
+  event: Record<string, unknown>,
+): ParsedDelta | null {
+  const props = event.properties as Record<string, unknown> | undefined;
+  const metrics = event.metrics as Record<string, unknown> | undefined;
+
+  const model =
+    typeof props?.model === "string" && props.model.length > 0
+      ? props.model
+      : "unknown";
+
+  // Prefer created_at from the event; fall back to current time
+  const timestamp =
+    typeof event.created_at === "string" && event.created_at.length > 0
+      ? event.created_at
+      : new Date().toISOString();
+
+  const tokens: TokenDelta = {
+    inputTokens: toNonNegInt(metrics?.input_tokens),
+    cachedInputTokens: toNonNegInt(metrics?.cache_read_tokens),
+    outputTokens: toNonNegInt(metrics?.output_tokens),
+    reasoningOutputTokens: 0,
+  };
+
+  if (isAllZero(tokens)) return null;
+
+  return { source: "copilot-cli", model, timestamp, tokens };
+}

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -72,5 +72,7 @@ export function resolveDefaultPaths(home = homedir()) {
     openclawDir: join(home, ".openclaw"),
     /** VSCode Copilot base dirs (stable + insiders, platform-aware) */
     vscodeCopilotDirs: resolveVscodeCopilotDirs(home),
+    /** GitHub Copilot CLI logs: ~/.copilot/logs */
+    copilotCliLogsDir: join(home, ".copilot", "logs"),
   };
 }

--- a/packages/core/src/__tests__/constants.test.ts
+++ b/packages/core/src/__tests__/constants.test.ts
@@ -12,14 +12,15 @@ import {
 } from "../constants.js";
 
 describe("SOURCES", () => {
-  it("should contain exactly 6 supported AI tools", () => {
-    expect(SOURCES).toHaveLength(6);
+  it("should contain exactly 7 supported AI tools", () => {
+    expect(SOURCES).toHaveLength(7);
     expect(SOURCES).toContain("claude-code");
     expect(SOURCES).toContain("codex");
     expect(SOURCES).toContain("gemini-cli");
     expect(SOURCES).toContain("opencode");
     expect(SOURCES).toContain("openclaw");
     expect(SOURCES).toContain("vscode-copilot");
+    expect(SOURCES).toContain("copilot-cli");
   });
 
   it("should be readonly at type level", () => {
@@ -32,6 +33,7 @@ describe("SOURCES", () => {
       "opencode",
       "openclaw",
       "vscode-copilot",
+      "copilot-cli",
     ]);
   });
 });

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -20,6 +20,7 @@ export const SOURCES: readonly Source[] = Object.freeze([
   "opencode",
   "openclaw",
   "vscode-copilot",
+  "copilot-cli",
 ] as const);
 
 /** Set form for O(1) membership checks */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,14 +10,15 @@
 // Source: Supported AI coding tools
 // ---------------------------------------------------------------------------
 
-/** The 6 supported AI coding tools */
+/** The 7 supported AI coding tools */
 export type Source =
   | "claude-code"
   | "codex"
   | "gemini-cli"
   | "opencode"
   | "openclaw"
-  | "vscode-copilot";
+  | "vscode-copilot"
+  | "copilot-cli";
 
 // ---------------------------------------------------------------------------
 // Token types

--- a/packages/web/src/__tests__/usage-helpers.test.ts
+++ b/packages/web/src/__tests__/usage-helpers.test.ts
@@ -205,6 +205,7 @@ describe("sourceLabel", () => {
     expect(sourceLabel("opencode")).toBe("OpenCode");
     expect(sourceLabel("openclaw")).toBe("OpenClaw");
     expect(sourceLabel("vscode-copilot")).toBe("VS Code Copilot");
+    expect(sourceLabel("copilot-cli")).toBe("GitHub Copilot CLI");
   });
 
   it("should return raw string for unknown sources", () => {

--- a/packages/web/src/app/api/projects/[id]/route.ts
+++ b/packages/web/src/app/api/projects/[id]/route.ts
@@ -18,6 +18,7 @@ const VALID_SOURCES = new Set([
   "opencode",
   "openclaw",
   "vscode-copilot",
+  "copilot-cli",
 ]);
 
 const MAX_NAME_LENGTH = 100;

--- a/packages/web/src/app/api/projects/route.ts
+++ b/packages/web/src/app/api/projects/route.ts
@@ -18,6 +18,7 @@ const VALID_SOURCES = new Set([
   "opencode",
   "openclaw",
   "vscode-copilot",
+  "copilot-cli",
 ]);
 
 const MAX_NAME_LENGTH = 100;

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -25,6 +25,7 @@ const VALID_SOURCES = new Set([
   "opencode",
   "openclaw",
   "vscode-copilot",
+  "copilot-cli",
 ]);
 
 const VALID_KINDS = new Set(["human", "automated"]);

--- a/packages/web/src/app/api/usage/route.ts
+++ b/packages/web/src/app/api/usage/route.ts
@@ -25,6 +25,7 @@ const VALID_SOURCES = new Set([
   "opencode",
   "openclaw",
   "vscode-copilot",
+  "copilot-cli",
 ]);
 
 const VALID_GRANULARITIES = new Set(["half-hour", "day"]);

--- a/packages/web/src/app/api/users/[slug]/route.ts
+++ b/packages/web/src/app/api/users/[slug]/route.ts
@@ -24,6 +24,7 @@ const VALID_SOURCES = new Set([
   "opencode",
   "openclaw",
   "vscode-copilot",
+  "copilot-cli",
 ]);
 
 const MAX_DAYS = 365;

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -156,6 +156,7 @@ const SOURCE_LABELS: Record<string, string> = {
   opencode: "OpenCode",
   openclaw: "OpenClaw",
   "vscode-copilot": "VS Code Copilot",
+  "copilot-cli": "GitHub Copilot CLI",
 };
 
 export function sourceLabel(source: string): string {

--- a/packages/web/src/lib/palette.ts
+++ b/packages/web/src/lib/palette.ts
@@ -67,6 +67,8 @@ const AGENT_COLOR_MAP: Record<string, ChartColor> = {
   "codex":         { color: chart.green,      token: "chart-4" },
   "openclaw":      { color: chart.lime,       token: "chart-5" },
   "copilot-vscode":{ color: chart.amber,      token: "chart-6" },
+  "vscode-copilot":{ color: chart.amber,      token: "chart-6" },
+  "copilot-cli":   { color: chart.orange,     token: "chart-7" },
 };
 
 /** Default color for unknown agents. */

--- a/packages/web/src/lib/pricing.ts
+++ b/packages/web/src/lib/pricing.ts
@@ -101,6 +101,7 @@ export const DEFAULT_SOURCE_DEFAULTS: Record<string, ModelPricing> = {
   opencode: { input: 2, output: 8, cached: 0.5 },
   openclaw: { input: 2, output: 8, cached: 0.5 },
   "vscode-copilot": { input: 3, output: 15, cached: 0.3 },
+  "copilot-cli": { input: 3, output: 15, cached: 0.3 },
 };
 
 export const DEFAULT_FALLBACK: ModelPricing = { input: 3, output: 15, cached: 0.3 };


### PR DESCRIPTION
## Summary

- Add `copilot-cli` as a new source tracking token usage from GitHub Copilot CLI (`~/.copilot/logs/process-*.log`)
- Parse `assistant_usage` telemetry events which contain per-request `input_tokens`, `output_tokens`, `cache_read_tokens`, and `model`
- Full incremental sync via byte-offset cursor (same pattern as Claude Code)

## Changes

**`packages/core`**
- Add `"copilot-cli"` to `Source` union type and `SOURCES` array (7th source)

**`packages/cli`**
- New parser: `parsers/copilot-cli.ts` — stateful multi-line JSON block extractor from process logs
- New driver: `drivers/token/copilot-cli-token-driver.ts` — byte-offset file driver
- Discovery: `discoverCopilotCliFiles()` for `process-*.log` files
- Paths: `copilotCliLogsDir → ~/.copilot/logs`
- Wired into `sync`, `notify`, `status`, `session-sync`, registry

**`packages/web`**
- Label: `"GitHub Copilot CLI"`
- Palette: `chart.orange` (chart-7)
- Pricing: source default `input=3 output=15 cached=0.3` (model-aware via prefix match)
- All API routes (`usage`, `sessions`, `projects`, `users/[slug]`): add `"copilot-cli"` to `VALID_SOURCES`

## Test plan

- [ ] 18 new tests added (8 parser + 10 driver), all 2057 tests pass
- [ ] Build passes with no TypeScript errors
- [ ] Verify `pew sync` picks up sessions from `~/.copilot/logs/` after running GitHub Copilot CLI
- [ ] Verify token counts appear correctly in dashboard under "GitHub Copilot CLI" source