### PR TITLE
feat: add pi coding agent as 8th supported source

### DIFF
--- a/packages/cli/src/__tests__/drivers/registry.test.ts
+++ b/packages/cli/src/__tests__/drivers/registry.test.ts
@@ -165,17 +165,24 @@ describe("createSessionDrivers", () => {
     expect(fileDrivers[0].source).toBe("codex");
   });
 
-  it("returns all 5 file drivers when all dirs are set", () => {
+  it("includes pi session driver when piSessionsDir is set", () => {
+    const { fileDrivers } = createSessionDrivers({ piSessionsDir: "/tmp/pi/sessions" });
+    expect(fileDrivers).toHaveLength(1);
+    expect(fileDrivers[0].source).toBe("pi");
+  });
+
+  it("returns all 6 file drivers when all dirs are set", () => {
     const { fileDrivers, dbDrivers } = createSessionDrivers({
       claudeDir: "/tmp/claude",
       geminiDir: "/tmp/gemini",
       openCodeMessageDir: "/tmp/oc",
       openclawDir: "/tmp/openclaw",
+      piSessionsDir: "/tmp/pi/sessions",
       codexSessionsDir: "/tmp/codex",
     });
-    expect(fileDrivers).toHaveLength(5);
+    expect(fileDrivers).toHaveLength(6);
     const sources = fileDrivers.map((d) => d.source);
-    expect(sources).toEqual(["claude-code", "codex", "gemini-cli", "opencode", "openclaw"]);
+    expect(sources).toEqual(["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "pi"]);
     expect(dbDrivers).toHaveLength(0);
   });
 

--- a/packages/cli/src/__tests__/drivers/registry.test.ts
+++ b/packages/cli/src/__tests__/drivers/registry.test.ts
@@ -58,25 +58,32 @@ describe("createTokenDrivers", () => {
     expect(fileDrivers).toHaveLength(0);
   });
 
+  it("includes pi file driver when piSessionsDir is set", () => {
+    const { fileDrivers } = createTokenDrivers({ piSessionsDir: "/tmp/pi/sessions" });
+    expect(fileDrivers).toHaveLength(1);
+    expect(fileDrivers[0].source).toBe("pi");
+  });
+
   it("includes copilot-cli file driver when copilotCliLogsDir is set", () => {
     const { fileDrivers } = createTokenDrivers({ copilotCliLogsDir: "/tmp/copilot/logs" });
     expect(fileDrivers).toHaveLength(1);
     expect(fileDrivers[0].source).toBe("copilot-cli");
   });
 
-  it("returns all 7 file drivers when all dirs are set", () => {
+  it("returns all 8 file drivers when all dirs are set", () => {
     const { fileDrivers, dbDrivers } = createTokenDrivers({
       claudeDir: "/tmp/claude",
       geminiDir: "/tmp/gemini",
       openCodeMessageDir: "/tmp/oc",
       openclawDir: "/tmp/openclaw",
+      piSessionsDir: "/tmp/pi/sessions",
       codexSessionsDir: "/tmp/codex",
       vscodeCopilotDirs: ["/tmp/vsc"],
       copilotCliLogsDir: "/tmp/copilot/logs",
     });
-    expect(fileDrivers).toHaveLength(7);
+    expect(fileDrivers).toHaveLength(8);
     const sources = fileDrivers.map((d) => d.source);
-    expect(sources).toEqual(["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "vscode-copilot", "copilot-cli"]);
+    expect(sources).toEqual(["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "pi", "vscode-copilot", "copilot-cli"]);
     expect(dbDrivers).toHaveLength(0);
   });
 

--- a/packages/cli/src/__tests__/pi-hook.test.ts
+++ b/packages/cli/src/__tests__/pi-hook.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, rm, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { installPiHook, uninstallPiHook, getPiHookStatus } from "../notifier/pi-hook.js";
+
+describe("pi-hook", () => {
+  let testDir: string;
+  let extensionPath: string;
+  const notifyPath = "/home/test/.config/pew/bin/notify.cjs";
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `pew-pi-hook-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(testDir, { recursive: true });
+    extensionPath = join(testDir, "pew-sync.ts");
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe("installPiHook", () => {
+    it("creates extension file with correct content", async () => {
+      const result = await installPiHook({ extensionPath, notifyPath });
+      expect(result.source).toBe("pi");
+      expect(result.action).toBe("install");
+      expect(result.changed).toBe(true);
+
+      const content = await readFile(extensionPath, "utf8");
+      expect(content).toContain("PEW_PI_HOOK");
+      expect(content).toContain("session_shutdown");
+      expect(content).toContain(notifyPath);
+      expect(content).toContain("--source=pi");
+    });
+
+    it("reports unchanged if already installed", async () => {
+      await installPiHook({ extensionPath, notifyPath });
+      const result = await installPiHook({ extensionPath, notifyPath });
+      expect(result.changed).toBe(false);
+      expect(result.detail).toContain("already installed");
+    });
+
+    it("updates if content differs", async () => {
+      await writeFile(extensionPath, "// PEW_PI_HOOK\nold content\n", "utf8");
+      const result = await installPiHook({ extensionPath, notifyPath });
+      expect(result.changed).toBe(true);
+
+      const content = await readFile(extensionPath, "utf8");
+      expect(content).toContain("session_shutdown");
+    });
+  });
+
+  describe("uninstallPiHook", () => {
+    it("removes extension file", async () => {
+      await installPiHook({ extensionPath, notifyPath });
+      const result = await uninstallPiHook({ extensionPath, notifyPath });
+      expect(result.source).toBe("pi");
+      expect(result.action).toBe("uninstall");
+      expect(result.changed).toBe(true);
+    });
+
+    it("skips if file not found", async () => {
+      const result = await uninstallPiHook({ extensionPath, notifyPath });
+      expect(result.action).toBe("skip");
+      expect(result.changed).toBe(false);
+    });
+
+    it("skips if file not managed by pew", async () => {
+      await writeFile(extensionPath, "// some other extension\n", "utf8");
+      const result = await uninstallPiHook({ extensionPath, notifyPath });
+      expect(result.action).toBe("skip");
+      expect(result.changed).toBe(false);
+    });
+  });
+
+  describe("getPiHookStatus", () => {
+    it("returns installed when hook exists", async () => {
+      await installPiHook({ extensionPath, notifyPath });
+      const status = await getPiHookStatus({ extensionPath, notifyPath });
+      expect(status).toBe("installed");
+    });
+
+    it("returns not-installed when hook missing", async () => {
+      const status = await getPiHookStatus({ extensionPath, notifyPath });
+      expect(status).toBe("not-installed");
+    });
+
+    it("returns not-installed when file exists but no marker", async () => {
+      await writeFile(extensionPath, "// other extension\n", "utf8");
+      const status = await getPiHookStatus({ extensionPath, notifyPath });
+      expect(status).toBe("not-installed");
+    });
+  });
+});

--- a/packages/cli/src/__tests__/pi-parser.test.ts
+++ b/packages/cli/src/__tests__/pi-parser.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, mkdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parsePiFile, normalizePiUsage } from "../parsers/pi.js";
+
+describe("normalizePiUsage", () => {
+  it("maps pi usage fields to TokenDelta", () => {
+    const result = normalizePiUsage({
+      input: 3,
+      output: 577,
+      cacheRead: 0,
+      cacheWrite: 19631,
+      totalTokens: 20209,
+    });
+    expect(result).toEqual({
+      inputTokens: 3 + 19631, // input + cacheWrite
+      cachedInputTokens: 0,
+      outputTokens: 577,
+      reasoningOutputTokens: 0,
+    });
+  });
+
+  it("maps cacheRead to cachedInputTokens", () => {
+    const result = normalizePiUsage({
+      input: 1,
+      output: 99,
+      cacheRead: 15521,
+      cacheWrite: 1448,
+    });
+    expect(result).toEqual({
+      inputTokens: 1 + 1448,
+      cachedInputTokens: 15521,
+      outputTokens: 99,
+      reasoningOutputTokens: 0,
+    });
+  });
+
+  it("handles missing fields gracefully", () => {
+    const result = normalizePiUsage({});
+    expect(result).toEqual({
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+    });
+  });
+
+  it("treats negative values as zero", () => {
+    const result = normalizePiUsage({ input: -5, output: -1 });
+    expect(result).toEqual({
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+    });
+  });
+});
+
+describe("parsePiFile", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `pew-pi-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("parses assistant messages with usage data", async () => {
+    const filePath = join(testDir, "session.jsonl");
+    const lines = [
+      JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "test-session",
+        timestamp: "2026-04-07T04:41:54.637Z",
+        cwd: "/test",
+      }),
+      JSON.stringify({
+        type: "model_change",
+        id: "mc1",
+        parentId: null,
+        timestamp: "2026-04-07T04:41:55.864Z",
+        provider: "github-copilot",
+        modelId: "claude-opus-4.6-1m",
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "msg1",
+        parentId: "mc1",
+        timestamp: "2026-04-07T04:42:45.105Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello" }],
+          model: "claude-opus-4.6-1m",
+          usage: {
+            input: 3,
+            output: 577,
+            cacheRead: 0,
+            cacheWrite: 19631,
+            totalTokens: 20209,
+          },
+        },
+      }),
+    ];
+    await writeFile(filePath, lines.join("\n") + "\n");
+
+    const result = await parsePiFile({ filePath, startOffset: 0 });
+    expect(result.deltas).toHaveLength(1);
+    expect(result.deltas[0]).toEqual({
+      source: "pi",
+      model: "claude-opus-4.6-1m",
+      timestamp: "2026-04-07T04:42:45.105Z",
+      tokens: {
+        inputTokens: 3 + 19631,
+        cachedInputTokens: 0,
+        outputTokens: 577,
+        reasoningOutputTokens: 0,
+      },
+    });
+    const st = await stat(filePath);
+    expect(result.endOffset).toBe(st.size);
+  });
+
+  it("skips non-assistant messages", async () => {
+    const filePath = join(testDir, "session.jsonl");
+    const lines = [
+      JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "test",
+        timestamp: "2026-04-07T04:41:54.637Z",
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "msg1",
+        parentId: null,
+        timestamp: "2026-04-07T04:42:25.493Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Hello" }],
+          timestamp: 1775536945492,
+        },
+      }),
+      JSON.stringify({
+        type: "model_change",
+        id: "mc1",
+        timestamp: "2026-04-07T04:41:55.864Z",
+        provider: "anthropic",
+        modelId: "claude-sonnet-4",
+      }),
+    ];
+    await writeFile(filePath, lines.join("\n") + "\n");
+
+    const result = await parsePiFile({ filePath, startOffset: 0 });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("resumes from byte offset", async () => {
+    const filePath = join(testDir, "session.jsonl");
+    const line1 = JSON.stringify({
+      type: "message",
+      id: "msg1",
+      parentId: null,
+      timestamp: "2026-04-07T04:42:45.105Z",
+      message: {
+        role: "assistant",
+        model: "claude-opus-4.6-1m",
+        content: [],
+        usage: { input: 3, output: 100, cacheRead: 0, cacheWrite: 1000 },
+      },
+    });
+    const line2 = JSON.stringify({
+      type: "message",
+      id: "msg2",
+      parentId: "msg1",
+      timestamp: "2026-04-07T04:43:00.000Z",
+      message: {
+        role: "assistant",
+        model: "claude-opus-4.6-1m",
+        content: [],
+        usage: { input: 5, output: 200, cacheRead: 500, cacheWrite: 2000 },
+      },
+    });
+    await writeFile(filePath, line1 + "\n" + line2 + "\n");
+
+    // First parse — get both
+    const result1 = await parsePiFile({ filePath, startOffset: 0 });
+    expect(result1.deltas).toHaveLength(2);
+
+    // Resume — get nothing new
+    const result2 = await parsePiFile({
+      filePath,
+      startOffset: result1.endOffset,
+    });
+    expect(result2.deltas).toHaveLength(0);
+    expect(result2.endOffset).toBe(result1.endOffset);
+  });
+
+  it("skips messages with zero usage", async () => {
+    const filePath = join(testDir, "session.jsonl");
+    const line = JSON.stringify({
+      type: "message",
+      id: "msg1",
+      parentId: null,
+      timestamp: "2026-04-07T04:42:45.105Z",
+      message: {
+        role: "assistant",
+        model: "some-model",
+        content: [],
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    });
+    await writeFile(filePath, line + "\n");
+
+    const result = await parsePiFile({ filePath, startOffset: 0 });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("skips messages without model", async () => {
+    const filePath = join(testDir, "session.jsonl");
+    const line = JSON.stringify({
+      type: "message",
+      id: "msg1",
+      parentId: null,
+      timestamp: "2026-04-07T04:42:45.105Z",
+      message: {
+        role: "assistant",
+        content: [],
+        usage: { input: 3, output: 100, cacheRead: 0, cacheWrite: 1000 },
+      },
+    });
+    await writeFile(filePath, line + "\n");
+
+    const result = await parsePiFile({ filePath, startOffset: 0 });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("handles multiple assistant messages across turns", async () => {
+    const filePath = join(testDir, "session.jsonl");
+    const messages = [
+      {
+        type: "message",
+        id: "msg1",
+        parentId: null,
+        timestamp: "2026-04-07T04:42:45.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4.6-1m",
+          content: [],
+          usage: { input: 3, output: 135, cacheRead: 0, cacheWrite: 15521 },
+        },
+      },
+      {
+        type: "message",
+        id: "msg2",
+        parentId: "msg1",
+        timestamp: "2026-04-07T04:42:50.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4.6-1m",
+          content: [],
+          usage: { input: 1, output: 99, cacheRead: 15521, cacheWrite: 1448 },
+        },
+      },
+      {
+        type: "message",
+        id: "msg3",
+        parentId: "msg2",
+        timestamp: "2026-04-07T04:43:00.000Z",
+        message: {
+          role: "assistant",
+          model: "gemini-3-pro-preview",
+          content: [],
+          usage: { input: 381, output: 89, cacheRead: 3199, cacheWrite: 0 },
+        },
+      },
+    ];
+    await writeFile(filePath, messages.map((m) => JSON.stringify(m)).join("\n") + "\n");
+
+    const result = await parsePiFile({ filePath, startOffset: 0 });
+    expect(result.deltas).toHaveLength(3);
+
+    // First message
+    expect(result.deltas[0].source).toBe("pi");
+    expect(result.deltas[0].model).toBe("claude-opus-4.6-1m");
+    expect(result.deltas[0].tokens.inputTokens).toBe(3 + 15521);
+    expect(result.deltas[0].tokens.outputTokens).toBe(135);
+
+    // Third message — different model
+    expect(result.deltas[2].model).toBe("gemini-3-pro-preview");
+    expect(result.deltas[2].tokens.inputTokens).toBe(381 + 0);
+    expect(result.deltas[2].tokens.cachedInputTokens).toBe(3199);
+  });
+
+  it("returns empty for missing file", async () => {
+    const result = await parsePiFile({
+      filePath: join(testDir, "nonexistent.jsonl"),
+      startOffset: 0,
+    });
+    expect(result.deltas).toHaveLength(0);
+    expect(result.endOffset).toBe(0);
+  });
+
+  it("handles malformed JSON lines gracefully", async () => {
+    const filePath = join(testDir, "session.jsonl");
+    const validLine = JSON.stringify({
+      type: "message",
+      id: "msg1",
+      parentId: null,
+      timestamp: "2026-04-07T04:42:45.000Z",
+      message: {
+        role: "assistant",
+        model: "claude-opus-4.6-1m",
+        content: [],
+        usage: { input: 3, output: 100, cacheRead: 0, cacheWrite: 1000 },
+      },
+    });
+    await writeFile(filePath, "not valid json\n" + validLine + "\n");
+
+    const result = await parsePiFile({ filePath, startOffset: 0 });
+    expect(result.deltas).toHaveLength(1);
+    expect(result.deltas[0].model).toBe("claude-opus-4.6-1m");
+  });
+});

--- a/packages/cli/src/__tests__/pi-session.test.ts
+++ b/packages/cli/src/__tests__/pi-session.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { collectPiSessions } from "../parsers/pi-session.js";
+
+describe("collectPiSessions", () => {
+  let testDir: string;
+  let sessionDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `pew-pi-sess-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    sessionDir = join(testDir, "--test-project--");
+    await mkdir(sessionDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("extracts session snapshot from a pi JSONL file", async () => {
+    const filePath = join(sessionDir, "session.jsonl");
+    const lines = [
+      JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "abc-123",
+        timestamp: "2026-04-07T04:41:54.637Z",
+        cwd: "/test/project",
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "msg1",
+        parentId: null,
+        timestamp: "2026-04-07T04:42:25.000Z",
+        message: { role: "user", content: [{ type: "text", text: "Hello" }] },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "msg2",
+        parentId: "msg1",
+        timestamp: "2026-04-07T04:42:45.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4.6-1m",
+          content: [{ type: "text", text: "Hi!" }],
+          usage: { input: 3, output: 100, cacheRead: 0, cacheWrite: 1000 },
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "msg3",
+        parentId: "msg2",
+        timestamp: "2026-04-07T04:43:00.000Z",
+        message: { role: "toolResult", toolCallId: "t1", content: [] },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "msg4",
+        parentId: "msg3",
+        timestamp: "2026-04-07T04:44:00.000Z",
+        message: {
+          role: "assistant",
+          model: "gemini-3-pro",
+          content: [],
+          usage: { input: 5, output: 200 },
+        },
+      }),
+    ];
+    await writeFile(filePath, lines.join("\n") + "\n");
+
+    const snapshots = await collectPiSessions(filePath);
+    expect(snapshots).toHaveLength(1);
+
+    const snap = snapshots[0];
+    expect(snap.sessionKey).toBe("pi:abc-123");
+    expect(snap.source).toBe("pi");
+    expect(snap.kind).toBe("human");
+    expect(snap.startedAt).toBe("2026-04-07T04:41:54.637Z");
+    expect(snap.lastMessageAt).toBe("2026-04-07T04:44:00.000Z");
+    expect(snap.userMessages).toBe(1);
+    expect(snap.assistantMessages).toBe(2);
+    // user(1) + assistant(2) + toolResult(1) = 4
+    expect(snap.totalMessages).toBe(4);
+    expect(snap.model).toBe("gemini-3-pro"); // last model wins
+    expect(snap.durationSeconds).toBeGreaterThan(0);
+    // projectRef is a hash of the directory name
+    expect(snap.projectRef).toBeTruthy();
+    expect(typeof snap.projectRef).toBe("string");
+  });
+
+  it("returns empty for file without session header", async () => {
+    const filePath = join(sessionDir, "no-header.jsonl");
+    await writeFile(filePath, JSON.stringify({
+      type: "message",
+      id: "msg1",
+      timestamp: "2026-04-07T04:42:25.000Z",
+      message: { role: "user", content: [] },
+    }) + "\n");
+
+    const snapshots = await collectPiSessions(filePath);
+    expect(snapshots).toHaveLength(0);
+  });
+
+  it("returns empty for missing file", async () => {
+    const snapshots = await collectPiSessions(join(testDir, "nonexistent.jsonl"));
+    expect(snapshots).toHaveLength(0);
+  });
+
+  it("returns empty for empty file", async () => {
+    const filePath = join(sessionDir, "empty.jsonl");
+    await writeFile(filePath, "");
+    const snapshots = await collectPiSessions(filePath);
+    expect(snapshots).toHaveLength(0);
+  });
+
+  it("computes correct duration in seconds", async () => {
+    const filePath = join(sessionDir, "duration.jsonl");
+    const lines = [
+      JSON.stringify({
+        type: "session",
+        id: "dur-test",
+        timestamp: "2026-04-07T10:00:00.000Z",
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "msg1",
+        timestamp: "2026-04-07T10:05:30.000Z",
+        message: { role: "assistant", model: "test-model", content: [] },
+      }),
+    ];
+    await writeFile(filePath, lines.join("\n") + "\n");
+
+    const snapshots = await collectPiSessions(filePath);
+    expect(snapshots).toHaveLength(1);
+    // 10:05:30 - 10:00:00 = 330 seconds
+    expect(snapshots[0].durationSeconds).toBe(330);
+  });
+
+  it("handles malformed lines gracefully", async () => {
+    const filePath = join(sessionDir, "malformed.jsonl");
+    const lines = [
+      JSON.stringify({ type: "session", id: "mal-test", timestamp: "2026-04-07T10:00:00.000Z" }),
+      "not valid json",
+      JSON.stringify({
+        type: "message",
+        id: "msg1",
+        timestamp: "2026-04-07T10:01:00.000Z",
+        message: { role: "user", content: [] },
+      }),
+    ];
+    await writeFile(filePath, lines.join("\n") + "\n");
+
+    const snapshots = await collectPiSessions(filePath);
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].userMessages).toBe(1);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -184,6 +184,7 @@ const syncCommand = defineCommand({
       openCodeDbPath: paths.openCodeDbPath,
       openMessageDb,
       openclawDir: paths.openclawDir,
+      piSessionsDir: paths.piSessionsDir,
       vscodeCopilotDirs: paths.vscodeCopilotDirs,
       copilotCliLogsDir: paths.copilotCliLogsDir,
       onCorruptLine: handleCorruptLine,
@@ -207,6 +208,7 @@ const syncCommand = defineCommand({
       if (result.sources.gemini > 0) deltaParts.push(`Gemini: ${result.sources.gemini}`);
       if (result.sources.opencode > 0) deltaParts.push(`OpenCode: ${result.sources.opencode}`);
       if (result.sources.openclaw > 0) deltaParts.push(`OpenClaw: ${result.sources.openclaw}`);
+      if (result.sources.pi > 0) deltaParts.push(`Pi: ${result.sources.pi}`);
       if (result.sources.vscodeCopilot > 0) deltaParts.push(`VSCode Copilot: ${result.sources.vscodeCopilot}`);
       if (result.sources.copilotCli > 0) deltaParts.push(`Copilot CLI: ${result.sources.copilotCli}`);
       if (deltaParts.length > 0) {
@@ -222,6 +224,7 @@ const syncCommand = defineCommand({
     if (fs.gemini > 0) scanParts.push(`Gemini: ${fs.gemini}`);
     if (fs.opencode > 0) scanParts.push(`OpenCode: ${fs.opencode}`);
     if (fs.openclaw > 0) scanParts.push(`OpenClaw: ${fs.openclaw}`);
+    if (fs.pi > 0) scanParts.push(`Pi: ${fs.pi}`);
     if (fs.vscodeCopilot > 0) scanParts.push(`VSCode Copilot: ${fs.vscodeCopilot}`);
     if (fs.copilotCli > 0) scanParts.push(`Copilot CLI: ${fs.copilotCli}`);
     if (scanParts.length > 0) {
@@ -306,6 +309,7 @@ const statusCommand = defineCommand({
         geminiDir: paths.geminiDir,
         openCodeMessageDir: paths.openCodeMessageDir,
         openclawDir: paths.openclawDir,
+        piSessionsDir: paths.piSessionsDir,
         vscodeCopilotDirs: paths.vscodeCopilotDirs,
         copilotCliLogsDir: paths.copilotCliLogsDir,
       },
@@ -468,6 +472,7 @@ const notifyCommand = defineCommand({
       openMessageDb: openMessageDb2,
       openSessionDb: openSessionDb2,
       openclawDir: paths.openclawDir,
+      piSessionsDir: paths.piSessionsDir,
       vscodeCopilotDirs: paths.vscodeCopilotDirs,
       copilotCliLogsDir: paths.copilotCliLogsDir,
       version: CLI_VERSION,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -245,6 +245,7 @@ const syncCommand = defineCommand({
       openCodeDbPath: paths.openCodeDbPath,
       openSessionDb,
       openclawDir: paths.openclawDir,
+      piSessionsDir: paths.piSessionsDir,
       onCorruptLine: handleCorruptLine,
       onProgress(event) {
         logSessionSyncProgress(event);
@@ -265,6 +266,7 @@ const syncCommand = defineCommand({
       if (sessionResult.sources.gemini > 0) sessParts.push(`Gemini: ${sessionResult.sources.gemini}`);
       if (sessionResult.sources.opencode > 0) sessParts.push(`OpenCode: ${sessionResult.sources.opencode}`);
       if (sessionResult.sources.openclaw > 0) sessParts.push(`OpenClaw: ${sessionResult.sources.openclaw}`);
+      if (sessionResult.sources.pi > 0) sessParts.push(`Pi: ${sessionResult.sources.pi}`);
       if (sessParts.length > 0) {
         log.text(pc.dim(sessParts.join("  |  ")));
       }
@@ -278,6 +280,7 @@ const syncCommand = defineCommand({
     if (sfs.gemini > 0) sessScanParts.push(`Gemini: ${sfs.gemini}`);
     if (sfs.opencode > 0) sessScanParts.push(`OpenCode: ${sfs.opencode}`);
     if (sfs.openclaw > 0) sessScanParts.push(`OpenClaw: ${sfs.openclaw}`);
+    if (sfs.pi > 0) sessScanParts.push(`Pi: ${sfs.pi}`);
     if (sessScanParts.length > 0) {
       log.text(`Files scanned: ${pc.dim(sessScanParts.join("  |  "))}`);
     }

--- a/packages/cli/src/commands/notify.ts
+++ b/packages/cli/src/commands/notify.ts
@@ -43,6 +43,7 @@ export async function executeNotify(
           openCodeDbPath: opts.openCodeDbPath,
           openMessageDb: opts.openMessageDb,
           openclawDir: opts.openclawDir,
+          piSessionsDir: opts.piSessionsDir,
           vscodeCopilotDirs: opts.vscodeCopilotDirs,
           copilotCliLogsDir: opts.copilotCliLogsDir,
         });

--- a/packages/cli/src/commands/notify.ts
+++ b/packages/cli/src/commands/notify.ts
@@ -68,6 +68,7 @@ export async function executeNotify(
           openCodeDbPath: opts.openCodeDbPath,
           openSessionDb: opts.openSessionDb,
           openclawDir: opts.openclawDir,
+          piSessionsDir: opts.piSessionsDir,
         });
         cycle.sessionSync = {
           totalSnapshots: sessionResult.totalSnapshots,

--- a/packages/cli/src/commands/session-sync.ts
+++ b/packages/cli/src/commands/session-sync.ts
@@ -134,6 +134,7 @@ function sourceKey(source: Source): keyof SessionSyncResult["sources"] | null {
     case "opencode": return "opencode";
     case "openclaw": return "openclaw";
     case "codex": return "codex";
+    case "pi": return null;
     case "vscode-copilot": return null;
     case "copilot-cli": return null;
   }

--- a/packages/cli/src/commands/session-sync.ts
+++ b/packages/cli/src/commands/session-sync.ts
@@ -56,6 +56,8 @@ export interface SessionSyncOptions {
   } | null;
   /** Override: OpenClaw data directory (~/.openclaw) */
   openclawDir?: string;
+  /** Override: Pi session directory (~/.pi/agent/sessions) */
+  piSessionsDir?: string;
   /** Progress callback */
   onProgress?: (event: SessionProgressEvent) => void;
   /** Callback invoked when a corrupted JSONL line is found in the queue */
@@ -81,6 +83,7 @@ export interface SessionSyncResult {
     gemini: number;
     opencode: number;
     openclaw: number;
+    pi: number;
   };
   /** Total files/directories scanned per source */
   filesScanned: {
@@ -89,6 +92,7 @@ export interface SessionSyncResult {
     gemini: number;
     opencode: number;
     openclaw: number;
+    pi: number;
   };
 }
 
@@ -134,7 +138,7 @@ function sourceKey(source: Source): keyof SessionSyncResult["sources"] | null {
     case "opencode": return "opencode";
     case "openclaw": return "openclaw";
     case "codex": return "codex";
-    case "pi": return null;
+    case "pi": return "pi";
     case "vscode-copilot": return null;
     case "copilot-cli": return null;
   }
@@ -158,8 +162,8 @@ export async function executeSessionSync(
   const cursors = await cursorStore.load();
 
   const allSnapshots: SessionSnapshot[] = [];
-  const sourceCounts = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0 };
-  const filesScanned = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0 };
+  const sourceCounts = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, pi: 0 };
+  const filesScanned = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, pi: 0 };
 
   // Build driver sets from options
   const { fileDrivers, dbDrivers } = createSessionDrivers(opts);
@@ -172,6 +176,7 @@ export async function executeSessionSync(
     openCodeMessageDir: opts.openCodeMessageDir,
     openCodeDbPath: opts.openCodeDbPath,
     openclawDir: opts.openclawDir,
+    piSessionsDir: opts.piSessionsDir,
   };
 
   // ---------- Phase 1: File-based drivers (generic loop) ----------

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -10,6 +10,7 @@ export interface SourceDirs {
   geminiDir: string;
   openCodeMessageDir: string;
   openclawDir: string;
+  piSessionsDir: string;
   vscodeCopilotDirs: string[];
   copilotCliLogsDir: string;
 }
@@ -40,6 +41,7 @@ function classifySource(filePath: string, dirs: SourceDirs): string {
   if (filePath.startsWith(dirs.geminiDir)) return "gemini-cli";
   if (filePath.startsWith(dirs.openCodeMessageDir)) return "opencode";
   if (filePath.startsWith(dirs.openclawDir)) return "openclaw";
+  if (filePath.startsWith(dirs.piSessionsDir)) return "pi";
   for (const dir of dirs.vscodeCopilotDirs) {
     if (filePath.startsWith(dir)) return "vscode-copilot";
   }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -38,6 +38,8 @@ export interface SyncOptions {
   openMessageDb?: (dbPath: string) => { queryMessages: QueryMessagesFn; close: () => void } | null;
   /** Override: OpenClaw data directory (~/.openclaw) */
   openclawDir?: string;
+  /** Override: Pi session directory (~/.pi/agent/sessions) */
+  piSessionsDir?: string;
   /** Override: VSCode Copilot base directories (stable + insiders) */
   vscodeCopilotDirs?: string[];
   /** Override: GitHub Copilot CLI logs directory (~/.copilot/logs) */
@@ -67,6 +69,7 @@ export interface SyncResult {
     gemini: number;
     opencode: number;
     openclaw: number;
+    pi: number;
     vscodeCopilot: number;
     copilotCli: number;
   };
@@ -77,6 +80,7 @@ export interface SyncResult {
     gemini: number;
     opencode: number;
     openclaw: number;
+    pi: number;
     vscodeCopilot: number;
     copilotCli: number;
   };
@@ -97,6 +101,7 @@ function sourceKey(source: Source): keyof SyncResult["sources"] {
     case "gemini-cli": return "gemini";
     case "opencode": return "opencode";
     case "openclaw": return "openclaw";
+    case "pi": return "pi";
     case "codex": return "codex";
     case "vscode-copilot": return "vscodeCopilot";
     case "copilot-cli": return "copilotCli";
@@ -181,8 +186,8 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
   let replayDetected = false;
 
   const allDeltas: ParsedDelta[] = [];
-  const sourceCounts = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0, copilotCli: 0 };
-  const filesScanned = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0, copilotCli: 0 };
+  const sourceCounts = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, pi: 0, vscodeCopilot: 0, copilotCli: 0 };
+  const filesScanned = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, pi: 0, vscodeCopilot: 0, copilotCli: 0 };
 
   // Collect all discovered file paths (across all drivers) for knownFilePaths
   const discoveredFiles = new Set<string>();
@@ -201,6 +206,7 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
     openCodeMessageDir: opts.openCodeMessageDir,
     openCodeDbPath: opts.openCodeDbPath,
     openclawDir: opts.openclawDir,
+    piSessionsDir: opts.piSessionsDir,
     vscodeCopilotDirs: opts.vscodeCopilotDirs,
     copilotCliLogsDir: opts.copilotCliLogsDir,
   };

--- a/packages/cli/src/discovery/sources.ts
+++ b/packages/cli/src/discovery/sources.ts
@@ -145,6 +145,16 @@ export async function discoverOpenClawFiles(
 }
 
 /**
+ * Discover pi session JSONL files.
+ * Path pattern: ~/.pi/agent/sessions/<encoded-cwd>/*.jsonl
+ */
+export async function discoverPiFiles(
+  piSessionsDir: string,
+): Promise<string[]> {
+  return collectFiles(piSessionsDir, (name) => name.endsWith(".jsonl"));
+}
+
+/**
  * Discover Codex CLI rollout files.
  * Path pattern: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
  */

--- a/packages/cli/src/drivers/registry.ts
+++ b/packages/cli/src/drivers/registry.ts
@@ -37,6 +37,7 @@ import { geminiSessionDriver } from "./session/gemini-session-driver.js";
 import { openCodeJsonSessionDriver } from "./session/opencode-json-session-driver.js";
 import { openClawSessionDriver } from "./session/openclaw-session-driver.js";
 import { codexSessionDriver } from "./session/codex-session-driver.js";
+import { piSessionDriver } from "./session/pi-session-driver.js";
 import {
   createOpenCodeSqliteSessionDriver,
   type OpenCodeSqliteSessionDriverOpts,
@@ -129,6 +130,7 @@ export interface SessionDriverRegistryOpts {
   openCodeMessageDir?: string;
   openclawDir?: string;
   codexSessionsDir?: string;
+  piSessionsDir?: string;
   openCodeDbPath?: string;
   openSessionDb?: OpenCodeSqliteSessionDriverOpts["openSessionDb"];
 }
@@ -161,6 +163,9 @@ export function createSessionDrivers(opts: SessionDriverRegistryOpts): SessionDr
   }
   if (opts.openclawDir) {
     fileDrivers.push(openClawSessionDriver);
+  }
+  if (opts.piSessionsDir) {
+    fileDrivers.push(piSessionDriver);
   }
   if (opts.openCodeDbPath && opts.openSessionDb) {
     dbDrivers.push(

--- a/packages/cli/src/drivers/registry.ts
+++ b/packages/cli/src/drivers/registry.ts
@@ -25,6 +25,7 @@ import { openClawTokenDriver } from "./token/openclaw-token-driver.js";
 import { codexTokenDriver } from "./token/codex-token-driver.js";
 import { vscodeCopilotTokenDriver } from "./token/vscode-copilot-token-driver.js";
 import { copilotCliTokenDriver } from "./token/copilot-cli-token-driver.js";
+import { piTokenDriver } from "./token/pi-token-driver.js";
 import {
   createOpenCodeSqliteTokenDriver,
   type OpenCodeSqliteTokenDriverOpts,
@@ -57,6 +58,7 @@ export interface TokenDriverRegistryOpts {
   openCodeMessageDir?: string;
   openclawDir?: string;
   codexSessionsDir?: string;
+  piSessionsDir?: string;
   vscodeCopilotDirs?: string[];
   copilotCliLogsDir?: string;
   openCodeDbPath?: string;
@@ -92,6 +94,9 @@ export function createTokenDrivers(opts: TokenDriverRegistryOpts): TokenDriverSe
   }
   if (opts.openclawDir) {
     fileDrivers.push(openClawTokenDriver);
+  }
+  if (opts.piSessionsDir) {
+    fileDrivers.push(piTokenDriver);
   }
   if (opts.vscodeCopilotDirs && opts.vscodeCopilotDirs.length > 0) {
     fileDrivers.push(vscodeCopilotTokenDriver);

--- a/packages/cli/src/drivers/session/pi-session-driver.ts
+++ b/packages/cli/src/drivers/session/pi-session-driver.ts
@@ -1,0 +1,34 @@
+/**
+ * Pi file session driver.
+ *
+ * Strategy: Full-scan on change (mtime + size dual-check).
+ * Parser: collectPiSessions(filePath)
+ */
+
+import type { SessionFileCursor } from "@pew/core";
+import { discoverPiFiles } from "../../discovery/sources.js";
+import { collectPiSessions } from "../../parsers/pi-session.js";
+import type { FileSessionDriver, DiscoverOpts, FileFingerprint } from "../types.js";
+
+export const piSessionDriver: FileSessionDriver<SessionFileCursor> = {
+  kind: "file",
+  source: "pi",
+
+  async discover(opts: DiscoverOpts): Promise<string[]> {
+    if (!opts.piSessionsDir) return [];
+    return discoverPiFiles(opts.piSessionsDir);
+  },
+
+  shouldSkip(cursor: SessionFileCursor | undefined, fingerprint: FileFingerprint): boolean {
+    if (!cursor) return false;
+    return cursor.mtimeMs === fingerprint.mtimeMs && cursor.size === fingerprint.size;
+  },
+
+  async parse(filePath: string) {
+    return collectPiSessions(filePath);
+  },
+
+  buildCursor(fingerprint: FileFingerprint): SessionFileCursor {
+    return { mtimeMs: fingerprint.mtimeMs, size: fingerprint.size };
+  },
+};

--- a/packages/cli/src/drivers/token/pi-token-driver.ts
+++ b/packages/cli/src/drivers/token/pi-token-driver.ts
@@ -1,0 +1,67 @@
+/**
+ * Pi file token driver.
+ *
+ * Strategy: Byte-offset JSONL streaming (same as Claude Code).
+ * Skip gate: fileUnchanged() (inode + mtimeMs + size).
+ * Parser: parsePiFile({ filePath, startOffset })
+ */
+
+import type { ByteOffsetCursor } from "@pew/core";
+import { discoverPiFiles } from "../../discovery/sources.js";
+import { parsePiFile } from "../../parsers/pi.js";
+import { fileUnchanged } from "../../utils/file-changed.js";
+import type {
+  FileTokenDriver,
+  DiscoverOpts,
+  SyncContext,
+  FileFingerprint,
+  ResumeState,
+  TokenParseResult,
+  ByteOffsetResumeState,
+} from "../types.js";
+
+/** Extended parse result carrying endOffset for cursor construction */
+interface PiParseResult extends TokenParseResult {
+  endOffset: number;
+}
+
+export const piTokenDriver: FileTokenDriver<ByteOffsetCursor> = {
+  kind: "file",
+  source: "pi",
+
+  async discover(opts: DiscoverOpts, _ctx: SyncContext): Promise<string[]> {
+    if (!opts.piSessionsDir) return [];
+    return discoverPiFiles(opts.piSessionsDir);
+  },
+
+  shouldSkip(cursor: ByteOffsetCursor | undefined, fingerprint: FileFingerprint): boolean {
+    return fileUnchanged(cursor, fingerprint);
+  },
+
+  resumeState(cursor: ByteOffsetCursor | undefined, fingerprint: FileFingerprint): ByteOffsetResumeState {
+    const startOffset =
+      cursor && cursor.inode === fingerprint.inode ? (cursor.offset ?? 0) : 0;
+    return { kind: "byte-offset", startOffset };
+  },
+
+  async parse(filePath: string, resume: ResumeState): Promise<PiParseResult> {
+    const r = resume as ByteOffsetResumeState;
+    const result = await parsePiFile({ filePath, startOffset: r.startOffset });
+    return { deltas: result.deltas, endOffset: result.endOffset };
+  },
+
+  buildCursor(
+    fingerprint: FileFingerprint,
+    result: TokenParseResult,
+    _prev?: ByteOffsetCursor,
+  ): ByteOffsetCursor {
+    const r = result as PiParseResult;
+    return {
+      inode: fingerprint.inode,
+      mtimeMs: fingerprint.mtimeMs,
+      size: fingerprint.size,
+      offset: r.endOffset,
+      updatedAt: new Date().toISOString(),
+    };
+  },
+};

--- a/packages/cli/src/drivers/types.ts
+++ b/packages/cli/src/drivers/types.ts
@@ -69,6 +69,7 @@ export interface DiscoverOpts {
   openCodeMessageDir?: string;
   openCodeDbPath?: string;
   openclawDir?: string;
+  piSessionsDir?: string;
   vscodeCopilotDirs?: string[];
   copilotCliLogsDir?: string;
 }

--- a/packages/cli/src/notifier/paths.ts
+++ b/packages/cli/src/notifier/paths.ts
@@ -18,6 +18,7 @@ export interface NotifierPaths {
   codexHome: string;
   codexConfigPath: string;
   codexNotifyOriginalPath: string;
+  piExtensionPath: string;
 }
 
 function normalizeEnvPath(value: string | undefined): string | null {
@@ -63,5 +64,6 @@ export function resolveNotifierPaths(
     codexHome,
     codexConfigPath: join(codexHome, "config.toml"),
     codexNotifyOriginalPath: join(stateDir, "codex_notify_original.json"),
+    piExtensionPath: join(home, ".pi", "agent", "extensions", "pew-sync.ts"),
   };
 }

--- a/packages/cli/src/notifier/pi-hook.ts
+++ b/packages/cli/src/notifier/pi-hook.ts
@@ -1,0 +1,143 @@
+/**
+ * Pi notification hook.
+ *
+ * Pi supports extensions via ~/.pi/agent/extensions/*.ts files.
+ * We install a simple extension that fires `pew notify --source=pi`
+ * on `session_shutdown` events.
+ *
+ * Unlike Claude/Gemini (which modify settings.json), pi hooks are
+ * standalone TypeScript files — install = write file, uninstall = delete file.
+ */
+
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { NotifierOperationResult, NotifierStatus } from "@pew/core";
+
+interface PiHookFs {
+  readFile: (path: string, encoding: BufferEncoding) => Promise<string>;
+  writeFile: (path: string, data: string, encoding: BufferEncoding) => Promise<unknown>;
+  mkdir: (path: string, options: { recursive: boolean }) => Promise<unknown>;
+  unlink: (path: string) => Promise<unknown>;
+}
+
+export interface PiHookOptions {
+  /** Path to the pew extension file, e.g. ~/.pi/agent/extensions/pew-sync.ts */
+  extensionPath: string;
+  /** Path to notify.cjs handler */
+  notifyPath: string;
+  fs?: PiHookFs;
+}
+
+const SOURCE = "pi";
+const MARKER = "PEW_PI_HOOK";
+
+function buildExtensionContent(notifyPath: string): string {
+  return `// ${MARKER} — managed by pew, do not edit
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { spawn } from "node:child_process";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_shutdown", async () => {
+    try {
+      const child = spawn("node", [${JSON.stringify(notifyPath)}, "--source=pi"], {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+    } catch {}
+  });
+}
+`;
+}
+
+export async function installPiHook(
+  opts: PiHookOptions,
+): Promise<NotifierOperationResult> {
+  const fs = opts.fs ?? { readFile, writeFile, mkdir, unlink };
+  const content = buildExtensionContent(opts.notifyPath);
+
+  // Check if already installed
+  let existing: string | null = null;
+  try {
+    existing = await fs.readFile(opts.extensionPath, "utf8");
+  } catch {
+    // File doesn't exist — will install
+  }
+
+  if (existing && existing.includes(MARKER)) {
+    // Already installed — check if content matches
+    if (existing === content) {
+      return {
+        source: SOURCE,
+        action: "install",
+        changed: false,
+        detail: "Pi hook already installed",
+      };
+    }
+    // Update to latest version
+  }
+
+  await fs.mkdir(dirname(opts.extensionPath), { recursive: true });
+  await fs.writeFile(opts.extensionPath, content, "utf8");
+
+  return {
+    source: SOURCE,
+    action: "install",
+    changed: true,
+    detail: "Pi hook installed",
+  };
+}
+
+export async function uninstallPiHook(
+  opts: PiHookOptions,
+): Promise<NotifierOperationResult> {
+  const fs = opts.fs ?? { readFile, writeFile, mkdir, unlink };
+
+  let existing: string | null = null;
+  try {
+    existing = await fs.readFile(opts.extensionPath, "utf8");
+  } catch {
+    return {
+      source: SOURCE,
+      action: "skip",
+      changed: false,
+      detail: "Pi hook not found",
+    };
+  }
+
+  if (!existing || !existing.includes(MARKER)) {
+    return {
+      source: SOURCE,
+      action: "skip",
+      changed: false,
+      detail: "Pi hook not managed by pew",
+    };
+  }
+
+  try {
+    await fs.unlink(opts.extensionPath);
+  } catch {
+    // Ignore removal errors
+  }
+
+  return {
+    source: SOURCE,
+    action: "uninstall",
+    changed: true,
+    detail: "Pi hook removed",
+  };
+}
+
+export async function getPiHookStatus(
+  opts: PiHookOptions,
+): Promise<NotifierStatus> {
+  const fs = opts.fs ?? { readFile, writeFile, mkdir, unlink };
+
+  try {
+    const content = await fs.readFile(opts.extensionPath, "utf8");
+    if (content.includes(MARKER)) return "installed";
+    return "not-installed";
+  } catch {
+    return "not-installed";
+  }
+}

--- a/packages/cli/src/notifier/registry.ts
+++ b/packages/cli/src/notifier/registry.ts
@@ -17,6 +17,11 @@ import {
   uninstallCodexNotifier,
   getCodexNotifierStatus,
 } from "./codex-notifier.js";
+import {
+  installPiHook,
+  uninstallPiHook,
+  getPiHookStatus,
+} from "./pi-hook.js";
 
 interface RegistryDeps {
   spawn?: (cmd: string, args: string[], opts?: object) => { status: number | null };
@@ -132,6 +137,25 @@ const DRIVERS: NotifierDriver[] = [
         pluginBaseDir: paths.openclawPluginDir,
         notifyPath: paths.notifyPath,
         openclawConfigPath: paths.openclawConfigPath,
+      }),
+  },
+  {
+    source: "pi",
+    displayName: "Pi",
+    install: (paths) =>
+      installPiHook({
+        extensionPath: paths.piExtensionPath,
+        notifyPath: paths.notifyPath,
+      }),
+    uninstall: (paths) =>
+      uninstallPiHook({
+        extensionPath: paths.piExtensionPath,
+        notifyPath: paths.notifyPath,
+      }),
+    status: (paths) =>
+      getPiHookStatus({
+        extensionPath: paths.piExtensionPath,
+        notifyPath: paths.notifyPath,
       }),
   },
 ];

--- a/packages/cli/src/parsers/pi-session.ts
+++ b/packages/cli/src/parsers/pi-session.ts
@@ -1,0 +1,140 @@
+/**
+ * Pi session collector.
+ *
+ * Full-scans a pi JSONL session file and extracts session-level metadata.
+ * Pi stores one session per file with a tree structure (id/parentId).
+ *
+ * Session header (first line): { type: "session", id, timestamp, cwd }
+ * Messages: { type: "message", message: { role, model, usage, ... } }
+ */
+
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { basename, dirname } from "node:path";
+import { createInterface } from "node:readline";
+import type { SessionSnapshot, Source } from "@pew/core";
+import { hashProjectRef } from "../utils/hash-project-ref.js";
+
+/**
+ * Extract project reference from a pi session file path.
+ *
+ * Pi stores sessions under ~/.pi/agent/sessions/<encoded-cwd>/<file>.jsonl
+ * The <encoded-cwd> directory name is a double-dash-delimited path encoding,
+ * e.g. "--Users-shaozliu-projects-3p-pew--".
+ *
+ * We hash the directory name through hashProjectRef() for privacy.
+ */
+function extractProjectRef(filePath: string): string | null {
+  const dirName = basename(dirname(filePath));
+  if (!dirName) return null;
+  return hashProjectRef(dirName);
+}
+
+/**
+ * Collect session snapshots from a pi JSONL session file.
+ *
+ * Each pi file is one session. We scan all lines to collect:
+ * - Session ID from the header line (type: "session")
+ * - Message counts (user, assistant, total)
+ * - Timestamps for wall-clock duration
+ * - Last seen model
+ */
+export async function collectPiSessions(
+  filePath: string,
+): Promise<SessionSnapshot[]> {
+  const st = await stat(filePath).catch(() => null);
+  if (!st || !st.isFile() || st.size === 0) return [];
+
+  let sessionId: string | null = null;
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let totalMessages = 0;
+  let minTimestamp: string | null = null;
+  let maxTimestamp: string | null = null;
+  let lastModel: string | null = null;
+
+  const stream = createReadStream(filePath, { encoding: "utf8" });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl) {
+      if (!line) continue;
+
+      let obj: Record<string, unknown>;
+      try {
+        obj = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      const type = typeof obj.type === "string" ? obj.type : null;
+      const timestamp =
+        typeof obj.timestamp === "string" ? obj.timestamp : null;
+
+      // Extract session ID from header
+      if (type === "session") {
+        sessionId = typeof obj.id === "string" ? obj.id : null;
+      }
+
+      // Track timestamps from all entries
+      if (timestamp) {
+        if (!minTimestamp || timestamp < minTimestamp) {
+          minTimestamp = timestamp;
+        }
+        if (!maxTimestamp || timestamp > maxTimestamp) {
+          maxTimestamp = timestamp;
+        }
+      }
+
+      // Count messages and track model
+      if (type === "message") {
+        const msg = obj.message as Record<string, unknown> | undefined;
+        if (!msg) continue;
+
+        const role = typeof msg.role === "string" ? msg.role : null;
+        totalMessages++;
+
+        if (role === "user") {
+          userMessages++;
+        } else if (role === "assistant") {
+          assistantMessages++;
+
+          // Track model from assistant messages
+          const model =
+            typeof msg.model === "string" ? msg.model.trim() : null;
+          if (model) lastModel = model;
+        }
+        // toolResult messages count toward totalMessages but not user/assistant
+      }
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+
+  if (!sessionId || !minTimestamp) return [];
+
+  const startedAt = minTimestamp;
+  const lastMessageAt = maxTimestamp ?? minTimestamp;
+  const durationMs =
+    new Date(lastMessageAt).getTime() - new Date(startedAt).getTime();
+
+  const projectRef = extractProjectRef(filePath);
+
+  return [
+    {
+      sessionKey: `pi:${sessionId}`,
+      source: "pi" as Source,
+      kind: "human",
+      startedAt,
+      lastMessageAt,
+      durationSeconds: Math.max(0, Math.floor(durationMs / 1000)),
+      userMessages,
+      assistantMessages,
+      totalMessages,
+      projectRef,
+      model: lastModel,
+      snapshotAt: new Date().toISOString(),
+    },
+  ];
+}

--- a/packages/cli/src/parsers/pi.ts
+++ b/packages/cli/src/parsers/pi.ts
@@ -1,0 +1,116 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import type { Source, TokenDelta } from "@pew/core";
+import type { ParsedDelta } from "./claude.js";
+import { isAllZero, toNonNegInt } from "../utils/token-delta.js";
+
+/** Result of parsing a single pi JSONL session file */
+export interface PiFileResult {
+  deltas: ParsedDelta[];
+  endOffset: number;
+}
+
+/**
+ * Normalize pi's usage object to our TokenDelta format.
+ *
+ * Pi session JSONL assistant messages carry per-turn absolute usage:
+ *   input + cacheWrite  → inputTokens
+ *   cacheRead           → cachedInputTokens
+ *   output              → outputTokens
+ *   (hardcoded 0)       → reasoningOutputTokens
+ *
+ * Note: pi's `input` field counts non-cached input tokens and `cacheWrite`
+ * counts tokens written to the cache (analogous to Anthropic's
+ * `cache_creation_input_tokens`). Together they represent total input.
+ */
+export function normalizePiUsage(u: Record<string, unknown>): TokenDelta {
+  return {
+    inputTokens:
+      toNonNegInt(u?.input) + toNonNegInt(u?.cacheWrite),
+    cachedInputTokens: toNonNegInt(u?.cacheRead),
+    outputTokens: toNonNegInt(u?.output),
+    reasoningOutputTokens: 0,
+  };
+}
+
+/**
+ * Parse a pi session JSONL file incrementally from a byte offset.
+ *
+ * Pi stores one JSONL file per session under ~/.pi/agent/sessions/<encoded-cwd>/.
+ * Each line is a JSON object with a `type` field. Assistant messages have
+ * `type: "message"` with `message.role === "assistant"` and a `message.usage`
+ * object containing per-turn absolute token counts.
+ *
+ * Strategy: Byte-offset streaming (same as Claude Code).
+ * Each usage block is standalone — no running-total diffing needed.
+ */
+export async function parsePiFile(opts: {
+  filePath: string;
+  startOffset: number;
+}): Promise<PiFileResult> {
+  const { filePath, startOffset } = opts;
+  const deltas: ParsedDelta[] = [];
+
+  const st = await stat(filePath).catch(() => null);
+  if (!st || !st.isFile()) return { deltas, endOffset: startOffset };
+
+  const endOffset = st.size;
+  if (startOffset >= endOffset) return { deltas, endOffset };
+
+  const stream = createReadStream(filePath, {
+    encoding: "utf8",
+    start: startOffset,
+  });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl) {
+      // Fast-path: skip lines that can't contain usage data
+      if (!line || !line.includes('"usage"')) continue;
+
+      let obj: Record<string, unknown>;
+      try {
+        obj = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      // Only process assistant messages
+      if (obj?.type !== "message") continue;
+
+      const msg = obj.message as Record<string, unknown> | undefined;
+      if (!msg || msg.role !== "assistant") continue;
+
+      // Extract usage
+      const usage = msg.usage as Record<string, unknown> | undefined;
+      if (!usage || typeof usage !== "object") continue;
+
+      // Extract model
+      const model =
+        typeof msg.model === "string" ? msg.model.trim() : null;
+      if (!model) continue;
+
+      // Extract timestamp from the outer JSONL entry
+      const timestamp =
+        typeof obj.timestamp === "string" ? obj.timestamp : null;
+      if (!timestamp) continue;
+
+      // Normalize and filter zero deltas
+      const delta = normalizePiUsage(usage);
+      if (isAllZero(delta)) continue;
+
+      deltas.push({
+        source: "pi" as Source,
+        model,
+        timestamp,
+        tokens: delta,
+      });
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+
+  return { deltas, endOffset };
+}

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -70,6 +70,8 @@ export function resolveDefaultPaths(home = homedir()) {
     openCodeDbPath: join(home, ".local", "share", "opencode", "opencode.db"),
     /** OpenClaw data: ~/.openclaw */
     openclawDir: join(home, ".openclaw"),
+    /** Pi session data: ~/.pi/agent/sessions */
+    piSessionsDir: join(home, ".pi", "agent", "sessions"),
     /** VSCode Copilot base dirs (stable + insiders, platform-aware) */
     vscodeCopilotDirs: resolveVscodeCopilotDirs(home),
     /** GitHub Copilot CLI logs: ~/.copilot/logs */

--- a/packages/core/src/__tests__/constants.test.ts
+++ b/packages/core/src/__tests__/constants.test.ts
@@ -12,13 +12,14 @@ import {
 } from "../constants.js";
 
 describe("SOURCES", () => {
-  it("should contain exactly 7 supported AI tools", () => {
-    expect(SOURCES).toHaveLength(7);
+  it("should contain exactly 8 supported AI tools", () => {
+    expect(SOURCES).toHaveLength(8);
     expect(SOURCES).toContain("claude-code");
     expect(SOURCES).toContain("codex");
     expect(SOURCES).toContain("gemini-cli");
     expect(SOURCES).toContain("opencode");
     expect(SOURCES).toContain("openclaw");
+    expect(SOURCES).toContain("pi");
     expect(SOURCES).toContain("vscode-copilot");
     expect(SOURCES).toContain("copilot-cli");
   });
@@ -32,6 +33,7 @@ describe("SOURCES", () => {
       "gemini-cli",
       "opencode",
       "openclaw",
+      "pi",
       "vscode-copilot",
       "copilot-cli",
     ]);

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -37,10 +37,11 @@ describe("Source type", () => {
       "gemini-cli",
       "opencode",
       "openclaw",
+      "pi",
       "vscode-copilot",
       "copilot-cli",
     ];
-    expect(sources).toHaveLength(7);
+    expect(sources).toHaveLength(8);
   });
 
   it("should reject unsupported tools at type level", () => {

--- a/packages/core/src/__tests__/validation.test.ts
+++ b/packages/core/src/__tests__/validation.test.ts
@@ -25,12 +25,13 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("isValidSource", () => {
-  it("should accept all 7 sources", () => {
+  it("should accept all 8 sources", () => {
     expect(isValidSource("claude-code")).toBe(true);
     expect(isValidSource("codex")).toBe(true);
     expect(isValidSource("gemini-cli")).toBe(true);
     expect(isValidSource("opencode")).toBe(true);
     expect(isValidSource("openclaw")).toBe(true);
+    expect(isValidSource("pi")).toBe(true);
     expect(isValidSource("vscode-copilot")).toBe(true);
     expect(isValidSource("copilot-cli")).toBe(true);
   });
@@ -234,7 +235,7 @@ describe("validateIngestRecord", () => {
   });
 
   it("should accept all 7 sources", () => {
-    for (const source of ["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "vscode-copilot", "copilot-cli"]) {
+    for (const source of ["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "pi", "vscode-copilot", "copilot-cli"]) {
       const rec = { ...validTokenRecord(), source };
       expect(validateIngestRecord(rec, 0).valid).toBe(true);
     }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -19,6 +19,7 @@ export const SOURCES: readonly Source[] = Object.freeze([
   "gemini-cli",
   "opencode",
   "openclaw",
+  "pi",
   "vscode-copilot",
   "copilot-cli",
 ] as const);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,13 +10,14 @@
 // Source: Supported AI coding tools
 // ---------------------------------------------------------------------------
 
-/** The 7 supported AI coding tools */
+/** The 8 supported AI coding tools */
 export type Source =
   | "claude-code"
   | "codex"
   | "gemini-cli"
   | "opencode"
   | "openclaw"
+  | "pi"
   | "vscode-copilot"
   | "copilot-cli";
 

--- a/packages/web/src/__tests__/usage-helpers.test.ts
+++ b/packages/web/src/__tests__/usage-helpers.test.ts
@@ -204,6 +204,7 @@ describe("sourceLabel", () => {
     expect(sourceLabel("gemini-cli")).toBe("Gemini CLI");
     expect(sourceLabel("opencode")).toBe("OpenCode");
     expect(sourceLabel("openclaw")).toBe("OpenClaw");
+    expect(sourceLabel("pi")).toBe("Pi");
     expect(sourceLabel("vscode-copilot")).toBe("VS Code Copilot");
     expect(sourceLabel("copilot-cli")).toBe("GitHub Copilot CLI");
   });

--- a/packages/web/src/app/api/projects/[id]/route.ts
+++ b/packages/web/src/app/api/projects/[id]/route.ts
@@ -17,6 +17,7 @@ const VALID_SOURCES = new Set([
   "gemini-cli",
   "opencode",
   "openclaw",
+  "pi",
   "vscode-copilot",
   "copilot-cli",
 ]);

--- a/packages/web/src/app/api/projects/route.ts
+++ b/packages/web/src/app/api/projects/route.ts
@@ -17,6 +17,7 @@ const VALID_SOURCES = new Set([
   "gemini-cli",
   "opencode",
   "openclaw",
+  "pi",
   "vscode-copilot",
   "copilot-cli",
 ]);

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -24,6 +24,7 @@ const VALID_SOURCES = new Set([
   "gemini-cli",
   "opencode",
   "openclaw",
+  "pi",
   "vscode-copilot",
   "copilot-cli",
 ]);

--- a/packages/web/src/app/api/usage/route.ts
+++ b/packages/web/src/app/api/usage/route.ts
@@ -24,6 +24,7 @@ const VALID_SOURCES = new Set([
   "gemini-cli",
   "opencode",
   "openclaw",
+  "pi",
   "vscode-copilot",
   "copilot-cli",
 ]);

--- a/packages/web/src/app/api/users/[slug]/route.ts
+++ b/packages/web/src/app/api/users/[slug]/route.ts
@@ -31,6 +31,7 @@ const VALID_SOURCES = new Set([
   "gemini-cli",
   "opencode",
   "openclaw",
+  "pi",
   "vscode-copilot",
   "copilot-cli",
 ]);

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -155,6 +155,7 @@ const SOURCE_LABELS: Record<string, string> = {
   "gemini-cli": "Gemini CLI",
   opencode: "OpenCode",
   openclaw: "OpenClaw",
+  pi: "Pi",
   "vscode-copilot": "VS Code Copilot",
   "copilot-cli": "GitHub Copilot CLI",
 };

--- a/packages/web/src/lib/palette.ts
+++ b/packages/web/src/lib/palette.ts
@@ -67,12 +67,13 @@ const AGENT_COLOR_MAP: Record<string, ChartColor> = {
   "gemini-cli":    { color: chart.pink,    token: "chart-3" },
   "codex":         { color: chart.coral,   token: "chart-4" },
   "openclaw":      { color: chart.orange,  token: "chart-5" },
+  "pi":            { color: chart.acid,    token: "chart-8" },
   "vscode-copilot":{ color: chart.gold,    token: "chart-6" },
   "copilot-cli":   { color: chart.lime,    token: "chart-7" },
 };
 
 /** Default color for unknown agents. */
-const AGENT_FALLBACK: ChartColor = { color: chart.acid, token: "chart-8" };
+const AGENT_FALLBACK: ChartColor = { color: chart.teal, token: "chart-9" };
 
 /**
  * Get a stable color for an agent (source slug).

--- a/packages/web/src/lib/pricing.ts
+++ b/packages/web/src/lib/pricing.ts
@@ -100,6 +100,7 @@ export const DEFAULT_SOURCE_DEFAULTS: Record<string, ModelPricing> = {
   "gemini-cli": { input: 1.25, output: 10, cached: 0.31 },
   opencode: { input: 2, output: 8, cached: 0.5 },
   openclaw: { input: 2, output: 8, cached: 0.5 },
+  pi: { input: 3, output: 15, cached: 0.3 },
   "vscode-copilot": { input: 3, output: 15, cached: 0.3 },
   "copilot-cli": { input: 3, output: 15, cached: 0.3 },
 };


### PR DESCRIPTION
## Summary

Add support for [pi](https://github.com/badic/pi-mono) coding agent as the 8th tracked AI tool.

### What is pi?

Pi is a terminal-based AI coding agent (like Claude Code) that stores session logs as JSONL files under `~/.pi/agent/sessions/<encoded-cwd>/`. Each assistant message contains per-turn absolute token usage with fields: `input`, `output`, `cacheRead`, `cacheWrite`.

### Token mapping

| Pi field | → pew TokenDelta |
|----------|------------------|
| `input + cacheWrite` | `inputTokens` |
| `cacheRead` | `cachedInputTokens` |
| `output` | `outputTokens` |
| (hardcoded 0) | `reasoningOutputTokens` |

### Changes (27 files)

**`packages/core`**
- Add `"pi"` to `Source` type union and `SOURCES` array
- Update validation + constants + types tests (7→8 sources)

**`packages/cli`**
- `parsers/pi.ts` — JSONL parser with `normalizePiUsage()`
- `drivers/token/pi-token-driver.ts` — byte-offset file driver (same strategy as Claude Code)
- `discovery/sources.ts` — `discoverPiFiles()` for `~/.pi/agent/sessions/`
- `drivers/registry.ts` — register pi token driver
- `commands/sync.ts`, `notify.ts`, `status.ts`, `cli.ts` — wire `piSessionsDir` throughout
- `utils/paths.ts` — add `piSessionsDir` default path
- `__tests__/pi-parser.test.ts` — 12 test cases (normalization, incremental resume, edge cases)
- `__tests__/drivers/registry.test.ts` — updated for 8 drivers

**`packages/web`**
- Source label: `"Pi"`
- Chart color: `chart.acid` (chart-8)
- Pricing fallback: same as Claude Code ($3/$15/$0.3)
- All 5 API route source arrays updated

### Not included (future work)
- Pi session driver (session statistics)
- Pi notification hook (`pew init` auto-sync)

### Tests

```
✓ packages/core/src/__tests__/types.test.ts (27 tests)
✓ packages/core/src/__tests__/constants.test.ts (9 tests)
✓ packages/core/src/__tests__/validation.test.ts (68 tests)
✓ packages/cli/src/__tests__/pi-parser.test.ts (12 tests)
✓ packages/cli/src/__tests__/drivers/registry.test.ts (25 tests)
Test Files  5 passed (5)
     Tests  141 passed (141)
```
