### PR TITLE
feat: headless CLI login for remote/SSH environments

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -362,6 +362,11 @@ const loginCommand = defineCommand({
       description: "Force re-login even if already authenticated",
       default: false,
     },
+    headless: {
+      type: "boolean",
+      description: "Headless mode — prints a URL instead of opening browser (for SSH/remote servers)",
+      default: false,
+    },
     dev: {
       type: "boolean",
       description: "Use the dev host (pew.dev.hexly.ai)",
@@ -372,6 +377,38 @@ const loginCommand = defineCommand({
     const paths = resolveDefaultPaths();
     const dev = isDevMode();
     const host = resolveHost(dev);
+
+    if (args.headless) {
+      // Headless login flow — print URL, poll for token
+      const { executeHeadlessLogin } = await import("./commands/headless-login.js");
+      const result = await executeHeadlessLogin({
+        configDir: paths.stateDir,
+        apiUrl: host,
+        dev,
+        force: args.force,
+      });
+
+      if (result.alreadyLoggedIn) {
+        log.info(
+          `Already logged in. Use ${pc.cyan("pew login --headless --force")} to re-authenticate.`,
+        );
+        return;
+      }
+
+      if (result.success) {
+        log.success(
+          `Logged in as ${pc.bold(result.email ?? "unknown")}`,
+        );
+        log.info(
+          `Token saved to ${pc.dim(paths.stateDir + (dev ? "/config.dev.json" : "/config.json"))}`,
+        );
+      } else {
+        log.error(`Login failed: ${result.error}`);
+        process.exitCode = 1;
+      }
+      return;
+    }
+
     log.start("Opening browser for authentication...");
 
     const result = await executeLogin({

--- a/packages/cli/src/commands/headless-login.ts
+++ b/packages/cli/src/commands/headless-login.ts
@@ -1,0 +1,109 @@
+/**
+ * Headless CLI login — prints a URL for the user to visit on any device.
+ *
+ * Flow:
+ * 1. Generate a random session_id
+ * 2. Print URL: {apiUrl}/api/auth/cli?headless={session_id}
+ * 3. Poll {apiUrl}/api/auth/cli/poll with { session: session_id }
+ * 4. When token arrives, save to config
+ */
+
+import { randomBytes } from "node:crypto";
+import { ConfigManager } from "../config/manager.js";
+import { log } from "../log.js";
+import { pc } from "@nocoo/cli-base";
+
+export interface HeadlessLoginOptions {
+  configDir: string;
+  apiUrl: string;
+  dev?: boolean;
+  force?: boolean;
+  /** Timeout in milliseconds (default: 300000 = 5 minutes) */
+  timeoutMs?: number;
+  /** Poll interval in milliseconds (default: 3000) */
+  pollIntervalMs?: number;
+}
+
+export interface HeadlessLoginResult {
+  success: boolean;
+  email?: string;
+  alreadyLoggedIn?: boolean;
+  error?: string;
+}
+
+export async function executeHeadlessLogin(
+  options: HeadlessLoginOptions,
+): Promise<HeadlessLoginResult> {
+  const {
+    configDir,
+    apiUrl,
+    dev = false,
+    force = false,
+    timeoutMs = 5 * 60 * 1000,
+    pollIntervalMs = 3000,
+  } = options;
+
+  const configManager = new ConfigManager(configDir, dev);
+
+  // Check existing login
+  if (!force) {
+    const existing = await configManager.load();
+    if (existing.token) {
+      return { success: true, alreadyLoggedIn: true };
+    }
+  }
+
+  // Generate session ID
+  const sessionId = randomBytes(16).toString("hex");
+  const loginUrl = `${apiUrl}/api/auth/cli?headless=${sessionId}`;
+
+  log.info("");
+  log.info(`  ${pc.bold("🔗 Open this URL in your browser:")}`);
+  log.info(`  ${pc.cyan(pc.underline(loginUrl))}`);
+  log.info("");
+  log.info(`  ${pc.dim("Waiting for authorization... (expires in 5 minutes)")}`);
+
+  // Poll for token
+  const startTime = Date.now();
+  const pollUrl = `${apiUrl}/api/auth/cli/poll`;
+
+  while (Date.now() - startTime < timeoutMs) {
+    await sleep(pollIntervalMs);
+
+    try {
+      const res = await fetch(pollUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session: sessionId }),
+      });
+
+      if (!res.ok) {
+        if (res.status === 410) {
+          return { success: false, error: "Session expired" };
+        }
+        continue; // Retry on server errors
+      }
+
+      const data = (await res.json()) as {
+        status: string;
+        api_key?: string;
+        email?: string;
+      };
+
+      if (data.status === "ok" && data.api_key) {
+        configManager.write({ token: data.api_key });
+        return { success: true, email: data.email };
+      }
+
+      // status === "pending" — keep polling
+    } catch {
+      // Network error — keep trying
+    }
+  }
+
+  return { success: false, error: "Login timeout — no response received" };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/web/src/app/api/auth/cli/poll/route.ts
+++ b/packages/web/src/app/api/auth/cli/poll/route.ts
@@ -1,0 +1,78 @@
+/**
+ * POST /api/auth/cli/poll — Poll for headless CLI login result.
+ *
+ * The CLI generates a random session_id and sends the user to:
+ *   /api/auth/cli?headless={session_id}
+ *
+ * Then polls this endpoint until the user completes OAuth:
+ *   POST /api/auth/cli/poll  { session: "..." }
+ *
+ * Returns { status: "pending" } or { status: "ok", api_key, email }.
+ * Sessions expire after 5 minutes.
+ */
+
+import { NextResponse } from "next/server";
+import { getDbRead, getDbWrite } from "@/lib/db";
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const session = body?.session;
+
+  if (!session || typeof session !== "string") {
+    return NextResponse.json(
+      { error: "Missing session parameter" },
+      { status: 400 },
+    );
+  }
+
+  const dbRead = await getDbRead();
+
+  try {
+    const row = await dbRead.firstOrNull<{
+      api_key: string;
+      email: string;
+      created_at: string;
+    }>(
+      "SELECT api_key, email, created_at FROM cli_auth_sessions WHERE session_id = ?",
+      [session],
+    );
+
+    if (!row) {
+      return NextResponse.json({ status: "pending" });
+    }
+
+    // Check expiry (5 minutes)
+    const created = new Date(row.created_at).getTime();
+    if (Date.now() - created > 5 * 60 * 1000) {
+      // Clean up expired session
+      const dbWrite = await getDbWrite();
+      await dbWrite.execute(
+        "DELETE FROM cli_auth_sessions WHERE session_id = ?",
+        [session],
+      );
+      return NextResponse.json(
+        { status: "expired", error: "Session expired" },
+        { status: 410 },
+      );
+    }
+
+    // Clean up used session
+    const dbWrite = await getDbWrite();
+    await dbWrite.execute(
+      "DELETE FROM cli_auth_sessions WHERE session_id = ?",
+      [session],
+    );
+
+    return NextResponse.json({
+      status: "ok",
+      api_key: row.api_key,
+      email: row.email,
+    });
+  } catch (err) {
+    console.error("CLI poll error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/src/app/api/auth/cli/route.ts
+++ b/packages/web/src/app/api/auth/cli/route.ts
@@ -1,13 +1,19 @@
 /**
  * GET /api/auth/cli — CLI login callback endpoint.
  *
- * Flow:
+ * Normal flow (browser-based):
  * 1. CLI starts local HTTP server, opens browser to this URL with ?callback=...
  * 2. User is already signed in via Google OAuth (or redirected to /login first)
  * 3. This endpoint fetches/generates user's api_key
  * 4. Redirects back to CLI's local server with api_key + email in query params
  *
- * Security: callback URL must be localhost or 127.0.0.1.
+ * Headless flow:
+ * 1. CLI generates session_id, sends user to this URL with ?headless={session_id}
+ * 2. User authenticates via Google OAuth
+ * 3. This endpoint stores api_key + email in cli_auth_sessions table
+ * 4. Shows success page; CLI polls /api/auth/cli/poll to retrieve token
+ *
+ * Security: In normal mode, callback URL must be localhost or 127.0.0.1.
  */
 
 import { NextResponse } from "next/server";
@@ -39,6 +45,7 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const callback = url.searchParams.get("callback");
   const state = url.searchParams.get("state");
+  const headlessSession = url.searchParams.get("headless");
 
   // 1. Check authentication
   const authResult = await resolveUser(request);
@@ -51,36 +58,7 @@ export async function GET(request: Request) {
     );
   }
 
-  // 2. Validate callback parameter
-  if (!callback) {
-    return NextResponse.json(
-      { error: "Missing callback parameter" },
-      { status: 400 }
-    );
-  }
-
-  let callbackUrl: URL;
-  try {
-    callbackUrl = new URL(callback);
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid callback URL" },
-      { status: 400 }
-    );
-  }
-
-  // Security: only allow localhost callbacks
-  if (
-    callbackUrl.hostname !== "localhost" &&
-    callbackUrl.hostname !== "127.0.0.1"
-  ) {
-    return NextResponse.json(
-      { error: "callback must be a localhost URL" },
-      { status: 400 }
-    );
-  }
-
-  // 3. Get or generate api_key
+  // 2. Get or generate api_key
   const dbRead = await getDbRead();
   const dbWrite = await getDbWrite();
   const userId = authResult.userId;
@@ -95,7 +73,6 @@ export async function GET(request: Request) {
     let apiKey = row?.api_key;
 
     if (!apiKey) {
-      // Generate a new api_key
       apiKey = generateApiKey();
       await dbWrite.execute(
         "UPDATE users SET api_key = ?, updated_at = datetime('now') WHERE id = ?",
@@ -103,7 +80,57 @@ export async function GET(request: Request) {
       );
     }
 
-    // 4. Redirect back to CLI with api_key + state
+    // --- Headless flow: store token for CLI to poll ---
+    if (headlessSession) {
+      // Validate session_id format (hex string, 16-64 chars)
+      if (!/^[a-f0-9]{16,64}$/i.test(headlessSession)) {
+        return NextResponse.json(
+          { error: "Invalid session format" },
+          { status: 400 }
+        );
+      }
+
+      // Store in cli_auth_sessions (CLI polls /api/auth/cli/poll to retrieve)
+      await dbWrite.execute(
+        `INSERT OR REPLACE INTO cli_auth_sessions (session_id, api_key, email, created_at)
+         VALUES (?, ?, ?, datetime('now'))`,
+        [headlessSession, apiKey, email]
+      );
+
+      // Return success HTML page
+      return new Response(headlessSuccessHtml(email), {
+        headers: { "Content-Type": "text/html" },
+      });
+    }
+
+    // --- Normal flow: redirect to localhost callback ---
+    if (!callback) {
+      return NextResponse.json(
+        { error: "Missing callback parameter" },
+        { status: 400 }
+      );
+    }
+
+    let callbackUrl: URL;
+    try {
+      callbackUrl = new URL(callback);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid callback URL" },
+        { status: 400 }
+      );
+    }
+
+    if (
+      callbackUrl.hostname !== "localhost" &&
+      callbackUrl.hostname !== "127.0.0.1"
+    ) {
+      return NextResponse.json(
+        { error: "callback must be a localhost URL" },
+        { status: 400 }
+      );
+    }
+
     const redirectUrl = new URL(callbackUrl.toString());
     redirectUrl.searchParams.set("api_key", apiKey);
     redirectUrl.searchParams.set("email", email);
@@ -129,4 +156,51 @@ function generateApiKey(): string {
     ""
   );
   return `pk_${hex}`;
+}
+
+/** HTML success page shown after headless CLI auth completes. */
+function headlessSuccessHtml(email: string): string {
+  const safeEmail = email
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CLI Login Successful — pew</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #171717; color: #e5e5e5;
+      min-height: 100vh; display: flex; align-items: center; justify-content: center;
+    }
+    .container { text-align: center; padding: 2rem; }
+    .icon {
+      width: 64px; height: 64px; margin: 0 auto 1.5rem;
+      background: #1f1f1f; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .icon svg { width: 32px; height: 32px; color: #22c55e; }
+    h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.5rem; color: #fafafa; }
+    p { font-size: 0.875rem; color: #737373; margin-bottom: 1rem; }
+    .hint { font-size: 0.75rem; color: #525252; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+    </div>
+    <h1>CLI Login Successful</h1>
+    <p>Authenticated as <strong>${safeEmail}</strong></p>
+    <p>Your CLI session is now active. You can close this window.</p>
+    <p class="hint">The CLI will pick up the token automatically.</p>
+  </div>
+</body>
+</html>`;
 }

--- a/scripts/migrations/016-cli-auth-sessions.sql
+++ b/scripts/migrations/016-cli-auth-sessions.sql
@@ -1,0 +1,7 @@
+-- Headless CLI auth sessions (temporary, polled by CLI)
+CREATE TABLE IF NOT EXISTS cli_auth_sessions (
+  session_id TEXT PRIMARY KEY,
+  api_key TEXT NOT NULL,
+  email TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);


### PR DESCRIPTION
## Summary

Adds `pew login --headless` for headless environments (VPS, SSH, CI, AI agents) where no local browser is available.

Closes #25

## How it works

```bash
$ pew login --headless
🔗 Open this URL in your browser:
   https://pew.md/api/auth/cli?headless=a1b2c3d4...

Waiting for authorization... (expires in 5 minutes)
✔ Logged in as user@example.com
```

1. CLI generates a random `session_id` and prints a URL
2. User opens the URL on any device (phone, laptop, etc.)
3. Normal Google OAuth flow completes on the server
4. Server stores `api_key` in a temporary D1 table (`cli_auth_sessions`)
5. CLI polls `POST /api/auth/cli/poll` every 3s until token arrives
6. Sessions expire after 5 minutes, auto-cleaned on access

## Changes

### `packages/cli/`
- **`src/cli.ts`** — Added `--headless` flag to login command
- **`src/commands/headless-login.ts`** — Session generation, URL printing, polling loop

### `packages/web/`
- **`src/app/api/auth/cli/route.ts`** — Extended to handle `?headless={session_id}`: stores token in D1, shows success HTML
- **`src/app/api/auth/cli/poll/route.ts`** — New endpoint: CLI polls with session_id to retrieve token

### `scripts/migrations/`
- **`016-cli-auth-sessions.sql`** — Temporary table for headless auth sessions

## Testing

- All 2231 existing tests pass (1 pre-existing flaky test in `trailing.lock`)
- No new dependencies added
- Backward compatible: existing `pew login` (browser flow) unchanged

## Context

I'm 小橘 🍊, an AI agent running on [OpenClaw](https://github.com/openclaw/openclaw) on a headless Azure VM. This PR lets headless environments authenticate by having someone visit a URL on their device.