### PR TITLE
feat(web): add same-period month comparison to dashboard stat cards

### DIFF
--- a/packages/web/src/__tests__/usage-helpers.test.ts
+++ b/packages/web/src/__tests__/usage-helpers.test.ts
@@ -421,8 +421,13 @@ describe("computeMoMGrowth", () => {
     expect(result.previousMonth.tokens).toBe(0);
     expect(result.previousMonth.cost).toBe(0);
     expect(result.previousMonth.days).toBe(0);
+    expect(result.previousMonthSameDate.tokens).toBe(0);
+    expect(result.previousMonthSameDate.cost).toBe(0);
+    expect(result.previousMonthSameDate.days).toBe(0);
     expect(result.tokenGrowth).toBe(0);
     expect(result.costGrowth).toBe(0);
+    expect(result.sameDateTokenGrowth).toBe(0);
+    expect(result.sameDateCostGrowth).toBe(0);
   });
 
   it("should split rows into current and previous month", () => {
@@ -494,6 +499,62 @@ describe("computeMoMGrowth", () => {
 
     expect(result.previousMonth.days).toBe(1);
     expect(result.currentMonth.days).toBe(2);
+  });
+
+  it("should compute same-date comparison (only previous month days <= current day)", () => {
+    // ref date = March 15 → only include Feb 1-15 for same-date comparison
+    const rows = [
+      // February: day 5 (included), day 10 (included), day 20 (excluded)
+      makeRow({ hour_start: "2026-02-05T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ hour_start: "2026-02-10T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ hour_start: "2026-02-20T10:00:00Z", total_tokens: 3000, input_tokens: 2400, output_tokens: 600, cached_input_tokens: 300 }),
+      // March (current): day 5 and day 10
+      makeRow({ hour_start: "2026-03-05T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+      makeRow({ hour_start: "2026-03-10T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+    ];
+
+    const result = computeMoMGrowth(rows, makePricingMap(), new Date("2026-03-15"));
+
+    // Full month: prev=5000, cur=4000 → tokenGrowth = -20%
+    expect(result.previousMonth.tokens).toBe(5000);
+    expect(result.currentMonth.tokens).toBe(4000);
+    expect(result.tokenGrowth).toBeCloseTo(-20);
+
+    // Same-date (Feb 1-15 only): prev=2000, cur=4000 → sameDateTokenGrowth = +100%
+    expect(result.previousMonthSameDate.tokens).toBe(2000);
+    expect(result.previousMonthSameDate.days).toBe(2);
+    expect(result.sameDateTokenGrowth).toBeCloseTo(100);
+  });
+
+  it("should include previous month day equal to current day in same-date subset", () => {
+    // ref date = March 15 → Feb 15 should be INCLUDED (d <= currentDay)
+    const rows = [
+      makeRow({ hour_start: "2026-02-15T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ hour_start: "2026-03-10T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+    ];
+
+    const result = computeMoMGrowth(rows, makePricingMap(), new Date("2026-03-15"));
+
+    expect(result.previousMonthSameDate.tokens).toBe(1000);
+    expect(result.sameDateTokenGrowth).toBeCloseTo(100);
+  });
+
+  it("should return zero same-date growth when no previous same-date data", () => {
+    // ref date = March 2 → only Feb 1-2 for same-date; all Feb data is after day 2
+    const rows = [
+      makeRow({ hour_start: "2026-02-15T10:00:00Z", total_tokens: 3000, input_tokens: 2400, output_tokens: 600, cached_input_tokens: 300 }),
+      makeRow({ hour_start: "2026-03-01T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+    ];
+
+    const result = computeMoMGrowth(rows, makePricingMap(), new Date("2026-03-02"));
+
+    // Full month comparison still works
+    expect(result.previousMonth.tokens).toBe(3000);
+    expect(result.tokenGrowth).toBeCloseTo(-66.67, 1);
+
+    // Same-date: no Feb data in days 1-2 → growth = 0
+    expect(result.previousMonthSameDate.tokens).toBe(0);
+    expect(result.sameDateTokenGrowth).toBe(0);
   });
 
   it("should assign UTC midnight row to previous month for west-of-UTC timezone (tzOffset=480, PST)", () => {

--- a/packages/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/web/src/app/(dashboard)/dashboard/page.tsx
@@ -242,9 +242,14 @@ export default function DashboardPage() {
                 subtitle={subtitle}
                 icon={Zap}
                 iconColor="text-primary"
-                {...(mom && mom.previousMonth.tokens > 0
-                  ? { trend: { value: Math.round(mom.tokenGrowth), label: "vs last month" } }
-                  : {})}
+                trends={mom ? [
+                  ...(mom.previousMonthSameDate.tokens > 0
+                    ? [{ value: Math.round(mom.sameDateTokenGrowth), label: "vs same period" }]
+                    : []),
+                  ...(mom.previousMonth.tokens > 0
+                    ? [{ value: Math.round(mom.tokenGrowth), label: "vs last month" }]
+                    : []),
+                ] : undefined}
               />
               <StatCard
                 title="Input Tokens"
@@ -264,9 +269,14 @@ export default function DashboardPage() {
                 subtitle="Based on public pricing"
                 icon={DollarSign}
                 iconColor="text-chart-6"
-                {...(mom && mom.previousMonth.cost > 0
-                  ? { trend: { value: -Math.round(mom.costGrowth), label: "vs last month" } }
-                  : {})}
+                trends={mom ? [
+                  ...(mom.previousMonthSameDate.cost > 0
+                    ? [{ value: -Math.round(mom.sameDateCostGrowth), label: "vs same period" }]
+                    : []),
+                  ...(mom.previousMonth.cost > 0
+                    ? [{ value: -Math.round(mom.costGrowth), label: "vs last month" }]
+                    : []),
+                ] : undefined}
               />
             </StatGrid>
 

--- a/packages/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/web/src/app/(dashboard)/dashboard/page.tsx
@@ -243,7 +243,7 @@ export default function DashboardPage() {
                 icon={Zap}
                 iconColor="text-primary"
                 trends={mom ? [
-                  ...(mom.previousMonthSameDate.tokens > 0
+                  ...(mom.previousMonthSameDate.tokens > 0 && mom.previousMonthSameDate.tokens !== mom.previousMonth.tokens
                     ? [{ value: Math.round(mom.sameDateTokenGrowth), label: "vs same period" }]
                     : []),
                   ...(mom.previousMonth.tokens > 0
@@ -270,7 +270,7 @@ export default function DashboardPage() {
                 icon={DollarSign}
                 iconColor="text-chart-6"
                 trends={mom ? [
-                  ...(mom.previousMonthSameDate.cost > 0
+                  ...(mom.previousMonthSameDate.cost > 0 && mom.previousMonthSameDate.tokens !== mom.previousMonth.tokens
                     ? [{ value: -Math.round(mom.sameDateCostGrowth), label: "vs same period" }]
                     : []),
                   ...(mom.previousMonth.cost > 0

--- a/packages/web/src/components/dashboard/stat-card.tsx
+++ b/packages/web/src/components/dashboard/stat-card.tsx
@@ -12,6 +12,7 @@ export interface StatCardProps {
   icon?: LucideIcon;
   iconColor?: string;
   trend?: { value: number; label?: string };
+  trends?: { value: number; label?: string }[] | undefined;
   className?: string;
 }
 
@@ -26,10 +27,11 @@ export function StatCard({
   icon: Icon,
   iconColor = "text-muted-foreground",
   trend,
+  trends,
   className,
 }: StatCardProps) {
-  const isPositive = trend && trend.value > 0;
-  const isNegative = trend && trend.value < 0;
+  // Merge single trend + trends array into one list
+  const allTrends = trends ?? (trend ? [trend] : []);
 
   return (
     <div className={cn("rounded-[var(--radius-card)] bg-secondary p-4 md:p-5", className)}>
@@ -49,22 +51,30 @@ export function StatCard({
           </div>
         )}
       </div>
-      {trend && (
-        <div className="mt-3 flex items-center gap-1 text-xs">
-          <span
-            className={cn(
-              "font-medium",
-              isPositive && "text-success",
-              isNegative && "text-destructive",
-              !isPositive && !isNegative && "text-muted-foreground"
-            )}
-          >
-            {isPositive && "+"}
-            {trend.value}%
-          </span>
-          {trend.label && (
-            <span className="text-muted-foreground">{trend.label}</span>
-          )}
+      {allTrends.length > 0 && (
+        <div className="mt-3 flex flex-col gap-1">
+          {allTrends.map((t, i) => {
+            const isPos = t.value > 0;
+            const isNeg = t.value < 0;
+            return (
+              <div key={i} className="flex items-center gap-1 text-xs">
+                <span
+                  className={cn(
+                    "font-medium",
+                    isPos && "text-success",
+                    isNeg && "text-destructive",
+                    !isPos && !isNeg && "text-muted-foreground"
+                  )}
+                >
+                  {isPos && "+"}
+                  {t.value}%
+                </span>
+                {t.label && (
+                  <span className="text-muted-foreground">{t.label}</span>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/web/src/lib/usage-helpers.ts
+++ b/packages/web/src/lib/usage-helpers.ts
@@ -104,10 +104,16 @@ export interface WeekdayWeekendStats {
 export interface MoMComparison {
   currentMonth: { tokens: number; cost: number; days: number };
   previousMonth: { tokens: number; cost: number; days: number };
+  /** Previous month data up to the same day-of-month as the reference date. */
+  previousMonthSameDate: { tokens: number; cost: number; days: number };
   /** Percentage change in tokens: (current - previous) / previous * 100 */
   tokenGrowth: number;
   /** Percentage change in cost: (current - previous) / previous * 100 */
   costGrowth: number;
+  /** Same-date token growth: current month vs previous month up to same day */
+  sameDateTokenGrowth: number;
+  /** Same-date cost growth: current month vs previous month up to same day */
+  sameDateCostGrowth: number;
 }
 
 /** Consecutive usage day streak info. */
@@ -507,6 +513,7 @@ export function computeMoMGrowth(
   const ref = now ?? new Date();
   const currentYear = ref.getFullYear();
   const currentMonth = ref.getMonth(); // 0-indexed
+  const currentDay = ref.getDate(); // 1-indexed day of month
 
   // Previous month (handles January → December of previous year)
   const prevYear = currentMonth === 0 ? currentYear - 1 : currentYear;
@@ -520,10 +527,16 @@ export function computeMoMGrowth(
   let prevCost = 0;
   const prevDays = new Set<string>();
 
+  // Same-date subset: previous month rows where day <= currentDay
+  let prevSameDateTokens = 0;
+  let prevSameDateCost = 0;
+  const prevSameDateDays = new Set<string>();
+
   for (const r of rows) {
     const dateStr = toLocalDateStr(r.hour_start, tzOffset);
     const y = parseInt(dateStr.slice(0, 4), 10);
     const m = parseInt(dateStr.slice(5, 7), 10) - 1; // 0-indexed
+    const d = parseInt(dateStr.slice(8, 10), 10); // day of month
 
     const pricing = lookupPricing(pricingMap, r.model, r.source);
     const cost = estimateCost(
@@ -541,10 +554,17 @@ export function computeMoMGrowth(
       prevTokens += r.total_tokens;
       prevCost += cost.totalCost;
       prevDays.add(dateStr);
+
+      // Same-date subset: only count days up to the current day-of-month
+      if (d <= currentDay) {
+        prevSameDateTokens += r.total_tokens;
+        prevSameDateCost += cost.totalCost;
+        prevSameDateDays.add(dateStr);
+      }
     }
   }
 
-  // Growth: (current - previous) / previous * 100; 0 if no previous
+  // Full month growth: (current - previous) / previous * 100; 0 if no previous
   const tokenGrowth = prevTokens > 0
     ? ((curTokens - prevTokens) / prevTokens) * 100
     : 0;
@@ -552,11 +572,22 @@ export function computeMoMGrowth(
     ? ((curCost - prevCost) / prevCost) * 100
     : 0;
 
+  // Same-date growth: current month vs previous month up to same day
+  const sameDateTokenGrowth = prevSameDateTokens > 0
+    ? ((curTokens - prevSameDateTokens) / prevSameDateTokens) * 100
+    : 0;
+  const sameDateCostGrowth = prevSameDateCost > 0
+    ? ((curCost - prevSameDateCost) / prevSameDateCost) * 100
+    : 0;
+
   return {
     currentMonth: { tokens: curTokens, cost: curCost, days: curDays.size },
     previousMonth: { tokens: prevTokens, cost: prevCost, days: prevDays.size },
+    previousMonthSameDate: { tokens: prevSameDateTokens, cost: prevSameDateCost, days: prevSameDateDays.size },
     tokenGrowth,
     costGrowth,
+    sameDateTokenGrowth,
+    sameDateCostGrowth,
   };
 }
 


### PR DESCRIPTION
## Summary

Add a **"vs same period"** comparison alongside the existing **"vs last month"** on Total Tokens and Est. Cost dashboard cards.

### Motivation

The full-month comparison is misleading early in the month — e.g., on April 2nd, comparing 2 days of April against all 31 days of March always shows a huge drop. The same-period comparison (Apr 1–2 vs Mar 1–2) gives a fairer picture.

### Changes

- **`usage-helpers.ts`**: `MoMComparison` gains `previousMonthSameDate`, `sameDateTokenGrowth`, `sameDateCostGrowth`. `computeMoMGrowth()` tracks previous-month rows where day ≤ current day-of-month.
- **`stat-card.tsx`**: New `trends` array prop for rendering multiple trend lines.
- **`dashboard/page.tsx`**: Shows both comparisons. When months have unequal lengths and currentDay exceeds previous month's last day (e.g., Mar 31 vs Feb 28), the redundant same-period line is hidden automatically.
- **Tests**: 3 new test cases. All 2187 tests pass.

### UI Behavior

| Scenario | Displayed |
|----------|-----------|
| Apr 2 (early month) | `+120% vs same period` · `-40% vs last month` |
| Mar 31 vs Feb (28 days) | `-40% vs last month` (same-period hidden, would be identical) |
| No previous month data | No trend shown |