### PR TITLE
feat: add Showcase system (ProductHunt-style project sharing)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "packages/cli": {
       "name": "@nocoo/pew",
-      "version": "2.2.2",
+      "version": "2.2.6",
       "bin": {
         "pew": "dist/bin.js",
       },
@@ -35,20 +35,21 @@
     },
     "packages/core": {
       "name": "@pew/core",
-      "version": "2.2.2",
+      "version": "2.2.6",
       "devDependencies": {
         "@types/node": "^22.0.0",
       },
     },
     "packages/web": {
       "name": "@pew/web",
-      "version": "2.2.2",
+      "version": "2.2.6",
       "dependencies": {
         "@auth/core": "^0.34.3",
         "@aws-sdk/client-s3": "^3.1007.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
+        "nanoid": "^5.1.7",
         "next": "^16.1.0",
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "^1.4.3",
@@ -72,7 +73,7 @@
     },
     "packages/worker": {
       "name": "@pew/worker",
-      "version": "2.2.2",
+      "version": "2.2.6",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250307.0",
         "@pew/core": "workspace:*",
@@ -82,7 +83,7 @@
     },
     "packages/worker-read": {
       "name": "@pew/worker-read",
-      "version": "2.2.2",
+      "version": "2.2.6",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250307.0",
         "typescript": "^5.9.0",
@@ -1158,7 +1159,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -1444,6 +1445,8 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
+    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1481,6 +1484,8 @@
     "next-auth/@auth/core/preact": ["preact@10.24.3", "", {}, "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="],
 
     "next-auth/@auth/core/preact-render-to-string": ["preact-render-to-string@6.5.11", "", { "peerDependencies": { "preact": ">=10" } }, "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw=="],
+
+    "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/docs/34-showcase-system.md
+++ b/docs/34-showcase-system.md
@@ -1,0 +1,559 @@
+# 34 — Showcase System
+
+> ProductHunt-style project showcase: users submit GitHub projects, others can upvote.
+
+## Overview
+
+Showcase is a community feature where pew users can submit their GitHub projects for others to discover and upvote. Think of it as a mini ProductHunt integrated into pew's leaderboard ecosystem.
+
+### User Stories
+
+1. **Submitter**: As a pew user, I want to showcase my GitHub project so others can discover it
+2. **Viewer**: As anyone (logged in or not), I want to browse showcased projects publicly
+3. **Voter**: As a logged-in user, I want to upvote showcases I like
+4. **Manager**: As a submitter, I want to manage my showcases (toggle visibility, delete)
+
+### Access Model
+
+Consistent with existing leaderboard:
+
+| Action | Auth Required |
+|--------|---------------|
+| Browse showcases | No (public) |
+| View single showcase | No (public, if `is_public=1`) |
+| Submit showcase | Yes |
+| Upvote/un-upvote | Yes |
+| Edit own showcase | Yes (owner only) |
+| Delete own showcase | Yes (owner only) |
+| View hidden showcase | Yes (owner/admin only) |
+
+## Database Schema
+
+### New Tables
+
+```sql
+-- scripts/migrations/016-showcases.sql
+
+-- ============================================================
+-- Showcases (user-submitted GitHub projects)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS showcases (
+  id              TEXT PRIMARY KEY,                         -- nanoid
+  user_id         TEXT NOT NULL REFERENCES users(id),       -- submitter
+  repo_key        TEXT NOT NULL,                            -- normalized: "owner/repo" lowercase
+  github_url      TEXT NOT NULL,                            -- display URL (original casing)
+  title           TEXT NOT NULL,                            -- fetched from GitHub, immutable
+  description     TEXT,                                     -- fetched from GitHub, immutable
+  tagline         TEXT,                                     -- user-provided recommendation (editable)
+  og_image_url    TEXT,                                     -- GitHub OG image URL
+  is_public       INTEGER NOT NULL DEFAULT 1,               -- 1=visible, 0=hidden
+  upvote_count    INTEGER NOT NULL DEFAULT 0,               -- denormalized, updated atomically
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(repo_key)                                          -- one submission per repo (normalized)
+);
+
+CREATE INDEX IF NOT EXISTS idx_showcases_user ON showcases(user_id);
+CREATE INDEX IF NOT EXISTS idx_showcases_public_sort ON showcases(is_public, upvote_count DESC, created_at DESC);
+
+-- ============================================================
+-- Showcase Upvotes (one per user per showcase)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS showcase_upvotes (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  showcase_id  TEXT NOT NULL REFERENCES showcases(id) ON DELETE CASCADE,
+  user_id      TEXT NOT NULL REFERENCES users(id),
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(showcase_id, user_id)                              -- one upvote per user
+);
+
+CREATE INDEX IF NOT EXISTS idx_showcase_upvotes_showcase ON showcase_upvotes(showcase_id);
+CREATE INDEX IF NOT EXISTS idx_showcase_upvotes_user ON showcase_upvotes(user_id);
+```
+
+### Schema Notes
+
+- **`repo_key`** (not `github_url`) has UNIQUE constraint — normalized `owner/repo` lowercase
+- **`title` / `description`** are immutable after creation (fetched from GitHub)
+- **`tagline`** is user-editable recommendation text (optional, max 280 chars)
+- **`upvote_count`** updated atomically with upvote insert/delete (same SQL statement batch)
+- **`og_image_url`** constructed from repo_key, with fallback placeholder
+
+### URL Normalization
+
+```typescript
+// Input: any valid GitHub repo URL
+// Output: { repoKey: "owner/repo", displayUrl: "https://github.com/owner/repo" }
+
+function normalizeGitHubUrl(url: string): { repoKey: string; displayUrl: string } | null {
+  const match = url.match(/^https?:\/\/github\.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)\/?$/);
+  if (!match) return null;
+  const [, owner, repo] = match;
+  const repoKey = `${owner}/${repo}`.toLowerCase();
+  const displayUrl = `https://github.com/${owner}/${repo}`;
+  return { repoKey, displayUrl };
+}
+```
+
+## API Routes
+
+### `/api/showcases` — List & Create
+
+```
+GET  /api/showcases              — list public showcases (no auth required)
+POST /api/showcases              — submit new showcase (auth required)
+```
+
+#### GET Query Parameters
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `mine` | `"1"` | If set, return current user's showcases (auth required) |
+| `limit` | number | Max results (default 20, max 100) |
+| `cursor` | string | Pagination cursor (showcase ID) |
+
+#### GET Response
+
+```typescript
+interface ShowcaseListResponse {
+  showcases: Array<{
+    id: string;
+    repo_key: string;
+    github_url: string;
+    title: string;
+    description: string | null;
+    tagline: string | null;
+    og_image_url: string | null;
+    upvote_count: number;
+    created_at: string;
+    user: {
+      id: string;
+      name: string | null;
+      nickname: string | null;
+      image: string | null;
+      slug: string | null;
+    };
+    has_upvoted: boolean | null;  // null if not logged in
+  }>;
+  next_cursor: string | null;
+}
+```
+
+**Behavior:**
+- Without `mine`: returns `is_public=1` showcases only
+- With `mine=1`: returns all showcases owned by current user (requires auth)
+- `has_upvoted` is `null` for unauthenticated requests
+
+#### POST Request
+
+```typescript
+interface CreateShowcaseRequest {
+  github_url: string;   // must be https://github.com/{owner}/{repo} format
+  tagline?: string;     // optional recommendation (max 280 chars)
+}
+```
+
+**Response codes:**
+- `201` — Created successfully
+- `400` — Invalid URL format
+- `401` — Not authenticated
+- `404` — Repository not found on GitHub (doesn't exist or private)
+- `409` — Repository already showcased (by anyone)
+- `422` — GitHub API error (rate limit, timeout, etc.)
+
+### `/api/showcases/preview` — Preview Before Submit
+
+```
+POST /api/showcases/preview      — fetch GitHub metadata for preview (auth required)
+```
+
+#### Request
+
+```typescript
+interface PreviewRequest {
+  github_url: string;
+}
+```
+
+#### Response
+
+```typescript
+interface PreviewResponse {
+  repo_key: string;
+  github_url: string;        // normalized display URL
+  title: string;
+  description: string | null;
+  og_image_url: string;
+  already_exists: boolean;   // true if repo_key already in showcases
+}
+```
+
+**Response codes:**
+- `200` — Preview fetched successfully
+- `400` — Invalid URL format
+- `401` — Not authenticated
+- `404` — Repository not found on GitHub
+- `422` — GitHub API error
+
+### `/api/showcases/[id]` — Read, Update, Delete
+
+```
+GET    /api/showcases/[id]       — get single showcase
+PATCH  /api/showcases/[id]       — update showcase (owner only)
+DELETE /api/showcases/[id]       — delete showcase (owner only)
+```
+
+#### GET Access Control
+
+- `is_public=1`: Anyone can view
+- `is_public=0`: Only owner or admin can view; others get `404`
+
+#### PATCH Request
+
+```typescript
+interface UpdateShowcaseRequest {
+  tagline?: string | null;   // user recommendation (null to clear)
+  is_public?: boolean;       // visibility toggle
+}
+```
+
+**Note:** `title` and `description` are NOT editable — they come from GitHub. If user wants to change them, they should update their GitHub repo.
+
+### `/api/showcases/[id]/upvote` — Toggle Upvote
+
+```
+POST /api/showcases/[id]/upvote  — toggle upvote (auth required)
+```
+
+#### Response
+
+```typescript
+interface UpvoteResponse {
+  upvoted: boolean;       // new state after toggle
+  upvote_count: number;   // updated count
+}
+```
+
+#### Atomic Update Strategy
+
+To maintain consistency between `showcase_upvotes` and `showcases.upvote_count`, use a single batch write:
+
+```typescript
+// Toggle ON (add upvote)
+await dbWrite.batch([
+  {
+    sql: `INSERT INTO showcase_upvotes (showcase_id, user_id) VALUES (?, ?)`,
+    params: [showcaseId, userId],
+  },
+  {
+    sql: `UPDATE showcases SET upvote_count = upvote_count + 1, updated_at = datetime('now') WHERE id = ?`,
+    params: [showcaseId],
+  },
+]);
+
+// Toggle OFF (remove upvote)
+await dbWrite.batch([
+  {
+    sql: `DELETE FROM showcase_upvotes WHERE showcase_id = ? AND user_id = ?`,
+    params: [showcaseId, userId],
+  },
+  {
+    sql: `UPDATE showcases SET upvote_count = upvote_count - 1, updated_at = datetime('now') WHERE id = ?`,
+    params: [showcaseId],
+  },
+]);
+```
+
+**Note:** D1 batch is NOT transactional, but both statements affect independent rows. Worst case on partial failure: count drifts by 1. Acceptable for v1; can add periodic reconciliation job later if needed.
+
+## GitHub Integration
+
+### URL Validation
+
+Valid formats:
+- `https://github.com/owner/repo`
+- `https://github.com/owner/repo/`
+- `http://github.com/owner/repo` (normalized to https)
+
+Invalid formats (rejected with 400):
+- `https://github.com/owner` (user/org page)
+- `https://github.com/owner/repo/blob/main/file.ts` (file path)
+- `https://github.com/owner/repo/tree/main` (branch/path)
+- `https://github.com/owner/repo/issues/123` (issue page)
+- `https://gitlab.com/...` (wrong host)
+
+Regex:
+```typescript
+const GITHUB_REPO_PATTERN = /^https?:\/\/github\.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)\/?$/;
+```
+
+### Metadata Fetching
+
+```typescript
+async function fetchGitHubMetadata(owner: string, repo: string): Promise<GitHubMetadata> {
+  const url = `https://api.github.com/repos/${owner}/${repo}`;
+  const res = await fetch(url, {
+    headers: { "User-Agent": "pew-showcase/1.0" },
+    signal: AbortSignal.timeout(5000),  // 5s timeout
+  });
+
+  if (res.status === 404) {
+    throw new GitHubError("NOT_FOUND", "Repository not found or is private");
+  }
+  if (res.status === 403) {
+    const remaining = res.headers.get("X-RateLimit-Remaining");
+    if (remaining === "0") {
+      throw new GitHubError("RATE_LIMITED", "GitHub API rate limit exceeded");
+    }
+    throw new GitHubError("FORBIDDEN", "Access denied");
+  }
+  if (!res.ok) {
+    throw new GitHubError("UPSTREAM_ERROR", `GitHub API error: ${res.status}`);
+  }
+
+  const data = await res.json();
+  return {
+    title: data.name || `${owner}/${repo}`,
+    description: data.description || null,
+  };
+}
+```
+
+### Error Mapping
+
+| GitHub Status | API Response | Message |
+|---------------|--------------|---------|
+| 404 | 404 | "Repository not found or is private" |
+| 403 (rate limit) | 422 | "GitHub API rate limit exceeded. Try again later." |
+| 403 (other) | 422 | "Cannot access repository" |
+| 5xx / timeout | 422 | "GitHub is temporarily unavailable. Try again later." |
+| Network error | 422 | "Failed to connect to GitHub" |
+
+### OG Image Strategy
+
+GitHub OG images are served from `opengraph.githubassets.com`. Strategy:
+
+1. **Construction**: `https://opengraph.githubassets.com/1/${owner}/${repo}`
+2. **Storage**: Store URL in `og_image_url` column
+3. **Rendering**: Use plain `<img>` tag (not `next/image`) with `onError` fallback
+4. **Fallback**: On error, show gradient placeholder with repo name
+
+```tsx
+function ShowcaseImage({ url, repoKey }: { url: string | null; repoKey: string }) {
+  const [error, setError] = useState(false);
+
+  if (!url || error) {
+    return (
+      <div className="bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
+        <span className="text-muted-foreground text-sm">{repoKey}</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={url}
+      alt={repoKey}
+      className="object-cover"
+      onError={() => setError(true)}
+    />
+  );
+}
+```
+
+## Frontend Pages
+
+### Leaderboard → Showcases (`/leaderboard/showcases`)
+
+New tab in LeaderboardNav alongside Individual, Seasons, Achievements.
+
+**Layout:**
+- "Add Showcase" button (top right, shown only if logged in)
+- ProductHunt-style card list
+- Each card shows:
+  - OG image (left, 16:9 aspect, 200px width)
+  - Title + tagline (center, tagline in muted color)
+  - GitHub description (truncated, small text)
+  - Submitter avatar + name (bottom)
+  - Upvote button + count (right side)
+
+**Sorting:** `upvote_count DESC, created_at DESC, id DESC`
+
+**Upvote interaction:**
+- Not logged in: clicking upvote shows "Login to upvote" tooltip or redirects
+- Logged in: optimistic toggle with rollback on error
+
+**Add Showcase (from leaderboard):**
+- Click "Add Showcase" → opens modal
+- Same modal as settings page
+
+### Settings → Showcases (`/settings/showcases`)
+
+Dashboard page for managing user's showcases.
+
+**Layout:**
+- Header: "My Showcases" with "Add Showcase" button
+- List of user's showcases (cards):
+  - OG image thumbnail (80px)
+  - Title, tagline (truncated)
+  - Upvote count
+  - Public/Hidden badge
+  - Actions: Edit (tagline + visibility), Delete
+
+**Add Showcase Modal:**
+1. Input: GitHub URL
+2. Click "Preview" or auto-fetch on blur
+3. Show preview: image, title, description (read-only)
+4. Input: Tagline (optional, "Why do you recommend this?")
+5. Submit button
+
+**Edit Showcase Modal:**
+- Tagline input (editable)
+- Public/Hidden toggle
+- "Title and description come from GitHub" note with link to edit on GitHub
+- Save/Cancel buttons
+
+## Component Hierarchy
+
+```
+packages/web/src/
+├── app/
+│   ├── (dashboard)/
+│   │   └── settings/
+│   │       └── showcases/
+│   │           └── page.tsx           # Settings → Showcases management
+│   ├── leaderboard/
+│   │   └── showcases/
+│   │       └── page.tsx               # Leaderboard → Showcases tab
+│   └── api/
+│       └── showcases/
+│           ├── route.ts               # GET list, POST create
+│           ├── preview/
+│           │   └── route.ts           # POST preview
+│           └── [id]/
+│               ├── route.ts           # GET, PATCH, DELETE
+│               └── upvote/
+│                   └── route.ts       # POST toggle
+├── components/
+│   └── showcase/
+│       ├── showcase-card.tsx          # Card for list display
+│       ├── showcase-image.tsx         # Image with fallback
+│       ├── showcase-form-modal.tsx    # Add/Edit modal
+│       └── upvote-button.tsx          # Upvote button with count
+└── hooks/
+    └── use-showcases.ts               # SWR hook for showcase list
+```
+
+## Implementation Plan
+
+### Phase 1: Database & Core API
+
+1. **Migration** — `scripts/migrations/016-showcases.sql`
+2. **Lib: GitHub helpers** — `lib/github.ts` (URL normalization, metadata fetch)
+3. **API: Preview** — `api/showcases/preview/route.ts`
+4. **API: List & Create** — `api/showcases/route.ts`
+5. **API: Single CRUD** — `api/showcases/[id]/route.ts`
+6. **API: Upvote** — `api/showcases/[id]/upvote/route.ts`
+
+### Phase 2: Frontend
+
+7. **LeaderboardNav update** — add Showcases tab
+8. **Showcase components** — card, image, upvote button
+9. **Leaderboard showcases page** — `/leaderboard/showcases`
+10. **Settings showcases page** — `/settings/showcases`
+11. **Form modal** — add/edit with preview
+
+## Atomic Commits
+
+```
+feat(db): add showcases and upvotes tables (016-showcases.sql)
+feat(lib): add GitHub URL normalization and metadata fetch helpers
+feat(api): implement showcase preview endpoint
+feat(api): implement showcases list and create endpoints
+feat(api): implement showcase single CRUD operations
+feat(api): implement showcase upvote toggle
+feat(web): add Showcases tab to LeaderboardNav
+feat(web): add showcase card and image components
+feat(web): add leaderboard showcases page
+feat(web): add settings showcases management page
+feat(web): add showcase form modal with preview
+docs: update README index with 34-showcase-system
+```
+
+## Testing Strategy
+
+### L1 — Unit Tests
+
+- `normalizeGitHubUrl()` — valid/invalid URLs, case normalization
+- `parseGitHubError()` — error type mapping
+- Upvote state derivation
+
+### L2 — Integration Tests (API E2E)
+
+**Auth & Access:**
+- Guest can GET `/api/showcases` (list public)
+- Guest cannot POST `/api/showcases` (401)
+- Guest cannot POST upvote (401)
+- Guest gets 404 for hidden showcase
+- Owner can GET own hidden showcase
+- Non-owner gets 404 for others' hidden showcase
+
+**CRUD:**
+- Create with valid URL → 201 + metadata populated
+- Create with invalid URL format → 400
+- Create with non-existent repo → 404
+- Create duplicate repo_key → 409
+- Update tagline → 200
+- Update title (should fail or be ignored)
+- Delete own → 200
+- Delete others' → 403
+
+**Upvote:**
+- Toggle on → upvoted=true, count+1
+- Toggle off → upvoted=false, count-1
+- Idempotent: double toggle = original state
+
+**Edge cases:**
+- GitHub API rate limit simulation → 422
+- GitHub timeout → 422
+- Empty description from GitHub → null stored
+
+### L3 — E2E (Playwright)
+
+- Guest browses showcases, sees upvote buttons but cannot click
+- Login → upvote → count updates
+- Add showcase from leaderboard page
+- Add showcase from settings page
+- Edit tagline, toggle visibility
+- Delete showcase with confirmation
+
+## Security Considerations
+
+1. **Public browse, auth for actions** — consistent with leaderboard
+2. **Ownership enforcement** — PATCH/DELETE check `user_id`
+3. **Hidden showcase isolation** — non-owner/admin returns 404, not 403
+4. **URL validation** — strict regex prevents injection
+5. **Tagline sanitization** — escape HTML on display
+6. **No GitHub token** — public API only, accept rate limits
+
+## Decisions
+
+1. **Title/description immutable** — Source of truth is GitHub. Encourages users to maintain good GitHub READMEs.
+
+2. **Tagline field** — Allows personal recommendation without duplicating GitHub metadata. Max 280 chars (tweet-length).
+
+3. **repo_key for dedup** — Lowercase `owner/repo` ensures same repo can't be submitted twice regardless of URL casing.
+
+4. **No featured/pinned in v1** — Keep it simple. Can add `featured_at` column later.
+
+5. **Plain img, not next/image** — Avoids remote domain whitelist complexity. Fallback handles failures gracefully.
+
+6. **20 items per page** — Reasonable for ProductHunt-style browsing. Cursor pagination for performance.
+
+---
+
+**Status:** design-complete
+**Author:** Claude
+**Date:** 2026-04-07

--- a/docs/34-showcase-system.md
+++ b/docs/34-showcase-system.md
@@ -12,6 +12,7 @@ Showcase is a community feature where pew users can submit their GitHub projects
 2. **Viewer**: As anyone (logged in or not), I want to browse showcased projects publicly
 3. **Voter**: As a logged-in user, I want to upvote showcases I like
 4. **Manager**: As a submitter, I want to manage my showcases (toggle visibility, delete)
+5. **Admin**: As an admin, I want to moderate all showcases (view hidden, edit, delete)
 
 ### Access Model
 
@@ -27,6 +28,9 @@ Consistent with existing leaderboard:
 | Delete own showcase | Yes (owner only) |
 | View hidden showcase | Yes (owner/admin only) |
 | Refresh from GitHub | Yes (owner only) |
+| **Admin: list all showcases** | Yes (admin only) |
+| **Admin: edit any showcase** | Yes (admin only) |
+| **Admin: delete any showcase** | Yes (admin only) |
 
 ## Database Schema
 
@@ -49,7 +53,6 @@ CREATE TABLE IF NOT EXISTS showcases (
   tagline         TEXT,                                     -- user-provided recommendation (editable)
   og_image_url    TEXT,                                     -- GitHub OG image URL
   is_public       INTEGER NOT NULL DEFAULT 1,               -- 1=visible, 0=hidden
-  upvote_count    INTEGER NOT NULL DEFAULT 0,               -- denormalized, updated atomically
   refreshed_at    TEXT NOT NULL DEFAULT (datetime('now')),  -- last GitHub metadata sync
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
@@ -58,6 +61,7 @@ CREATE TABLE IF NOT EXISTS showcases (
 
 CREATE INDEX IF NOT EXISTS idx_showcases_user ON showcases(user_id);
 CREATE INDEX IF NOT EXISTS idx_showcases_public_sort ON showcases(is_public, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_showcases_created ON showcases(created_at DESC);
 
 -- ============================================================
 -- Showcase Upvotes (one per user per showcase)
@@ -80,9 +84,9 @@ CREATE INDEX IF NOT EXISTS idx_showcase_upvotes_user ON showcase_upvotes(user_id
 - **`repo_key`** (not `github_url`) has UNIQUE constraint — normalized `owner/repo` lowercase
 - **`title` / `description`** fetched from GitHub, can be refreshed via owner action
 - **`tagline`** is user-editable recommendation text (optional, max 280 chars)
-- **`upvote_count`** updated atomically with upvote insert/delete (same SQL statement batch)
 - **`og_image_url`** constructed from repo_key, with fallback placeholder
 - **`refreshed_at`** tracks last GitHub metadata sync
+- **No `upvote_count` column** — v1 computes count via JOIN at read time (simpler, always accurate)
 
 ### URL Normalization
 
@@ -123,14 +127,10 @@ POST /api/showcases              — submit new showcase (auth required)
 
 Rationale:
 - Showcase list is expected to be small in v1 (<1000 items)
-- `upvote_count` changes frequently via user actions
-- Cursor-based pagination with mutable sort keys (upvote_count) would require complex tuple cursors (`{upvote_count, created_at, id}`) and still exhibit instability during concurrent upvotes
 - Offset/limit is simpler to implement and debug
 - Trade-off: deep pagination may show duplicates/gaps if data changes mid-browse — acceptable for v1 given small dataset
 
-Future: If showcase count grows significantly, revisit with:
-- Keyset pagination on stable sort (created_at DESC, id DESC)
-- Or accept upvote_count instability as "live leaderboard" behavior
+Future: If showcase count grows significantly, revisit with keyset pagination on stable sort (created_at DESC, id DESC).
 
 #### GET Response
 
@@ -144,8 +144,8 @@ interface ShowcaseListResponse {
     description: string | null;
     tagline: string | null;
     og_image_url: string | null;
-    upvote_count: number;
-    is_public: boolean;         // included for mine=1; always true for public list
+    upvote_count: number;           // computed via COUNT(*)
+    is_public: boolean;             // included for mine=1 and admin; always true for public list
     created_at: string;
     user: {
       id: string;
@@ -154,9 +154,9 @@ interface ShowcaseListResponse {
       image: string | null;
       slug: string | null;
     };
-    has_upvoted: boolean | null;  // null if not logged in
+    has_upvoted: boolean | null;    // null if not logged in
   }>;
-  total: number;                  // total count for pagination UI
+  total: number;                    // total count for pagination UI
   limit: number;
   offset: number;
 }
@@ -168,10 +168,22 @@ interface ShowcaseListResponse {
 - `has_upvoted` is `null` for unauthenticated requests
 - Sorted by `created_at DESC, id DESC` (stable sort)
 
-**Sorting rationale:**
-- v1 uses `created_at DESC` (newest first) as primary sort, not `upvote_count`
-- This avoids pagination instability from concurrent upvotes
-- "Most upvoted" can be a future sort option with explicit instability trade-off
+#### Upvote Count Query
+
+Since there's no denormalized `upvote_count` column, compute it via JOIN:
+
+```sql
+SELECT
+  s.*,
+  COUNT(u.id) as upvote_count,
+  MAX(CASE WHEN u.user_id = ? THEN 1 ELSE 0 END) as has_upvoted
+FROM showcases s
+LEFT JOIN showcase_upvotes u ON u.showcase_id = s.id
+WHERE s.is_public = 1
+GROUP BY s.id
+ORDER BY s.created_at DESC, s.id DESC
+LIMIT ? OFFSET ?
+```
 
 #### POST Request
 
@@ -228,8 +240,8 @@ interface PreviewResponse {
 
 ```
 GET    /api/showcases/[id]       — get single showcase
-PATCH  /api/showcases/[id]       — update showcase (owner only)
-DELETE /api/showcases/[id]       — delete showcase (owner only)
+PATCH  /api/showcases/[id]       — update showcase (owner or admin)
+DELETE /api/showcases/[id]       — delete showcase (owner or admin)
 ```
 
 #### GET Access Control
@@ -246,7 +258,16 @@ interface UpdateShowcaseRequest {
 }
 ```
 
+**Access:**
+- Owner can edit own showcase
+- Admin can edit any showcase (for moderation — e.g., hide inappropriate content)
+
 **Note:** `title` and `description` are NOT directly editable. Use the refresh endpoint to re-fetch from GitHub.
+
+#### DELETE Access
+
+- Owner can delete own showcase
+- Admin can delete any showcase
 
 ### `/api/showcases/[id]/refresh` — Refresh from GitHub
 
@@ -263,6 +284,8 @@ interface RefreshResponse {
   title: string;
   description: string | null;
   og_image_url: string;
+  repo_key: string;          // may change if renamed
+  github_url: string;        // may change if renamed
   refreshed_at: string;
 }
 ```
@@ -270,14 +293,19 @@ interface RefreshResponse {
 **Behavior:**
 - Re-fetches metadata from GitHub API
 - Updates `title`, `description`, `og_image_url`, `refreshed_at`
-- If repo was renamed/transferred, updates `repo_key` and `github_url`
-- If repo no longer exists (404), returns error but does NOT delete showcase
+- If repo was renamed/transferred:
+  - Compute new `repo_key` from GitHub response
+  - **Check if new `repo_key` already exists** in another showcase
+  - If conflict: return `409` with message "Repository was renamed to {new_key} but that repo is already showcased"
+  - If no conflict: update `repo_key` and `github_url`
+- If repo no longer exists (404), returns `410` but does NOT delete showcase
 
 **Response codes:**
 - `200` — Refreshed successfully
 - `401` — Not authenticated
 - `403` — Not owner
 - `404` — Showcase not found (or hidden and not owner)
+- `409` — Repo was renamed but new repo_key conflicts with existing showcase
 - `410` — GitHub repo no longer exists ("Repository was deleted or made private")
 - `422` — GitHub API error
 
@@ -292,67 +320,70 @@ POST /api/showcases/[id]/upvote  — toggle upvote (auth required)
 ```typescript
 interface UpvoteResponse {
   upvoted: boolean;       // new state after toggle
-  upvote_count: number;   // updated count (from showcase_upvotes, not denormalized)
+  upvote_count: number;   // fresh COUNT(*) from showcase_upvotes
 }
 ```
 
-#### Atomic Update Strategy
+#### Implementation
 
-To maintain consistency between `showcase_upvotes` and `showcases.upvote_count`, use a single batch write:
+Simple insert/delete — no denormalized count to maintain:
 
 ```typescript
-// Toggle ON (add upvote)
-await dbWrite.batch([
-  {
-    sql: `INSERT INTO showcase_upvotes (showcase_id, user_id) VALUES (?, ?)`,
-    params: [showcaseId, userId],
-  },
-  {
-    sql: `UPDATE showcases SET upvote_count = upvote_count + 1, updated_at = datetime('now') WHERE id = ?`,
-    params: [showcaseId],
-  },
-]);
+// Check current state
+const existing = await dbRead.firstOrNull(
+  `SELECT id FROM showcase_upvotes WHERE showcase_id = ? AND user_id = ?`,
+  [showcaseId, userId]
+);
 
-// Toggle OFF (remove upvote)
-await dbWrite.batch([
-  {
-    sql: `DELETE FROM showcase_upvotes WHERE showcase_id = ? AND user_id = ?`,
-    params: [showcaseId, userId],
-  },
-  {
-    sql: `UPDATE showcases SET upvote_count = upvote_count - 1, updated_at = datetime('now') WHERE id = ?`,
-    params: [showcaseId],
-  },
-]);
+if (existing) {
+  // Remove upvote
+  await dbWrite.execute(
+    `DELETE FROM showcase_upvotes WHERE showcase_id = ? AND user_id = ?`,
+    [showcaseId, userId]
+  );
+} else {
+  // Add upvote
+  await dbWrite.execute(
+    `INSERT INTO showcase_upvotes (showcase_id, user_id) VALUES (?, ?)`,
+    [showcaseId, userId]
+  );
+}
+
+// Get fresh count
+const { count } = await dbRead.first(
+  `SELECT COUNT(*) as count FROM showcase_upvotes WHERE showcase_id = ?`,
+  [showcaseId]
+);
+
+return { upvoted: !existing, upvote_count: count };
 ```
 
-#### Upvote Count Consistency
+### `/api/admin/showcases` — Admin List All
 
-**D1 batch is NOT transactional.** On partial failure, `upvote_count` may drift from actual `COUNT(*)` of `showcase_upvotes`.
+```
+GET /api/admin/showcases         — list all showcases (admin only)
+```
 
-**Mitigation strategy:**
+#### GET Query Parameters
 
-1. **Read-time truth**: When returning `upvote_count` in API responses, read from `showcase_upvotes` aggregate:
-   ```sql
-   SELECT s.*, COUNT(u.id) as actual_upvote_count
-   FROM showcases s
-   LEFT JOIN showcase_upvotes u ON u.showcase_id = s.id
-   WHERE s.id = ?
-   GROUP BY s.id
-   ```
+| Param | Type | Description |
+|-------|------|-------------|
+| `is_public` | `"0"` or `"1"` | Filter by visibility (omit for all) |
+| `user_id` | string | Filter by submitter |
+| `limit` | number | Max results (default 50, max 200) |
+| `offset` | number | Skip first N results (default 0) |
 
-2. **Denormalized field for sorting only**: `showcases.upvote_count` is used for index-based sorting but NOT trusted for display.
+#### GET Response
 
-3. **Periodic reconciliation**: Admin endpoint or cron job to fix drift:
-   ```sql
-   UPDATE showcases SET upvote_count = (
-     SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = showcases.id
-   )
-   ```
+Same as `/api/showcases` response, but:
+- Returns ALL showcases (public and hidden)
+- Always includes actual `is_public` value
+- Includes submitter info for moderation context
 
-4. **Optimistic UI**: Frontend shows optimistic count; on error rollback, re-fetch true count.
-
-This approach ensures **display accuracy** while accepting **sort-order may lag by 1** in rare partial-failure scenarios.
+**Response codes:**
+- `200` — Success
+- `401` — Not authenticated
+- `403` — Not admin
 
 ## GitHub Integration
 
@@ -506,29 +537,57 @@ Dashboard page for managing user's showcases.
 - Note: "Title and description are synced from GitHub"
 - Save/Cancel buttons
 
+### Admin → Showcases (`/admin/showcases`)
+
+Admin page for moderating all showcases.
+
+**Layout:**
+- Header: "Showcase Moderation"
+- Filters: visibility (all/public/hidden), search by user
+- Table view with columns:
+  - Thumbnail
+  - Title / repo_key
+  - Submitter (name + email)
+  - Upvote count
+  - Status (Public/Hidden badge)
+  - Created at
+  - Actions: View, Edit, Hide/Unhide, Delete
+
+**Actions:**
+- **View**: Opens showcase in new tab
+- **Edit**: Opens modal to edit tagline and visibility
+- **Hide/Unhide**: Quick toggle for `is_public`
+- **Delete**: Confirmation dialog, then hard delete
+
 ## Component Hierarchy
 
 ```
 packages/web/src/
 ├── app/
 │   ├── (dashboard)/
-│   │   └── settings/
+│   │   ├── settings/
+│   │   │   └── showcases/
+│   │   │       └── page.tsx           # Settings → Showcases management
+│   │   └── admin/
 │   │       └── showcases/
-│   │           └── page.tsx           # Settings → Showcases management
+│   │           └── page.tsx           # Admin → Showcase moderation
 │   ├── leaderboard/
 │   │   └── showcases/
 │   │       └── page.tsx               # Leaderboard → Showcases tab
 │   └── api/
-│       └── showcases/
-│           ├── route.ts               # GET list, POST create
-│           ├── preview/
-│           │   └── route.ts           # POST preview
-│           └── [id]/
-│               ├── route.ts           # GET, PATCH, DELETE
-│               ├── refresh/
-│               │   └── route.ts       # POST refresh from GitHub
-│               └── upvote/
-│                   └── route.ts       # POST toggle
+│       ├── showcases/
+│       │   ├── route.ts               # GET list, POST create
+│       │   ├── preview/
+│       │   │   └── route.ts           # POST preview
+│       │   └── [id]/
+│       │       ├── route.ts           # GET, PATCH, DELETE
+│       │       ├── refresh/
+│       │       │   └── route.ts       # POST refresh from GitHub
+│       │       └── upvote/
+│       │           └── route.ts       # POST toggle
+│       └── admin/
+│           └── showcases/
+│               └── route.ts           # GET all (admin)
 ├── components/
 │   └── showcase/
 │       ├── showcase-card.tsx          # Card for list display
@@ -550,14 +609,16 @@ packages/web/src/
 5. **API: Single CRUD** — `api/showcases/[id]/route.ts`
 6. **API: Refresh** — `api/showcases/[id]/refresh/route.ts`
 7. **API: Upvote** — `api/showcases/[id]/upvote/route.ts`
+8. **API: Admin list** — `api/admin/showcases/route.ts`
 
 ### Phase 2: Frontend
 
-8. **LeaderboardNav update** — add Showcases tab
-9. **Showcase components** — card, image, upvote button
-10. **Leaderboard showcases page** — `/leaderboard/showcases`
-11. **Settings showcases page** — `/settings/showcases`
-12. **Form modal** — add/edit with preview and refresh
+9. **LeaderboardNav update** — add Showcases tab
+10. **Showcase components** — card, image, upvote button
+11. **Leaderboard showcases page** — `/leaderboard/showcases`
+12. **Settings showcases page** — `/settings/showcases`
+13. **Form modal** — add/edit with preview and refresh
+14. **Admin showcases page** — `/admin/showcases`
 
 ## Atomic Commits
 
@@ -569,11 +630,13 @@ feat(api): implement showcases list and create endpoints
 feat(api): implement showcase single CRUD operations
 feat(api): implement showcase refresh from GitHub
 feat(api): implement showcase upvote toggle
+feat(api): implement admin showcases list endpoint
 feat(web): add Showcases tab to LeaderboardNav
 feat(web): add showcase card and image components
 feat(web): add leaderboard showcases page
 feat(web): add settings showcases management page
 feat(web): add showcase form modal with preview
+feat(web): add admin showcases moderation page
 docs: update README index with 34-showcase-system
 ```
 
@@ -583,7 +646,6 @@ docs: update README index with 34-showcase-system
 
 - `normalizeGitHubUrl()` — valid/invalid URLs, case normalization
 - `parseGitHubError()` — error type mapping
-- Upvote state derivation
 
 ### L2 — Integration Tests (API E2E)
 
@@ -594,6 +656,9 @@ docs: update README index with 34-showcase-system
 - Guest gets 404 for hidden showcase
 - Owner can GET own hidden showcase
 - Non-owner gets 404 for others' hidden showcase
+- Admin can GET any hidden showcase
+- Admin can GET `/api/admin/showcases`
+- Non-admin gets 403 on `/api/admin/showcases`
 
 **CRUD:**
 - Create with valid URL → 201 + metadata populated
@@ -604,12 +669,16 @@ docs: update README index with 34-showcase-system
 - Update title directly (should fail or be ignored)
 - Delete own → 200
 - Delete others' → 403
+- Admin delete any → 200
+- Admin hide any → 200
 
 **Refresh:**
 - Owner refresh → 200 + updated metadata
 - Non-owner refresh → 403
 - Refresh deleted repo → 410
 - Refresh with rate limit → 422
+- Refresh renamed repo (no conflict) → 200 + updated repo_key
+- Refresh renamed repo (conflict exists) → 409
 
 **Upvote:**
 - Toggle on → upvoted=true, count+1
@@ -639,15 +708,19 @@ docs: update README index with 34-showcase-system
 - Refresh from GitHub updates title/description
 - Delete showcase with confirmation
 - Pagination: load more works correctly
+- Admin: view all showcases including hidden
+- Admin: hide/unhide showcase
+- Admin: delete showcase
 
 ## Security Considerations
 
 1. **Public browse, auth for actions** — consistent with leaderboard
-2. **Ownership enforcement** — PATCH/DELETE/refresh check `user_id`
-3. **Hidden showcase isolation** — non-owner/admin returns 404, not 403
-4. **URL validation** — strict regex prevents injection
-5. **Tagline sanitization** — escape HTML on display
-6. **No GitHub token** — public API only, accept rate limits
+2. **Ownership enforcement** — PATCH/DELETE/refresh check `user_id` (or admin)
+3. **Admin bypass** — Admin can view/edit/delete any showcase for moderation
+4. **Hidden showcase isolation** — non-owner/non-admin returns 404, not 403
+5. **URL validation** — strict regex prevents injection
+6. **Tagline sanitization** — escape HTML on display
+7. **No GitHub token** — public API only, accept rate limits
 
 ## Decisions
 
@@ -665,7 +738,11 @@ docs: update README index with 34-showcase-system
 
 7. **Sort by created_at, not upvote_count** — Stable pagination. "Most upvoted" sort can be added later with explicit instability trade-off.
 
-8. **Read-time upvote count** — Display shows COUNT(*) from upvotes table; denormalized field for sort index only.
+8. **No denormalized upvote_count** — v1 computes count via JOIN. Simpler, always accurate, no drift. If performance becomes an issue at scale, add denormalized column then.
+
+9. **Refresh conflict handling** — If repo renamed to an already-showcased repo, return 409 with explanation. User must manually resolve (e.g., delete one showcase).
+
+10. **Admin moderation** — Admins can view all, edit any, delete any. Primary use case: hiding inappropriate content or spam.
 
 ---
 

--- a/docs/34-showcase-system.md
+++ b/docs/34-showcase-system.md
@@ -26,6 +26,7 @@ Consistent with existing leaderboard:
 | Edit own showcase | Yes (owner only) |
 | Delete own showcase | Yes (owner only) |
 | View hidden showcase | Yes (owner/admin only) |
+| Refresh from GitHub | Yes (owner only) |
 
 ## Database Schema
 
@@ -43,19 +44,20 @@ CREATE TABLE IF NOT EXISTS showcases (
   user_id         TEXT NOT NULL REFERENCES users(id),       -- submitter
   repo_key        TEXT NOT NULL,                            -- normalized: "owner/repo" lowercase
   github_url      TEXT NOT NULL,                            -- display URL (original casing)
-  title           TEXT NOT NULL,                            -- fetched from GitHub, immutable
-  description     TEXT,                                     -- fetched from GitHub, immutable
+  title           TEXT NOT NULL,                            -- fetched from GitHub
+  description     TEXT,                                     -- fetched from GitHub
   tagline         TEXT,                                     -- user-provided recommendation (editable)
   og_image_url    TEXT,                                     -- GitHub OG image URL
   is_public       INTEGER NOT NULL DEFAULT 1,               -- 1=visible, 0=hidden
   upvote_count    INTEGER NOT NULL DEFAULT 0,               -- denormalized, updated atomically
+  refreshed_at    TEXT NOT NULL DEFAULT (datetime('now')),  -- last GitHub metadata sync
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(repo_key)                                          -- one submission per repo (normalized)
 );
 
 CREATE INDEX IF NOT EXISTS idx_showcases_user ON showcases(user_id);
-CREATE INDEX IF NOT EXISTS idx_showcases_public_sort ON showcases(is_public, upvote_count DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_showcases_public_sort ON showcases(is_public, created_at DESC);
 
 -- ============================================================
 -- Showcase Upvotes (one per user per showcase)
@@ -76,10 +78,11 @@ CREATE INDEX IF NOT EXISTS idx_showcase_upvotes_user ON showcase_upvotes(user_id
 ### Schema Notes
 
 - **`repo_key`** (not `github_url`) has UNIQUE constraint — normalized `owner/repo` lowercase
-- **`title` / `description`** are immutable after creation (fetched from GitHub)
+- **`title` / `description`** fetched from GitHub, can be refreshed via owner action
 - **`tagline`** is user-editable recommendation text (optional, max 280 chars)
 - **`upvote_count`** updated atomically with upvote insert/delete (same SQL statement batch)
 - **`og_image_url`** constructed from repo_key, with fallback placeholder
+- **`refreshed_at`** tracks last GitHub metadata sync
 
 ### URL Normalization
 
@@ -112,7 +115,22 @@ POST /api/showcases              — submit new showcase (auth required)
 |-------|------|-------------|
 | `mine` | `"1"` | If set, return current user's showcases (auth required) |
 | `limit` | number | Max results (default 20, max 100) |
-| `cursor` | string | Pagination cursor (showcase ID) |
+| `offset` | number | Skip first N results (default 0) |
+
+#### Pagination Strategy: Offset/Limit
+
+**v1 uses simple offset/limit pagination** instead of cursor-based pagination.
+
+Rationale:
+- Showcase list is expected to be small in v1 (<1000 items)
+- `upvote_count` changes frequently via user actions
+- Cursor-based pagination with mutable sort keys (upvote_count) would require complex tuple cursors (`{upvote_count, created_at, id}`) and still exhibit instability during concurrent upvotes
+- Offset/limit is simpler to implement and debug
+- Trade-off: deep pagination may show duplicates/gaps if data changes mid-browse — acceptable for v1 given small dataset
+
+Future: If showcase count grows significantly, revisit with:
+- Keyset pagination on stable sort (created_at DESC, id DESC)
+- Or accept upvote_count instability as "live leaderboard" behavior
 
 #### GET Response
 
@@ -127,6 +145,7 @@ interface ShowcaseListResponse {
     tagline: string | null;
     og_image_url: string | null;
     upvote_count: number;
+    is_public: boolean;         // included for mine=1; always true for public list
     created_at: string;
     user: {
       id: string;
@@ -137,14 +156,22 @@ interface ShowcaseListResponse {
     };
     has_upvoted: boolean | null;  // null if not logged in
   }>;
-  next_cursor: string | null;
+  total: number;                  // total count for pagination UI
+  limit: number;
+  offset: number;
 }
 ```
 
 **Behavior:**
-- Without `mine`: returns `is_public=1` showcases only
-- With `mine=1`: returns all showcases owned by current user (requires auth)
+- Without `mine`: returns `is_public=1` showcases only, `is_public` always `true` in response
+- With `mine=1`: returns all showcases owned by current user (requires auth), includes actual `is_public` value
 - `has_upvoted` is `null` for unauthenticated requests
+- Sorted by `created_at DESC, id DESC` (stable sort)
+
+**Sorting rationale:**
+- v1 uses `created_at DESC` (newest first) as primary sort, not `upvote_count`
+- This avoids pagination instability from concurrent upvotes
+- "Most upvoted" can be a future sort option with explicit instability trade-off
 
 #### POST Request
 
@@ -219,7 +246,40 @@ interface UpdateShowcaseRequest {
 }
 ```
 
-**Note:** `title` and `description` are NOT editable — they come from GitHub. If user wants to change them, they should update their GitHub repo.
+**Note:** `title` and `description` are NOT directly editable. Use the refresh endpoint to re-fetch from GitHub.
+
+### `/api/showcases/[id]/refresh` — Refresh from GitHub
+
+```
+POST /api/showcases/[id]/refresh  — re-fetch metadata from GitHub (owner only)
+```
+
+This endpoint allows showcase owners to update title, description, and OG image when they've changed their GitHub repository.
+
+#### Response
+
+```typescript
+interface RefreshResponse {
+  title: string;
+  description: string | null;
+  og_image_url: string;
+  refreshed_at: string;
+}
+```
+
+**Behavior:**
+- Re-fetches metadata from GitHub API
+- Updates `title`, `description`, `og_image_url`, `refreshed_at`
+- If repo was renamed/transferred, updates `repo_key` and `github_url`
+- If repo no longer exists (404), returns error but does NOT delete showcase
+
+**Response codes:**
+- `200` — Refreshed successfully
+- `401` — Not authenticated
+- `403` — Not owner
+- `404` — Showcase not found (or hidden and not owner)
+- `410` — GitHub repo no longer exists ("Repository was deleted or made private")
+- `422` — GitHub API error
 
 ### `/api/showcases/[id]/upvote` — Toggle Upvote
 
@@ -232,7 +292,7 @@ POST /api/showcases/[id]/upvote  — toggle upvote (auth required)
 ```typescript
 interface UpvoteResponse {
   upvoted: boolean;       // new state after toggle
-  upvote_count: number;   // updated count
+  upvote_count: number;   // updated count (from showcase_upvotes, not denormalized)
 }
 ```
 
@@ -266,7 +326,33 @@ await dbWrite.batch([
 ]);
 ```
 
-**Note:** D1 batch is NOT transactional, but both statements affect independent rows. Worst case on partial failure: count drifts by 1. Acceptable for v1; can add periodic reconciliation job later if needed.
+#### Upvote Count Consistency
+
+**D1 batch is NOT transactional.** On partial failure, `upvote_count` may drift from actual `COUNT(*)` of `showcase_upvotes`.
+
+**Mitigation strategy:**
+
+1. **Read-time truth**: When returning `upvote_count` in API responses, read from `showcase_upvotes` aggregate:
+   ```sql
+   SELECT s.*, COUNT(u.id) as actual_upvote_count
+   FROM showcases s
+   LEFT JOIN showcase_upvotes u ON u.showcase_id = s.id
+   WHERE s.id = ?
+   GROUP BY s.id
+   ```
+
+2. **Denormalized field for sorting only**: `showcases.upvote_count` is used for index-based sorting but NOT trusted for display.
+
+3. **Periodic reconciliation**: Admin endpoint or cron job to fix drift:
+   ```sql
+   UPDATE showcases SET upvote_count = (
+     SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = showcases.id
+   )
+   ```
+
+4. **Optimistic UI**: Frontend shows optimistic count; on error rollback, re-fetch true count.
+
+This approach ensures **display accuracy** while accepting **sort-order may lag by 1** in rare partial-failure scenarios.
 
 ## GitHub Integration
 
@@ -315,8 +401,12 @@ async function fetchGitHubMetadata(owner: string, repo: string): Promise<GitHubM
 
   const data = await res.json();
   return {
+    // Handle repo rename/transfer: use current owner/name from API response
+    owner: data.owner?.login || owner,
+    name: data.name || repo,
     title: data.name || `${owner}/${repo}`,
     description: data.description || null,
+    fullName: data.full_name,  // "current_owner/current_name" for rename detection
   };
 }
 ```
@@ -379,7 +469,7 @@ New tab in LeaderboardNav alongside Individual, Seasons, Achievements.
   - Submitter avatar + name (bottom)
   - Upvote button + count (right side)
 
-**Sorting:** `upvote_count DESC, created_at DESC, id DESC`
+**Sorting:** `created_at DESC, id DESC` (newest first, stable)
 
 **Upvote interaction:**
 - Not logged in: clicking upvote shows "Login to upvote" tooltip or redirects
@@ -400,7 +490,7 @@ Dashboard page for managing user's showcases.
   - Title, tagline (truncated)
   - Upvote count
   - Public/Hidden badge
-  - Actions: Edit (tagline + visibility), Delete
+  - Actions: Edit (tagline + visibility), Refresh, Delete
 
 **Add Showcase Modal:**
 1. Input: GitHub URL
@@ -412,7 +502,8 @@ Dashboard page for managing user's showcases.
 **Edit Showcase Modal:**
 - Tagline input (editable)
 - Public/Hidden toggle
-- "Title and description come from GitHub" note with link to edit on GitHub
+- "Refresh from GitHub" button (updates title/description)
+- Note: "Title and description are synced from GitHub"
 - Save/Cancel buttons
 
 ## Component Hierarchy
@@ -434,6 +525,8 @@ packages/web/src/
 │           │   └── route.ts           # POST preview
 │           └── [id]/
 │               ├── route.ts           # GET, PATCH, DELETE
+│               ├── refresh/
+│               │   └── route.ts       # POST refresh from GitHub
 │               └── upvote/
 │                   └── route.ts       # POST toggle
 ├── components/
@@ -455,15 +548,16 @@ packages/web/src/
 3. **API: Preview** — `api/showcases/preview/route.ts`
 4. **API: List & Create** — `api/showcases/route.ts`
 5. **API: Single CRUD** — `api/showcases/[id]/route.ts`
-6. **API: Upvote** — `api/showcases/[id]/upvote/route.ts`
+6. **API: Refresh** — `api/showcases/[id]/refresh/route.ts`
+7. **API: Upvote** — `api/showcases/[id]/upvote/route.ts`
 
 ### Phase 2: Frontend
 
-7. **LeaderboardNav update** — add Showcases tab
-8. **Showcase components** — card, image, upvote button
-9. **Leaderboard showcases page** — `/leaderboard/showcases`
-10. **Settings showcases page** — `/settings/showcases`
-11. **Form modal** — add/edit with preview
+8. **LeaderboardNav update** — add Showcases tab
+9. **Showcase components** — card, image, upvote button
+10. **Leaderboard showcases page** — `/leaderboard/showcases`
+11. **Settings showcases page** — `/settings/showcases`
+12. **Form modal** — add/edit with preview and refresh
 
 ## Atomic Commits
 
@@ -473,6 +567,7 @@ feat(lib): add GitHub URL normalization and metadata fetch helpers
 feat(api): implement showcase preview endpoint
 feat(api): implement showcases list and create endpoints
 feat(api): implement showcase single CRUD operations
+feat(api): implement showcase refresh from GitHub
 feat(api): implement showcase upvote toggle
 feat(web): add Showcases tab to LeaderboardNav
 feat(web): add showcase card and image components
@@ -506,19 +601,33 @@ docs: update README index with 34-showcase-system
 - Create with non-existent repo → 404
 - Create duplicate repo_key → 409
 - Update tagline → 200
-- Update title (should fail or be ignored)
+- Update title directly (should fail or be ignored)
 - Delete own → 200
 - Delete others' → 403
+
+**Refresh:**
+- Owner refresh → 200 + updated metadata
+- Non-owner refresh → 403
+- Refresh deleted repo → 410
+- Refresh with rate limit → 422
 
 **Upvote:**
 - Toggle on → upvoted=true, count+1
 - Toggle off → upvoted=false, count-1
 - Idempotent: double toggle = original state
+- Verify returned count matches actual COUNT(*)
+
+**Pagination:**
+- offset=0, limit=10 returns first 10
+- offset=10, limit=10 returns next 10
+- offset beyond total returns empty array
+- total count is accurate
 
 **Edge cases:**
 - GitHub API rate limit simulation → 422
 - GitHub timeout → 422
 - Empty description from GitHub → null stored
+- URL case variations normalize to same repo_key
 
 ### L3 — E2E (Playwright)
 
@@ -527,12 +636,14 @@ docs: update README index with 34-showcase-system
 - Add showcase from leaderboard page
 - Add showcase from settings page
 - Edit tagline, toggle visibility
+- Refresh from GitHub updates title/description
 - Delete showcase with confirmation
+- Pagination: load more works correctly
 
 ## Security Considerations
 
 1. **Public browse, auth for actions** — consistent with leaderboard
-2. **Ownership enforcement** — PATCH/DELETE check `user_id`
+2. **Ownership enforcement** — PATCH/DELETE/refresh check `user_id`
 3. **Hidden showcase isolation** — non-owner/admin returns 404, not 403
 4. **URL validation** — strict regex prevents injection
 5. **Tagline sanitization** — escape HTML on display
@@ -540,7 +651,7 @@ docs: update README index with 34-showcase-system
 
 ## Decisions
 
-1. **Title/description immutable** — Source of truth is GitHub. Encourages users to maintain good GitHub READMEs.
+1. **Title/description from GitHub with refresh** — Source of truth is GitHub. Owner can manually trigger refresh when they update their repo.
 
 2. **Tagline field** — Allows personal recommendation without duplicating GitHub metadata. Max 280 chars (tweet-length).
 
@@ -550,7 +661,11 @@ docs: update README index with 34-showcase-system
 
 5. **Plain img, not next/image** — Avoids remote domain whitelist complexity. Fallback handles failures gracefully.
 
-6. **20 items per page** — Reasonable for ProductHunt-style browsing. Cursor pagination for performance.
+6. **Offset/limit pagination** — Simple and correct for small dataset. Cursor pagination deferred until scale requires it.
+
+7. **Sort by created_at, not upvote_count** — Stable pagination. "Most upvoted" sort can be added later with explicit instability trade-off.
+
+8. **Read-time upvote count** — Display shows COUNT(*) from upvotes table; denormalized field for sort index only.
 
 ---
 

--- a/docs/34-showcase-system.md
+++ b/docs/34-showcase-system.md
@@ -170,20 +170,34 @@ interface ShowcaseListResponse {
 
 #### Upvote Count Query
 
-Since there's no denormalized `upvote_count` column, compute it via JOIN:
+Since there's no denormalized `upvote_count` column, compute it via JOIN.
+
+**Authenticated user** — include `has_upvoted` via subquery:
 
 ```sql
 SELECT
   s.*,
-  COUNT(u.id) as upvote_count,
-  MAX(CASE WHEN u.user_id = ? THEN 1 ELSE 0 END) as has_upvoted
+  (SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = s.id) as upvote_count,
+  EXISTS(SELECT 1 FROM showcase_upvotes WHERE showcase_id = s.id AND user_id = ?) as has_upvoted
 FROM showcases s
-LEFT JOIN showcase_upvotes u ON u.showcase_id = s.id
 WHERE s.is_public = 1
-GROUP BY s.id
 ORDER BY s.created_at DESC, s.id DESC
 LIMIT ? OFFSET ?
 ```
+
+**Unauthenticated** — separate query without `has_upvoted` (return `null` in response):
+
+```sql
+SELECT
+  s.*,
+  (SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = s.id) as upvote_count
+FROM showcases s
+WHERE s.is_public = 1
+ORDER BY s.created_at DESC, s.id DESC
+LIMIT ? OFFSET ?
+```
+
+Implementation note: Use two separate SQL strings based on auth state. Do NOT pass `null` as user_id parameter — SQLite's `user_id = NULL` always evaluates to `NULL` (not `FALSE`), which would break the query logic.
 
 #### POST Request
 
@@ -375,10 +389,39 @@ GET /api/admin/showcases         — list all showcases (admin only)
 
 #### GET Response
 
-Same as `/api/showcases` response, but:
-- Returns ALL showcases (public and hidden)
-- Always includes actual `is_public` value
-- Includes submitter info for moderation context
+Admin response uses a **dedicated type** with additional fields for moderation:
+
+```typescript
+interface AdminShowcaseListResponse {
+  showcases: Array<{
+    id: string;
+    repo_key: string;
+    github_url: string;
+    title: string;
+    description: string | null;
+    tagline: string | null;
+    og_image_url: string | null;
+    upvote_count: number;
+    is_public: boolean;
+    created_at: string;
+    refreshed_at: string;
+    // Admin-only: full user info for moderation
+    user: {
+      id: string;
+      email: string;            // admin-only field
+      name: string | null;
+      nickname: string | null;
+      image: string | null;
+      slug: string | null;
+    };
+  }>;
+  total: number;
+  limit: number;
+  offset: number;
+}
+```
+
+Note: This is NOT the same type as public `ShowcaseListResponse`. Do not reuse — admin response includes `user.email` and omits `has_upvoted` (not relevant for moderation).
 
 **Response codes:**
 - `200` — Success

--- a/docs/34-showcase-system.md
+++ b/docs/34-showcase-system.md
@@ -654,14 +654,14 @@ packages/web/src/
 7. ✅ **API: Upvote** — `api/showcases/[id]/upvote/route.ts`
 8. ✅ **API: Admin list** — `api/admin/showcases/route.ts`
 
-### Phase 2: Frontend
+### Phase 2: Frontend ✅
 
-9. **LeaderboardNav update** — add Showcases tab
-10. **Showcase components** — card, image, upvote button
-11. **Leaderboard showcases page** — `/leaderboard/showcases`
-12. **Settings showcases page** — `/settings/showcases`
-13. **Form modal** — add/edit with preview and refresh
-14. **Admin showcases page** — `/admin/showcases`
+9. ✅ **LeaderboardNav update** — add Showcases tab
+10. ✅ **Showcase components** — card, image, upvote button
+11. ✅ **Leaderboard showcases page** — `/leaderboard/showcases`
+12. ✅ **Settings showcases page** — `/settings/showcases`
+13. ✅ **Form modal** — add/edit with preview and refresh
+14. ✅ **Admin showcases page** — `/admin/showcases`
 
 ## Atomic Commits
 
@@ -789,6 +789,6 @@ docs: update README index with 34-showcase-system
 
 ---
 
-**Status:** design-complete
+**Status:** implementation-complete
 **Author:** Claude
 **Date:** 2026-04-07

--- a/docs/34-showcase-system.md
+++ b/docs/34-showcase-system.md
@@ -643,16 +643,16 @@ packages/web/src/
 
 ## Implementation Plan
 
-### Phase 1: Database & Core API
+### Phase 1: Database & Core API ✅
 
-1. **Migration** — `scripts/migrations/016-showcases.sql`
-2. **Lib: GitHub helpers** — `lib/github.ts` (URL normalization, metadata fetch)
-3. **API: Preview** — `api/showcases/preview/route.ts`
-4. **API: List & Create** — `api/showcases/route.ts`
-5. **API: Single CRUD** — `api/showcases/[id]/route.ts`
-6. **API: Refresh** — `api/showcases/[id]/refresh/route.ts`
-7. **API: Upvote** — `api/showcases/[id]/upvote/route.ts`
-8. **API: Admin list** — `api/admin/showcases/route.ts`
+1. ✅ **Migration** — `scripts/migrations/016-showcases.sql`
+2. ✅ **Lib: GitHub helpers** — `lib/github.ts` (URL normalization, metadata fetch)
+3. ✅ **API: Preview** — `api/showcases/preview/route.ts`
+4. ✅ **API: List & Create** — `api/showcases/route.ts`
+5. ✅ **API: Single CRUD** — `api/showcases/[id]/route.ts`
+6. ✅ **API: Refresh** — `api/showcases/[id]/refresh/route.ts`
+7. ✅ **API: Upvote** — `api/showcases/[id]/upvote/route.ts`
+8. ✅ **API: Admin list** — `api/admin/showcases/route.ts`
 
 ### Phase 2: Frontend
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,5 +33,8 @@
 | 29 | [29-worker-read-migration.md](29-worker-read-migration.md) | Worker read migration — D1 REST API → Worker native binding | in-progress |
 | 30 | [30-quality-system-upgrade.md](30-quality-system-upgrade.md) | Quality system upgrade — L1+L2+L3+G1+G2 | done |
 | 31 | [31-d1-test-isolation.md](31-d1-test-isolation.md) | D1 test isolation — quality system → Tier S | done |
+| 32 | [32-proxy-token-gap-investigation.md](32-proxy-token-gap-investigation.md) | Proxy token gap investigation | reference |
+| 33 | [33-achievement-system-overhaul.md](33-achievement-system-overhaul.md) | Achievement system overhaul | in-progress |
+| 34 | [34-showcase-system.md](34-showcase-system.md) | ProductHunt-style showcase system | design-complete |
 
 > **Note:** Number 14 is intentionally vacant (original doc 14 was renumbered to 12 to fill a gap).

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,6 +14,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
+    "nanoid": "^5.1.7",
     "next": "^16.1.0",
     "next-auth": "^5.0.0-beta.30",
     "radix-ui": "^1.4.3",

--- a/packages/web/src/__tests__/admin-showcases.test.ts
+++ b/packages/web/src/__tests__/admin-showcases.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GET } from "@/app/api/admin/showcases/route";
+
+// Mock dependencies
+vi.mock("@/lib/auth-helpers", () => ({
+  resolveUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDbRead: vi.fn(),
+}));
+
+vi.mock("@/lib/admin", () => ({
+  isAdmin: vi.fn(),
+}));
+
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead } from "@/lib/db";
+import { isAdmin } from "@/lib/admin";
+
+const mockResolveUser = vi.mocked(resolveUser);
+const mockGetDbRead = vi.mocked(getDbRead);
+const mockIsAdmin = vi.mocked(isAdmin);
+
+function createRequest(params: Record<string, string> = {}): Request {
+  const url = new URL("http://localhost/api/admin/showcases");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new Request(url.toString(), { method: "GET" });
+}
+
+const mockShowcase = {
+  id: "s1",
+  user_id: "u1",
+  repo_key: "owner/repo",
+  github_url: "https://github.com/owner/repo",
+  title: "My Repo",
+  description: "A cool project",
+  tagline: "Check this out!",
+  og_image_url: "https://og.test/1/owner/repo",
+  is_public: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  refreshed_at: "2026-01-01T00:00:00Z",
+  user_name: "Test User",
+  user_nickname: null,
+  user_image: null,
+  user_slug: "testuser",
+  user_email: "user@example.com",
+  upvote_count: 5,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/showcases
+// ---------------------------------------------------------------------------
+
+describe("GET /api/admin/showcases", () => {
+  describe("authentication and authorization", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockResolveUser.mockResolvedValue(null);
+
+      const res = await GET(createRequest());
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when not admin", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "user@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+
+      const res = await GET(createRequest());
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("successful listing", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "admin", email: "admin@example.com" });
+      mockIsAdmin.mockReturnValue(true);
+    });
+
+    it("returns all showcases with user email", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 1 }),
+        query: vi.fn().mockResolvedValue({ results: [mockShowcase] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createRequest());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.showcases).toHaveLength(1);
+      expect(json.showcases[0].user.email).toBe("user@example.com");
+      expect(json.total).toBe(1);
+    });
+
+    it("filters by is_public=1", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 1 }),
+        query: vi.fn().mockResolvedValue({ results: [mockShowcase] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      await GET(createRequest({ is_public: "1" }));
+
+      expect(mockDb.firstOrNull).toHaveBeenCalledWith(
+        expect.stringContaining("WHERE s.is_public = ?"),
+        [1]
+      );
+    });
+
+    it("filters by is_public=0", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 0 }),
+        query: vi.fn().mockResolvedValue({ results: [] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      await GET(createRequest({ is_public: "0" }));
+
+      expect(mockDb.firstOrNull).toHaveBeenCalledWith(
+        expect.stringContaining("WHERE s.is_public = ?"),
+        [0]
+      );
+    });
+
+    it("filters by user_id", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 1 }),
+        query: vi.fn().mockResolvedValue({ results: [mockShowcase] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      await GET(createRequest({ user_id: "u1" }));
+
+      expect(mockDb.firstOrNull).toHaveBeenCalledWith(
+        expect.stringContaining("WHERE s.user_id = ?"),
+        ["u1"]
+      );
+    });
+
+    it("combines filters", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 1 }),
+        query: vi.fn().mockResolvedValue({ results: [mockShowcase] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      await GET(createRequest({ is_public: "1", user_id: "u1" }));
+
+      expect(mockDb.firstOrNull).toHaveBeenCalledWith(
+        expect.stringContaining("WHERE s.is_public = ? AND s.user_id = ?"),
+        [1, "u1"]
+      );
+    });
+
+    it("respects limit and offset params", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 100 }),
+        query: vi.fn().mockResolvedValue({ results: [] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createRequest({ limit: "10", offset: "20" }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.limit).toBe(10);
+      expect(json.offset).toBe(20);
+    });
+
+    it("caps limit at 200", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 0 }),
+        query: vi.fn().mockResolvedValue({ results: [] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createRequest({ limit: "500" }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.limit).toBe(200);
+    });
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "admin", email: "admin@example.com" });
+      mockIsAdmin.mockReturnValue(true);
+    });
+
+    it("handles missing table gracefully", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("no such table: showcases")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createRequest());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.showcases).toEqual([]);
+      expect(json.total).toBe(0);
+    });
+
+    it("returns 500 on unexpected DB error", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createRequest());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to list showcases");
+    });
+  });
+});

--- a/packages/web/src/__tests__/github.test.ts
+++ b/packages/web/src/__tests__/github.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  normalizeGitHubUrl,
+  isValidGitHubRepoUrl,
+  buildOgImageUrl,
+  gitHubErrorToStatus,
+  gitHubErrorMessage,
+  GitHubError,
+  fetchGitHubMetadata,
+} from "@/lib/github";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// normalizeGitHubUrl
+// ---------------------------------------------------------------------------
+
+describe("normalizeGitHubUrl", () => {
+  describe("valid URLs", () => {
+    it("normalizes https URL", () => {
+      const result = normalizeGitHubUrl("https://github.com/Owner/Repo");
+      expect(result).toEqual({
+        repoKey: "owner/repo",
+        displayUrl: "https://github.com/Owner/Repo",
+        owner: "Owner",
+        repo: "Repo",
+      });
+    });
+
+    it("normalizes http URL to https", () => {
+      const result = normalizeGitHubUrl("http://github.com/Owner/Repo");
+      expect(result).not.toBeNull();
+      expect(result!.displayUrl).toBe("https://github.com/Owner/Repo");
+    });
+
+    it("handles trailing slash", () => {
+      const result = normalizeGitHubUrl("https://github.com/Owner/Repo/");
+      expect(result).not.toBeNull();
+      expect(result!.repoKey).toBe("owner/repo");
+    });
+
+    it("preserves original casing in displayUrl", () => {
+      const result = normalizeGitHubUrl("https://github.com/MyOrg/MyRepo");
+      expect(result!.displayUrl).toBe("https://github.com/MyOrg/MyRepo");
+      expect(result!.owner).toBe("MyOrg");
+      expect(result!.repo).toBe("MyRepo");
+    });
+
+    it("lowercases repoKey for dedup", () => {
+      const result1 = normalizeGitHubUrl("https://github.com/Owner/REPO");
+      const result2 = normalizeGitHubUrl("https://github.com/OWNER/repo");
+      expect(result1!.repoKey).toBe("owner/repo");
+      expect(result2!.repoKey).toBe("owner/repo");
+    });
+
+    it("handles owner/repo with dots", () => {
+      const result = normalizeGitHubUrl("https://github.com/some.org/my.repo");
+      expect(result).not.toBeNull();
+      expect(result!.repoKey).toBe("some.org/my.repo");
+    });
+
+    it("handles owner/repo with hyphens", () => {
+      const result = normalizeGitHubUrl("https://github.com/my-org/my-repo");
+      expect(result).not.toBeNull();
+      expect(result!.repoKey).toBe("my-org/my-repo");
+    });
+
+    it("handles owner/repo with underscores", () => {
+      const result = normalizeGitHubUrl("https://github.com/my_org/my_repo");
+      expect(result).not.toBeNull();
+      expect(result!.repoKey).toBe("my_org/my_repo");
+    });
+
+    it("trims whitespace", () => {
+      const result = normalizeGitHubUrl("  https://github.com/Owner/Repo  ");
+      expect(result).not.toBeNull();
+      expect(result!.repoKey).toBe("owner/repo");
+    });
+  });
+
+  describe("invalid URLs", () => {
+    it("rejects user/org page (no repo)", () => {
+      expect(normalizeGitHubUrl("https://github.com/Owner")).toBeNull();
+    });
+
+    it("rejects file path URL", () => {
+      expect(
+        normalizeGitHubUrl("https://github.com/Owner/Repo/blob/main/file.ts")
+      ).toBeNull();
+    });
+
+    it("rejects tree URL", () => {
+      expect(
+        normalizeGitHubUrl("https://github.com/Owner/Repo/tree/main")
+      ).toBeNull();
+    });
+
+    it("rejects issue URL", () => {
+      expect(
+        normalizeGitHubUrl("https://github.com/Owner/Repo/issues/123")
+      ).toBeNull();
+    });
+
+    it("rejects pull request URL", () => {
+      expect(
+        normalizeGitHubUrl("https://github.com/Owner/Repo/pull/456")
+      ).toBeNull();
+    });
+
+    it("rejects non-GitHub URL", () => {
+      expect(normalizeGitHubUrl("https://gitlab.com/Owner/Repo")).toBeNull();
+    });
+
+    it("rejects malformed URL", () => {
+      expect(normalizeGitHubUrl("not-a-url")).toBeNull();
+    });
+
+    it("rejects empty string", () => {
+      expect(normalizeGitHubUrl("")).toBeNull();
+    });
+
+    it("rejects URL with extra path segments", () => {
+      expect(
+        normalizeGitHubUrl("https://github.com/Owner/Repo/extra")
+      ).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidGitHubRepoUrl
+// ---------------------------------------------------------------------------
+
+describe("isValidGitHubRepoUrl", () => {
+  it("returns true for valid URL", () => {
+    expect(isValidGitHubRepoUrl("https://github.com/Owner/Repo")).toBe(true);
+  });
+
+  it("returns false for invalid URL", () => {
+    expect(isValidGitHubRepoUrl("https://github.com/Owner")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOgImageUrl
+// ---------------------------------------------------------------------------
+
+describe("buildOgImageUrl", () => {
+  it("constructs correct OG image URL", () => {
+    const url = buildOgImageUrl("Owner", "Repo");
+    expect(url).toBe("https://opengraph.githubassets.com/1/Owner/Repo");
+  });
+
+  it("preserves casing", () => {
+    const url = buildOgImageUrl("MyOrg", "MyRepo");
+    expect(url).toBe("https://opengraph.githubassets.com/1/MyOrg/MyRepo");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHubError helpers
+// ---------------------------------------------------------------------------
+
+describe("gitHubErrorToStatus", () => {
+  it("maps NOT_FOUND to 404", () => {
+    const err = new GitHubError("NOT_FOUND", "test");
+    expect(gitHubErrorToStatus(err)).toBe(404);
+  });
+
+  it("maps RATE_LIMITED to 422", () => {
+    const err = new GitHubError("RATE_LIMITED", "test");
+    expect(gitHubErrorToStatus(err)).toBe(422);
+  });
+
+  it("maps FORBIDDEN to 422", () => {
+    const err = new GitHubError("FORBIDDEN", "test");
+    expect(gitHubErrorToStatus(err)).toBe(422);
+  });
+
+  it("maps UPSTREAM_ERROR to 422", () => {
+    const err = new GitHubError("UPSTREAM_ERROR", "test");
+    expect(gitHubErrorToStatus(err)).toBe(422);
+  });
+
+  it("maps NETWORK_ERROR to 422", () => {
+    const err = new GitHubError("NETWORK_ERROR", "test");
+    expect(gitHubErrorToStatus(err)).toBe(422);
+  });
+
+  it("maps TIMEOUT to 422", () => {
+    const err = new GitHubError("TIMEOUT", "test");
+    expect(gitHubErrorToStatus(err)).toBe(422);
+  });
+});
+
+describe("gitHubErrorMessage", () => {
+  it("returns user-friendly message for NOT_FOUND", () => {
+    const err = new GitHubError("NOT_FOUND", "test");
+    expect(gitHubErrorMessage(err)).toBe("Repository not found or is private");
+  });
+
+  it("returns user-friendly message for RATE_LIMITED", () => {
+    const err = new GitHubError("RATE_LIMITED", "test");
+    expect(gitHubErrorMessage(err)).toContain("rate limit");
+  });
+
+  it("returns user-friendly message for TIMEOUT", () => {
+    const err = new GitHubError("TIMEOUT", "test");
+    expect(gitHubErrorMessage(err)).toContain("timed out");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHubError class
+// ---------------------------------------------------------------------------
+
+describe("GitHubError", () => {
+  it("is an instance of Error", () => {
+    const err = new GitHubError("NOT_FOUND", "test message");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has correct name", () => {
+    const err = new GitHubError("NOT_FOUND", "test message");
+    expect(err.name).toBe("GitHubError");
+  });
+
+  it("has correct code", () => {
+    const err = new GitHubError("RATE_LIMITED", "test message");
+    expect(err.code).toBe("RATE_LIMITED");
+  });
+
+  it("has correct message", () => {
+    const err = new GitHubError("NOT_FOUND", "custom message");
+    expect(err.message).toBe("custom message");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchGitHubMetadata
+// ---------------------------------------------------------------------------
+
+describe("fetchGitHubMetadata", () => {
+  it("returns metadata for valid public repo", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: "my-repo",
+          description: "A cool project",
+          full_name: "owner/my-repo",
+          owner: { login: "owner" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const result = await fetchGitHubMetadata("owner", "my-repo");
+
+    expect(result).toEqual({
+      owner: "owner",
+      name: "my-repo",
+      title: "my-repo",
+      description: "A cool project",
+      fullName: "owner/my-repo",
+    });
+  });
+
+  it("handles repo with null description", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: "my-repo",
+          description: null,
+          full_name: "owner/my-repo",
+          owner: { login: "owner" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const result = await fetchGitHubMetadata("owner", "my-repo");
+    expect(result.description).toBeNull();
+  });
+
+  it("handles renamed/transferred repo", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: "new-name",
+          description: "Renamed repo",
+          full_name: "new-owner/new-name",
+          owner: { login: "new-owner" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const result = await fetchGitHubMetadata("old-owner", "old-name");
+
+    expect(result.owner).toBe("new-owner");
+    expect(result.name).toBe("new-name");
+    expect(result.fullName).toBe("new-owner/new-name");
+  });
+
+  it("throws NOT_FOUND for 404", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Not Found" }), { status: 404 })
+    );
+
+    await expect(fetchGitHubMetadata("owner", "nonexistent")).rejects.toThrow(
+      GitHubError
+    );
+    try {
+      await fetchGitHubMetadata("owner", "nonexistent");
+    } catch (err) {
+      expect((err as GitHubError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("throws RATE_LIMITED for 403 with zero remaining", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Rate limit" }), {
+        status: 403,
+        headers: { "X-RateLimit-Remaining": "0" },
+      })
+    );
+
+    await expect(fetchGitHubMetadata("owner", "repo")).rejects.toThrow(
+      GitHubError
+    );
+    try {
+      await fetchGitHubMetadata("owner", "repo");
+    } catch (err) {
+      expect((err as GitHubError).code).toBe("RATE_LIMITED");
+    }
+  });
+
+  it("throws FORBIDDEN for 403 without rate limit header", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Forbidden" }), { status: 403 })
+    );
+
+    await expect(fetchGitHubMetadata("owner", "repo")).rejects.toThrow(
+      GitHubError
+    );
+    try {
+      await fetchGitHubMetadata("owner", "repo");
+    } catch (err) {
+      expect((err as GitHubError).code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("throws UPSTREAM_ERROR for 500", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Server error" }), { status: 500 })
+    );
+
+    await expect(fetchGitHubMetadata("owner", "repo")).rejects.toThrow(
+      GitHubError
+    );
+    try {
+      await fetchGitHubMetadata("owner", "repo");
+    } catch (err) {
+      expect((err as GitHubError).code).toBe("UPSTREAM_ERROR");
+    }
+  });
+
+  it("throws NETWORK_ERROR on fetch failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network failed"));
+
+    await expect(fetchGitHubMetadata("owner", "repo")).rejects.toThrow(
+      GitHubError
+    );
+    try {
+      await fetchGitHubMetadata("owner", "repo");
+    } catch (err) {
+      expect((err as GitHubError).code).toBe("NETWORK_ERROR");
+    }
+  });
+
+  it("throws TIMEOUT on timeout error", async () => {
+    const timeoutError = new Error("Timeout");
+    timeoutError.name = "TimeoutError";
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(timeoutError);
+
+    await expect(fetchGitHubMetadata("owner", "repo")).rejects.toThrow(
+      GitHubError
+    );
+    try {
+      await fetchGitHubMetadata("owner", "repo");
+    } catch (err) {
+      expect((err as GitHubError).code).toBe("TIMEOUT");
+    }
+  });
+
+  it("uses fallback values when API response missing fields", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({}), // empty response
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const result = await fetchGitHubMetadata("owner", "repo");
+
+    expect(result.owner).toBe("owner"); // fallback to input
+    expect(result.name).toBe("repo"); // fallback to input
+    expect(result.title).toBe("owner/repo"); // fallback
+    expect(result.description).toBeNull();
+    expect(result.fullName).toBe("owner/repo"); // fallback
+  });
+
+  it("sends correct headers", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: "repo",
+          full_name: "owner/repo",
+          owner: { login: "owner" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    await fetchGitHubMetadata("owner", "repo");
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://api.github.com/repos/owner/repo");
+    expect(init!.headers).toEqual(
+      expect.objectContaining({
+        "User-Agent": "pew-showcase/1.0",
+        Accept: "application/vnd.github.v3+json",
+      })
+    );
+  });
+});

--- a/packages/web/src/__tests__/navigation.test.ts
+++ b/packages/web/src/__tests__/navigation.test.ts
@@ -23,11 +23,11 @@ describe("sidebar navigation", () => {
       expect(labels).not.toContain("Account");
     });
 
-    it("Settings group should contain Teams, Projects, Devices, then General", () => {
+    it("Settings group should contain Teams, Projects, Devices, Showcases, then General", () => {
       const settingsGroup = BASE_NAV_GROUPS.find((g) => g.label === "Settings");
       expect(settingsGroup).toBeDefined();
       const items = settingsGroup!.items.map((i) => i.label);
-      expect(items).toEqual(["Teams", "Projects", "Devices", "General"]);
+      expect(items).toEqual(["Teams", "Projects", "Devices", "Showcases", "General"]);
     });
 
     it("Teams should link to /teams", () => {
@@ -217,6 +217,7 @@ describe("route labels", () => {
       devices: "By Device",
       "manage-devices": "Devices",
       leaderboard: "Leaderboard",
+      showcases: "Showcases",
       admin: "Admin",
       seasons: "Seasons",
       storage: "Storage",

--- a/packages/web/src/__tests__/showcase-detail.test.ts
+++ b/packages/web/src/__tests__/showcase-detail.test.ts
@@ -1,0 +1,505 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GET, PATCH, DELETE } from "@/app/api/showcases/[id]/route";
+
+// Mock dependencies
+vi.mock("@/lib/auth-helpers", () => ({
+  resolveUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDbRead: vi.fn(),
+  getDbWrite: vi.fn(),
+}));
+
+vi.mock("@/lib/admin", () => ({
+  isAdmin: vi.fn(),
+}));
+
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead, getDbWrite } from "@/lib/db";
+import { isAdmin } from "@/lib/admin";
+
+const mockResolveUser = vi.mocked(resolveUser);
+const mockGetDbRead = vi.mocked(getDbRead);
+const mockGetDbWrite = vi.mocked(getDbWrite);
+const mockIsAdmin = vi.mocked(isAdmin);
+
+function createRequest(method: string, body?: unknown): Request {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  return new Request("http://localhost/api/showcases/s1", init);
+}
+
+function createContext(id: string = "s1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+const mockShowcase = {
+  id: "s1",
+  user_id: "u1",
+  repo_key: "owner/repo",
+  github_url: "https://github.com/owner/repo",
+  title: "My Repo",
+  description: "A cool project",
+  tagline: "Check this out!",
+  og_image_url: "https://og.test/1/owner/repo",
+  is_public: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  refreshed_at: "2026-01-01T00:00:00Z",
+  user_name: "Test User",
+  user_nickname: null,
+  user_image: null,
+  user_slug: "testuser",
+  upvote_count: 5,
+  has_upvoted: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/showcases/[id]
+// ---------------------------------------------------------------------------
+
+describe("GET /api/showcases/[id]", () => {
+  it("returns public showcase without auth", async () => {
+    mockResolveUser.mockResolvedValue(null);
+    const mockDb = {
+      firstOrNull: vi.fn().mockResolvedValue({ ...mockShowcase, has_upvoted: undefined }),
+    };
+    mockGetDbRead.mockResolvedValue(mockDb as never);
+
+    const res = await GET(createRequest("GET"), createContext());
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.id).toBe("s1");
+    expect(json.has_upvoted).toBeNull();
+  });
+
+  it("includes has_upvoted when authenticated", async () => {
+    mockResolveUser.mockResolvedValue({ userId: "u2", email: "test@example.com" });
+    mockIsAdmin.mockReturnValue(false);
+    const mockDb = {
+      firstOrNull: vi.fn().mockResolvedValue(mockShowcase),
+    };
+    mockGetDbRead.mockResolvedValue(mockDb as never);
+
+    const res = await GET(createRequest("GET"), createContext());
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.has_upvoted).toBe(true);
+  });
+
+  it("returns 404 for non-existent showcase", async () => {
+    mockResolveUser.mockResolvedValue(null);
+    const mockDb = {
+      firstOrNull: vi.fn().mockResolvedValue(null),
+    };
+    mockGetDbRead.mockResolvedValue(mockDb as never);
+
+    const res = await GET(createRequest("GET"), createContext());
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for hidden showcase to non-owner", async () => {
+    mockResolveUser.mockResolvedValue({ userId: "u2", email: "test@example.com" });
+    mockIsAdmin.mockReturnValue(false);
+    const mockDb = {
+      firstOrNull: vi.fn().mockResolvedValue({ ...mockShowcase, is_public: 0 }),
+    };
+    mockGetDbRead.mockResolvedValue(mockDb as never);
+
+    const res = await GET(createRequest("GET"), createContext());
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns hidden showcase to owner", async () => {
+    mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+    mockIsAdmin.mockReturnValue(false);
+    const mockDb = {
+      firstOrNull: vi.fn().mockResolvedValue({ ...mockShowcase, is_public: 0 }),
+    };
+    mockGetDbRead.mockResolvedValue(mockDb as never);
+
+    const res = await GET(createRequest("GET"), createContext());
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.is_public).toBe(false);
+  });
+
+  it("returns hidden showcase to admin", async () => {
+    mockResolveUser.mockResolvedValue({ userId: "admin", email: "admin@example.com" });
+    mockIsAdmin.mockReturnValue(true);
+    const mockDb = {
+      firstOrNull: vi.fn().mockResolvedValue({ ...mockShowcase, is_public: 0 }),
+    };
+    mockGetDbRead.mockResolvedValue(mockDb as never);
+
+    const res = await GET(createRequest("GET"), createContext());
+
+    expect(res.status).toBe(200);
+  });
+
+  it("handles missing table gracefully", async () => {
+    mockResolveUser.mockResolvedValue(null);
+    const mockDb = {
+      firstOrNull: vi.fn().mockRejectedValue(new Error("no such table: showcases")),
+    };
+    mockGetDbRead.mockResolvedValue(mockDb as never);
+
+    const res = await GET(createRequest("GET"), createContext());
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 on unexpected DB error", async () => {
+    mockResolveUser.mockResolvedValue(null);
+    const mockDb = {
+      firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+    };
+    mockGetDbRead.mockResolvedValue(mockDb as never);
+
+    const res = await GET(createRequest("GET"), createContext());
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Failed to get showcase");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/showcases/[id]
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/showcases/[id]", () => {
+  describe("authentication", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockResolveUser.mockResolvedValue(null);
+
+      const res = await PATCH(createRequest("PATCH", { tagline: "New" }), createContext());
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("authorization", () => {
+    it("allows owner to update", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await PATCH(createRequest("PATCH", { tagline: "Updated" }), createContext());
+
+      expect(res.status).toBe(200);
+    });
+
+    it("allows admin to update any showcase", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "admin", email: "admin@example.com" });
+      mockIsAdmin.mockReturnValue(true);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await PATCH(createRequest("PATCH", { is_public: false }), createContext());
+
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 403 for non-owner non-admin", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u2", email: "other@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await PATCH(createRequest("PATCH", { tagline: "Hacked" }), createContext());
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 404 when showcase not found", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(null),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await PATCH(createRequest("PATCH", { tagline: "Updated" }), createContext());
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("validation", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+    });
+
+    it("returns 400 for invalid JSON", async () => {
+      const req = new Request("http://localhost/api/showcases/s1", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      });
+
+      const res = await PATCH(req, createContext());
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("Invalid JSON");
+    });
+
+    it("returns 400 when tagline is not a string", async () => {
+      const res = await PATCH(createRequest("PATCH", { tagline: 123 }), createContext());
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("tagline must be a string");
+    });
+
+    it("returns 400 when tagline exceeds 280 chars", async () => {
+      const res = await PATCH(createRequest("PATCH", { tagline: "a".repeat(281) }), createContext());
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("280 characters");
+    });
+
+    it("returns 400 when is_public is not boolean", async () => {
+      const res = await PATCH(createRequest("PATCH", { is_public: "yes" }), createContext());
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("is_public must be a boolean");
+    });
+
+    it("returns 400 when no fields to update", async () => {
+      const res = await PATCH(createRequest("PATCH", {}), createContext());
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("No fields to update");
+    });
+
+    it("allows clearing tagline with null", async () => {
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await PATCH(createRequest("PATCH", { tagline: null }), createContext());
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles missing table gracefully", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("no such table: showcases")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await PATCH(createRequest("PATCH", { tagline: "New" }), createContext());
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 500 on DB read error", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await PATCH(createRequest("PATCH", { tagline: "New" }), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to find showcase");
+    });
+
+    it("returns 500 on DB write error", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockRejectedValue(new Error("Disk full")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await PATCH(createRequest("PATCH", { tagline: "New" }), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to update showcase");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/showcases/[id]
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/showcases/[id]", () => {
+  describe("authentication", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockResolveUser.mockResolvedValue(null);
+
+      const res = await DELETE(createRequest("DELETE"), createContext());
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("authorization", () => {
+    it("allows owner to delete", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await DELETE(createRequest("DELETE"), createContext());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.success).toBe(true);
+    });
+
+    it("allows admin to delete any showcase", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "admin", email: "admin@example.com" });
+      mockIsAdmin.mockReturnValue(true);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await DELETE(createRequest("DELETE"), createContext());
+
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 403 for non-owner non-admin", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u2", email: "other@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await DELETE(createRequest("DELETE"), createContext());
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 404 when showcase not found", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(null),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await DELETE(createRequest("DELETE"), createContext());
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles missing table gracefully", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("no such table: showcases")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await DELETE(createRequest("DELETE"), createContext());
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 500 on DB read error", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await DELETE(createRequest("DELETE"), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to find showcase");
+    });
+
+    it("returns 500 on DB write error", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      mockIsAdmin.mockReturnValue(false);
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", user_id: "u1" }),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockRejectedValue(new Error("Disk full")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await DELETE(createRequest("DELETE"), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to delete showcase");
+    });
+  });
+});

--- a/packages/web/src/__tests__/showcase-preview.test.ts
+++ b/packages/web/src/__tests__/showcase-preview.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { POST } from "@/app/api/showcases/preview/route";
+
+// Mock dependencies
+vi.mock("@/lib/auth-helpers", () => ({
+  resolveUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDbRead: vi.fn(),
+}));
+
+vi.mock("@/lib/github", () => ({
+  normalizeGitHubUrl: vi.fn(),
+  fetchGitHubMetadata: vi.fn(),
+  buildOgImageUrl: vi.fn(),
+  GitHubError: class GitHubError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+      this.name = "GitHubError";
+    }
+  },
+  gitHubErrorToStatus: vi.fn(),
+  gitHubErrorMessage: vi.fn(),
+}));
+
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead } from "@/lib/db";
+import {
+  normalizeGitHubUrl,
+  fetchGitHubMetadata,
+  buildOgImageUrl,
+  GitHubError,
+  gitHubErrorToStatus,
+  gitHubErrorMessage,
+} from "@/lib/github";
+
+const mockResolveUser = vi.mocked(resolveUser);
+const mockGetDbRead = vi.mocked(getDbRead);
+const mockNormalizeGitHubUrl = vi.mocked(normalizeGitHubUrl);
+const mockFetchGitHubMetadata = vi.mocked(fetchGitHubMetadata);
+const mockBuildOgImageUrl = vi.mocked(buildOgImageUrl);
+const mockGitHubErrorToStatus = vi.mocked(gitHubErrorToStatus);
+const mockGitHubErrorMessage = vi.mocked(gitHubErrorMessage);
+
+function createRequest(body: unknown): Request {
+  return new Request("http://localhost/api/showcases/preview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/showcases/preview", () => {
+  describe("authentication", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockResolveUser.mockResolvedValue(null);
+
+      const res = await POST(createRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error).toBe("Unauthorized");
+    });
+  });
+
+  describe("validation", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+    });
+
+    it("returns 400 for invalid JSON", async () => {
+      const req = new Request("http://localhost/api/showcases/preview", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("Invalid JSON");
+    });
+
+    it("returns 400 when github_url is missing", async () => {
+      const res = await POST(createRequest({}));
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("github_url is required");
+    });
+
+    it("returns 400 when github_url is not a string", async () => {
+      const res = await POST(createRequest({ github_url: 123 }));
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("github_url is required");
+    });
+
+    it("returns 400 for invalid GitHub URL format", async () => {
+      mockNormalizeGitHubUrl.mockReturnValue(null);
+
+      const res = await POST(createRequest({ github_url: "https://github.com/owner" }));
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("Invalid GitHub repository URL");
+    });
+  });
+
+  describe("GitHub API errors", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      mockNormalizeGitHubUrl.mockReturnValue({
+        repoKey: "owner/repo",
+        displayUrl: "https://github.com/owner/repo",
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("returns 404 when repo not found", async () => {
+      const error = new GitHubError("NOT_FOUND", "Not found");
+      mockFetchGitHubMetadata.mockRejectedValue(error);
+      mockGitHubErrorToStatus.mockReturnValue(404);
+      mockGitHubErrorMessage.mockReturnValue("Repository not found or is private");
+
+      const res = await POST(createRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error).toBe("Repository not found or is private");
+    });
+
+    it("returns 422 when rate limited", async () => {
+      const error = new GitHubError("RATE_LIMITED", "Rate limited");
+      mockFetchGitHubMetadata.mockRejectedValue(error);
+      mockGitHubErrorToStatus.mockReturnValue(422);
+      mockGitHubErrorMessage.mockReturnValue("GitHub API rate limit exceeded");
+
+      const res = await POST(createRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(422);
+      const json = await res.json();
+      expect(json.error).toBe("GitHub API rate limit exceeded");
+    });
+  });
+
+  describe("successful preview", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      mockNormalizeGitHubUrl.mockReturnValue({
+        repoKey: "owner/repo",
+        displayUrl: "https://github.com/owner/repo",
+        owner: "owner",
+        repo: "repo",
+      });
+      mockFetchGitHubMetadata.mockResolvedValue({
+        owner: "owner",
+        name: "repo",
+        title: "My Repo",
+        description: "A cool project",
+        fullName: "owner/repo",
+      });
+      mockBuildOgImageUrl.mockReturnValue("https://opengraph.githubassets.com/1/owner/repo");
+    });
+
+    it("returns preview data for new repo", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue(null),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await POST(createRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({
+        repo_key: "owner/repo",
+        github_url: "https://github.com/owner/repo",
+        title: "My Repo",
+        description: "A cool project",
+        og_image_url: "https://opengraph.githubassets.com/1/owner/repo",
+        already_exists: false,
+      });
+    });
+
+    it("returns already_exists=true for existing repo", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "existing-id" }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await POST(createRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.already_exists).toBe(true);
+    });
+
+    it("handles missing table gracefully", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("no such table: showcases")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await POST(createRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.already_exists).toBe(false);
+    });
+
+    it("returns 500 on unexpected DB error", async () => {
+      const mockDb = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await POST(createRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to check showcase existence");
+    });
+  });
+});

--- a/packages/web/src/__tests__/showcase-refresh.test.ts
+++ b/packages/web/src/__tests__/showcase-refresh.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { POST } from "@/app/api/showcases/[id]/refresh/route";
+
+// Mock dependencies
+vi.mock("@/lib/auth-helpers", () => ({
+  resolveUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDbRead: vi.fn(),
+  getDbWrite: vi.fn(),
+}));
+
+vi.mock("@/lib/github", () => ({
+  fetchGitHubMetadata: vi.fn(),
+  buildOgImageUrl: vi.fn(),
+  GitHubError: class GitHubError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+      this.name = "GitHubError";
+    }
+  },
+  gitHubErrorToStatus: vi.fn(),
+  gitHubErrorMessage: vi.fn(),
+}));
+
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead, getDbWrite } from "@/lib/db";
+import {
+  fetchGitHubMetadata,
+  buildOgImageUrl,
+  GitHubError,
+  gitHubErrorToStatus,
+  gitHubErrorMessage,
+} from "@/lib/github";
+
+const mockResolveUser = vi.mocked(resolveUser);
+const mockGetDbRead = vi.mocked(getDbRead);
+const mockGetDbWrite = vi.mocked(getDbWrite);
+const mockFetchGitHubMetadata = vi.mocked(fetchGitHubMetadata);
+const mockBuildOgImageUrl = vi.mocked(buildOgImageUrl);
+const mockGitHubErrorToStatus = vi.mocked(gitHubErrorToStatus);
+const mockGitHubErrorMessage = vi.mocked(gitHubErrorMessage);
+
+function createRequest(): Request {
+  return new Request("http://localhost/api/showcases/s1/refresh", {
+    method: "POST",
+  });
+}
+
+function createContext(id: string = "s1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+const mockShowcase = {
+  id: "s1",
+  user_id: "u1",
+  repo_key: "owner/repo",
+  github_url: "https://github.com/owner/repo",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/showcases/[id]/refresh
+// ---------------------------------------------------------------------------
+
+describe("POST /api/showcases/[id]/refresh", () => {
+  describe("authentication", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockResolveUser.mockResolvedValue(null);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("authorization", () => {
+    it("returns 403 for non-owner", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u2", email: "other@example.com" });
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(mockShowcase),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 404 when showcase not found", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(null),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("successful refresh", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+    });
+
+    it("updates metadata from GitHub", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(mockShowcase),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+      mockFetchGitHubMetadata.mockResolvedValue({
+        owner: "owner",
+        name: "repo",
+        title: "Updated Title",
+        description: "New description",
+        fullName: "owner/repo",
+      });
+      mockBuildOgImageUrl.mockReturnValue("https://og.test/1/owner/repo");
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.title).toBe("Updated Title");
+      expect(json.description).toBe("New description");
+      expect(json.repo_key).toBe("owner/repo");
+      expect(json.refreshed_at).toBeDefined();
+    });
+
+    it("handles repo rename without conflict", async () => {
+      const mockDbRead = {
+        firstOrNull: vi
+          .fn()
+          .mockResolvedValueOnce(mockShowcase) // First call: find showcase
+          .mockResolvedValueOnce(null), // Second call: check conflict
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+      mockFetchGitHubMetadata.mockResolvedValue({
+        owner: "newowner",
+        name: "newrepo",
+        title: "New Repo Name",
+        description: "Desc",
+        fullName: "newowner/newrepo",
+      });
+      mockBuildOgImageUrl.mockReturnValue("https://og.test/1/newowner/newrepo");
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.repo_key).toBe("newowner/newrepo");
+      expect(json.github_url).toBe("https://github.com/newowner/newrepo");
+    });
+
+    it("returns 409 when renamed repo conflicts with existing showcase", async () => {
+      const mockDbRead = {
+        firstOrNull: vi
+          .fn()
+          .mockResolvedValueOnce(mockShowcase) // First call: find showcase
+          .mockResolvedValueOnce({ id: "s2" }), // Second call: conflict exists
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockFetchGitHubMetadata.mockResolvedValue({
+        owner: "existing",
+        name: "repo",
+        title: "Existing",
+        description: null,
+        fullName: "existing/repo",
+      });
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(409);
+      const json = await res.json();
+      expect(json.error).toContain("already showcased");
+    });
+  });
+
+  describe("GitHub API errors", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(mockShowcase),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+    });
+
+    it("returns 410 when repo was deleted", async () => {
+      const error = new GitHubError("NOT_FOUND", "Not found");
+      mockFetchGitHubMetadata.mockRejectedValue(error);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(410);
+      const json = await res.json();
+      expect(json.error).toContain("deleted or made private");
+    });
+
+    it("returns 422 on rate limit", async () => {
+      const error = new GitHubError("RATE_LIMITED", "Rate limited");
+      mockFetchGitHubMetadata.mockRejectedValue(error);
+      mockGitHubErrorToStatus.mockReturnValue(422);
+      mockGitHubErrorMessage.mockReturnValue("GitHub API rate limit exceeded");
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(422);
+    });
+
+    it("returns 500 on unexpected GitHub error", async () => {
+      mockFetchGitHubMetadata.mockRejectedValue(new Error("Network error"));
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to fetch repository information");
+    });
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "owner@example.com" });
+    });
+
+    it("handles missing table gracefully", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("no such table: showcases")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 500 on DB read error", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to find showcase");
+    });
+
+    it("returns 500 on DB write error", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(mockShowcase),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockRejectedValue(new Error("Disk full")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+      mockFetchGitHubMetadata.mockResolvedValue({
+        owner: "owner",
+        name: "repo",
+        title: "Title",
+        description: null,
+        fullName: "owner/repo",
+      });
+      mockBuildOgImageUrl.mockReturnValue("https://og.test/1/owner/repo");
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to update showcase");
+    });
+
+    it("returns 500 on conflict check error", async () => {
+      const mockDbRead = {
+        firstOrNull: vi
+          .fn()
+          .mockResolvedValueOnce(mockShowcase)
+          .mockRejectedValueOnce(new Error("DB error")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockFetchGitHubMetadata.mockResolvedValue({
+        owner: "newowner",
+        name: "newrepo",
+        title: "New",
+        description: null,
+        fullName: "newowner/newrepo",
+      });
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to check for conflict");
+    });
+
+    it("returns 500 for invalid stored GitHub URL", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({
+          ...mockShowcase,
+          github_url: "invalid-url",
+        }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Invalid stored GitHub URL");
+    });
+  });
+});

--- a/packages/web/src/__tests__/showcase-upvote.test.ts
+++ b/packages/web/src/__tests__/showcase-upvote.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { POST } from "@/app/api/showcases/[id]/upvote/route";
+
+// Mock dependencies
+vi.mock("@/lib/auth-helpers", () => ({
+  resolveUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDbRead: vi.fn(),
+  getDbWrite: vi.fn(),
+}));
+
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead, getDbWrite } from "@/lib/db";
+
+const mockResolveUser = vi.mocked(resolveUser);
+const mockGetDbRead = vi.mocked(getDbRead);
+const mockGetDbWrite = vi.mocked(getDbWrite);
+
+function createRequest(): Request {
+  return new Request("http://localhost/api/showcases/s1/upvote", {
+    method: "POST",
+  });
+}
+
+function createContext(id: string = "s1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/showcases/[id]/upvote
+// ---------------------------------------------------------------------------
+
+describe("POST /api/showcases/[id]/upvote", () => {
+  describe("authentication", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockResolveUser.mockResolvedValue(null);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("showcase validation", () => {
+    it("returns 404 when showcase not found", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(null),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 403 when showcase is hidden", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "s1", is_public: 0 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error).toContain("hidden showcase");
+    });
+  });
+
+  describe("upvote toggle", () => {
+    it("adds upvote when not upvoted", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      const mockDbRead = {
+        firstOrNull: vi
+          .fn()
+          .mockResolvedValueOnce({ id: "s1", is_public: 1 }) // Check showcase
+          .mockResolvedValueOnce(null) // Check existing upvote
+          .mockResolvedValueOnce({ count: 5 }), // Get count
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.upvoted).toBe(true);
+      expect(json.upvote_count).toBe(5);
+      expect(mockDbWrite.execute).toHaveBeenCalledWith(
+        "INSERT INTO showcase_upvotes (showcase_id, user_id) VALUES (?, ?)",
+        ["s1", "u1"]
+      );
+    });
+
+    it("removes upvote when already upvoted", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      const mockDbRead = {
+        firstOrNull: vi
+          .fn()
+          .mockResolvedValueOnce({ id: "s1", is_public: 1 }) // Check showcase
+          .mockResolvedValueOnce({ id: 123 }) // Check existing upvote
+          .mockResolvedValueOnce({ count: 4 }), // Get count
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.upvoted).toBe(false);
+      expect(json.upvote_count).toBe(4);
+      expect(mockDbWrite.execute).toHaveBeenCalledWith(
+        "DELETE FROM showcase_upvotes WHERE showcase_id = ? AND user_id = ?",
+        ["s1", "u1"]
+      );
+    });
+
+    it("handles count query failure gracefully", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      const mockDbRead = {
+        firstOrNull: vi
+          .fn()
+          .mockResolvedValueOnce({ id: "s1", is_public: 1 }) // Check showcase
+          .mockResolvedValueOnce(null) // Check existing upvote
+          .mockRejectedValueOnce(new Error("DB error")), // Get count fails
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ changes: 1 }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      // Should still return 200 with count 0
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.upvoted).toBe(true);
+      expect(json.upvote_count).toBe(0);
+    });
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+    });
+
+    it("handles missing table gracefully", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("no such table: showcases")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 500 on showcase lookup error", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to find showcase");
+    });
+
+    it("returns 500 on upvote check error", async () => {
+      const mockDbRead = {
+        firstOrNull: vi
+          .fn()
+          .mockResolvedValueOnce({ id: "s1", is_public: 1 })
+          .mockRejectedValueOnce(new Error("DB error")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to check upvote status");
+    });
+
+    it("returns 500 on upvote toggle error", async () => {
+      const mockDbRead = {
+        firstOrNull: vi
+          .fn()
+          .mockResolvedValueOnce({ id: "s1", is_public: 1 })
+          .mockResolvedValueOnce(null),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockRejectedValue(new Error("Disk full")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await POST(createRequest(), createContext());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to toggle upvote");
+    });
+  });
+});

--- a/packages/web/src/__tests__/showcases-list-create.test.ts
+++ b/packages/web/src/__tests__/showcases-list-create.test.ts
@@ -1,0 +1,496 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GET, POST } from "@/app/api/showcases/route";
+
+// Mock dependencies
+vi.mock("@/lib/auth-helpers", () => ({
+  resolveUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDbRead: vi.fn(),
+  getDbWrite: vi.fn(),
+}));
+
+vi.mock("@/lib/github", () => ({
+  normalizeGitHubUrl: vi.fn(),
+  fetchGitHubMetadata: vi.fn(),
+  buildOgImageUrl: vi.fn(),
+  GitHubError: class GitHubError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+      this.name = "GitHubError";
+    }
+  },
+  gitHubErrorToStatus: vi.fn(),
+  gitHubErrorMessage: vi.fn(),
+}));
+
+vi.mock("nanoid", () => ({
+  nanoid: () => "test-nanoid-123",
+}));
+
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead, getDbWrite } from "@/lib/db";
+import {
+  normalizeGitHubUrl,
+  fetchGitHubMetadata,
+  buildOgImageUrl,
+  GitHubError,
+  gitHubErrorToStatus,
+  gitHubErrorMessage,
+} from "@/lib/github";
+
+const mockResolveUser = vi.mocked(resolveUser);
+const mockGetDbRead = vi.mocked(getDbRead);
+const mockGetDbWrite = vi.mocked(getDbWrite);
+const mockNormalizeGitHubUrl = vi.mocked(normalizeGitHubUrl);
+const mockFetchGitHubMetadata = vi.mocked(fetchGitHubMetadata);
+const mockBuildOgImageUrl = vi.mocked(buildOgImageUrl);
+const mockGitHubErrorToStatus = vi.mocked(gitHubErrorToStatus);
+const mockGitHubErrorMessage = vi.mocked(gitHubErrorMessage);
+
+function createGetRequest(params: Record<string, string> = {}): Request {
+  const url = new URL("http://localhost/api/showcases");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new Request(url.toString(), { method: "GET" });
+}
+
+function createPostRequest(body: unknown): Request {
+  return new Request("http://localhost/api/showcases", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/showcases
+// ---------------------------------------------------------------------------
+
+describe("GET /api/showcases", () => {
+  describe("public list (no mine param)", () => {
+    it("returns public showcases without auth", async () => {
+      mockResolveUser.mockResolvedValue(null);
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 1 }),
+        query: vi.fn().mockResolvedValue({
+          results: [
+            {
+              id: "s1",
+              user_id: "u1",
+              repo_key: "owner/repo",
+              github_url: "https://github.com/owner/repo",
+              title: "My Repo",
+              description: "A cool project",
+              tagline: null,
+              og_image_url: "https://og.test/1/owner/repo",
+              is_public: 1,
+              created_at: "2026-01-01T00:00:00Z",
+              refreshed_at: "2026-01-01T00:00:00Z",
+              user_name: "Test User",
+              user_nickname: null,
+              user_image: null,
+              user_slug: "testuser",
+              upvote_count: 5,
+            },
+          ],
+        }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createGetRequest());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.showcases).toHaveLength(1);
+      expect(json.showcases[0].id).toBe("s1");
+      expect(json.showcases[0].has_upvoted).toBeNull(); // unauthenticated
+      expect(json.total).toBe(1);
+    });
+
+    it("includes has_upvoted when authenticated", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u2", email: "test@example.com" });
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 1 }),
+        query: vi.fn().mockResolvedValue({
+          results: [
+            {
+              id: "s1",
+              user_id: "u1",
+              repo_key: "owner/repo",
+              github_url: "https://github.com/owner/repo",
+              title: "My Repo",
+              description: null,
+              tagline: null,
+              og_image_url: null,
+              is_public: 1,
+              created_at: "2026-01-01T00:00:00Z",
+              refreshed_at: "2026-01-01T00:00:00Z",
+              user_name: "Test User",
+              user_nickname: null,
+              user_image: null,
+              user_slug: null,
+              upvote_count: 3,
+              has_upvoted: 1,
+            },
+          ],
+        }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createGetRequest());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.showcases[0].has_upvoted).toBe(true);
+    });
+
+    it("respects limit and offset params", async () => {
+      mockResolveUser.mockResolvedValue(null);
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 50 }),
+        query: vi.fn().mockResolvedValue({ results: [] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createGetRequest({ limit: "10", offset: "20" }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.limit).toBe(10);
+      expect(json.offset).toBe(20);
+      expect(json.total).toBe(50);
+    });
+
+    it("caps limit at 100", async () => {
+      mockResolveUser.mockResolvedValue(null);
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 0 }),
+        query: vi.fn().mockResolvedValue({ results: [] }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createGetRequest({ limit: "200" }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.limit).toBe(100);
+    });
+
+    it("handles missing table gracefully", async () => {
+      mockResolveUser.mockResolvedValue(null);
+      const mockDb = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("no such table: showcases")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createGetRequest());
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.showcases).toEqual([]);
+      expect(json.total).toBe(0);
+    });
+
+    it("returns 500 on unexpected DB error", async () => {
+      mockResolveUser.mockResolvedValue(null);
+      const mockDb = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createGetRequest());
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to list showcases");
+    });
+  });
+
+  describe("mine=1 (user's showcases)", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockResolveUser.mockResolvedValue(null);
+
+      const res = await GET(createGetRequest({ mine: "1" }));
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns user's showcases including hidden", async () => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      const mockDb = {
+        firstOrNull: vi.fn().mockResolvedValue({ count: 2 }),
+        query: vi.fn().mockResolvedValue({
+          results: [
+            {
+              id: "s1",
+              user_id: "u1",
+              repo_key: "owner/repo1",
+              github_url: "https://github.com/owner/repo1",
+              title: "Repo 1",
+              description: null,
+              tagline: null,
+              og_image_url: null,
+              is_public: 1,
+              created_at: "2026-01-01T00:00:00Z",
+              refreshed_at: "2026-01-01T00:00:00Z",
+              user_name: "Test",
+              user_nickname: null,
+              user_image: null,
+              user_slug: null,
+              upvote_count: 5,
+              has_upvoted: 0,
+            },
+            {
+              id: "s2",
+              user_id: "u1",
+              repo_key: "owner/repo2",
+              github_url: "https://github.com/owner/repo2",
+              title: "Repo 2",
+              description: null,
+              tagline: null,
+              og_image_url: null,
+              is_public: 0, // hidden
+              created_at: "2026-01-02T00:00:00Z",
+              refreshed_at: "2026-01-02T00:00:00Z",
+              user_name: "Test",
+              user_nickname: null,
+              user_image: null,
+              user_slug: null,
+              upvote_count: 0,
+              has_upvoted: 0,
+            },
+          ],
+        }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDb as never);
+
+      const res = await GET(createGetRequest({ mine: "1" }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.showcases).toHaveLength(2);
+      expect(json.showcases[0].is_public).toBe(true);
+      expect(json.showcases[1].is_public).toBe(false); // actual value
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/showcases
+// ---------------------------------------------------------------------------
+
+describe("POST /api/showcases", () => {
+  describe("authentication", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockResolveUser.mockResolvedValue(null);
+
+      const res = await POST(createPostRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("validation", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+    });
+
+    it("returns 400 for invalid JSON", async () => {
+      const req = new Request("http://localhost/api/showcases", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when github_url is missing", async () => {
+      const res = await POST(createPostRequest({}));
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("github_url is required");
+    });
+
+    it("returns 400 for invalid URL format", async () => {
+      mockNormalizeGitHubUrl.mockReturnValue(null);
+
+      const res = await POST(createPostRequest({ github_url: "invalid" }));
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("Invalid GitHub repository URL");
+    });
+
+    it("returns 400 when tagline exceeds 280 chars", async () => {
+      const res = await POST(createPostRequest({
+        github_url: "https://github.com/owner/repo",
+        tagline: "a".repeat(281),
+      }));
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("280 characters");
+    });
+
+    it("returns 400 when tagline is not a string", async () => {
+      const res = await POST(createPostRequest({
+        github_url: "https://github.com/owner/repo",
+        tagline: 123,
+      }));
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("tagline must be a string");
+    });
+  });
+
+  describe("successful creation", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      mockNormalizeGitHubUrl.mockReturnValue({
+        repoKey: "owner/repo",
+        displayUrl: "https://github.com/owner/repo",
+        owner: "owner",
+        repo: "repo",
+      });
+      mockFetchGitHubMetadata.mockResolvedValue({
+        owner: "owner",
+        name: "repo",
+        title: "My Repo",
+        description: "A cool project",
+        fullName: "owner/repo",
+      });
+      mockBuildOgImageUrl.mockReturnValue("https://og.test/1/owner/repo");
+    });
+
+    it("creates showcase successfully", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(null),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await POST(createPostRequest({
+        github_url: "https://github.com/owner/repo",
+        tagline: "Check this out!",
+      }));
+
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.id).toBe("test-nanoid-123");
+      expect(json.repo_key).toBe("owner/repo");
+      expect(json.title).toBe("My Repo");
+      expect(json.tagline).toBe("Check this out!");
+      expect(json.upvote_count).toBe(0);
+    });
+
+    it("returns 409 when repo already showcased", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue({ id: "existing" }),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createPostRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(409);
+      const json = await res.json();
+      expect(json.error).toContain("already been showcased");
+    });
+
+    it("returns 409 on unique constraint violation", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(null),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockRejectedValue(new Error("UNIQUE constraint failed: showcases.repo_key")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await POST(createPostRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 500 on unexpected DB error during existence check", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+
+      const res = await POST(createPostRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to check showcase existence");
+    });
+
+    it("returns 500 on unexpected DB error during insert", async () => {
+      const mockDbRead = {
+        firstOrNull: vi.fn().mockResolvedValue(null),
+      };
+      const mockDbWrite = {
+        execute: vi.fn().mockRejectedValue(new Error("Disk full")),
+      };
+      mockGetDbRead.mockResolvedValue(mockDbRead as never);
+      mockGetDbWrite.mockResolvedValue(mockDbWrite as never);
+
+      const res = await POST(createPostRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to create showcase");
+    });
+  });
+
+  describe("GitHub API errors", () => {
+    beforeEach(() => {
+      mockResolveUser.mockResolvedValue({ userId: "u1", email: "test@example.com" });
+      mockNormalizeGitHubUrl.mockReturnValue({
+        repoKey: "owner/repo",
+        displayUrl: "https://github.com/owner/repo",
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("returns 404 when repo not found", async () => {
+      const error = new GitHubError("NOT_FOUND", "Not found");
+      mockFetchGitHubMetadata.mockRejectedValue(error);
+      mockGitHubErrorToStatus.mockReturnValue(404);
+      mockGitHubErrorMessage.mockReturnValue("Repository not found");
+
+      const res = await POST(createPostRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 500 on unexpected GitHub fetch error", async () => {
+      mockFetchGitHubMetadata.mockRejectedValue(new Error("Network error"));
+
+      const res = await POST(createPostRequest({ github_url: "https://github.com/owner/repo" }));
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Failed to fetch repository information");
+    });
+  });
+});

--- a/packages/web/src/app/(dashboard)/admin/showcases/admin-showcases-content.tsx
+++ b/packages/web/src/app/(dashboard)/admin/showcases/admin-showcases-content.tsx
@@ -1,0 +1,419 @@
+/**
+ * Client component for admin showcase moderation.
+ */
+
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Eye,
+  EyeOff,
+  Trash2,
+  ExternalLink,
+  RefreshCw,
+  ChevronUp,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ShowcaseImage } from "@/components/showcase";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AdminShowcase {
+  id: string;
+  repo_key: string;
+  github_url: string;
+  title: string;
+  description: string | null;
+  tagline: string | null;
+  og_image_url: string | null;
+  upvote_count: number;
+  is_public: boolean;
+  created_at: string;
+  refreshed_at: string;
+  user: {
+    id: string;
+    email: string;
+    name: string | null;
+    nickname: string | null;
+    image: string | null;
+    slug: string | null;
+  };
+}
+
+interface AdminShowcasesResponse {
+  showcases: AdminShowcase[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 50;
+
+type StatusFilter = "all" | "public" | "hidden";
+
+export function AdminShowcasesContent() {
+  const [data, setData] = useState<AdminShowcasesResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  // Fetch data
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams();
+      params.set("limit", String(PAGE_SIZE));
+      params.set("offset", String(offset));
+      if (statusFilter === "public") params.set("is_public", "1");
+      if (statusFilter === "hidden") params.set("is_public", "0");
+
+      const res = await fetch(`/api/admin/showcases?${params.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
+      }
+
+      const json = (await res.json()) as AdminShowcasesResponse;
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, [offset, statusFilter]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Toggle visibility
+  const handleToggleVisibility = useCallback(async (id: string, currentPublic: boolean) => {
+    setActionLoading(id);
+    try {
+      const res = await fetch(`/api/showcases/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_public: !currentPublic }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? "Failed to update");
+      }
+
+      // Optimistic update
+      setData((prev) =>
+        prev
+          ? {
+              ...prev,
+              showcases: prev.showcases.map((s) =>
+                s.id === id ? { ...s, is_public: !currentPublic } : s
+              ),
+            }
+          : null
+      );
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update showcase");
+    } finally {
+      setActionLoading(null);
+    }
+  }, []);
+
+  // Delete
+  const handleDelete = useCallback(async (id: string) => {
+    if (!confirm("Are you sure you want to delete this showcase? This cannot be undone.")) return;
+
+    setActionLoading(id);
+    try {
+      const res = await fetch(`/api/showcases/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? "Failed to delete");
+      }
+
+      // Remove from list
+      setData((prev) =>
+        prev
+          ? {
+              ...prev,
+              showcases: prev.showcases.filter((s) => s.id !== id),
+              total: prev.total - 1,
+            }
+          : null
+      );
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to delete showcase");
+    } finally {
+      setActionLoading(null);
+    }
+  }, []);
+
+  // Loading state
+  if (loading && !data) {
+    return (
+      <div className="rounded-xl bg-secondary p-1 animate-pulse">
+        <div className="h-64" />
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="rounded-xl bg-destructive/10 p-4 text-sm text-destructive">
+        Failed to load showcases: {error}
+      </div>
+    );
+  }
+
+  const showcases = data?.showcases ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          {/* Status filter */}
+          <div className="flex items-center gap-1 rounded-lg bg-secondary p-1">
+            {(["all", "public", "hidden"] as const).map((opt) => (
+              <button
+                key={opt}
+                onClick={() => {
+                  setStatusFilter(opt);
+                  setOffset(0);
+                }}
+                className={cn(
+                  "rounded-md px-3 py-1.5 text-xs font-medium transition-colors capitalize",
+                  statusFilter === opt
+                    ? "bg-card text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+
+          <span className="text-sm text-muted-foreground ml-2">
+            {total} {total === 1 ? "showcase" : "showcases"}
+          </span>
+        </div>
+
+        <button
+          onClick={() => fetchData()}
+          disabled={loading}
+          className={cn(
+            "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors",
+            loading && "animate-spin"
+          )}
+          title="Refresh"
+        >
+          <RefreshCw className="h-4 w-4" strokeWidth={1.5} />
+        </button>
+      </div>
+
+      {/* Table */}
+      {showcases.length === 0 ? (
+        <div className="rounded-xl bg-secondary p-8 text-center">
+          <p className="text-muted-foreground">No showcases found.</p>
+        </div>
+      ) : (
+        <div className="rounded-xl bg-secondary p-1 overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground">
+                  Showcase
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground hidden md:table-cell">
+                  Submitter
+                </th>
+                <th className="px-4 py-3 text-center text-xs font-medium text-muted-foreground w-20">
+                  Upvotes
+                </th>
+                <th className="px-4 py-3 text-center text-xs font-medium text-muted-foreground w-24">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground w-24">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {showcases.map((showcase) => {
+                const displayName = showcase.user.nickname || showcase.user.name || "Anonymous";
+                const isLoading = actionLoading === showcase.id;
+
+                return (
+                  <tr
+                    key={showcase.id}
+                    className={cn(
+                      "border-b border-border/50 last:border-0 hover:bg-accent/50 transition-colors",
+                      isLoading && "opacity-50"
+                    )}
+                  >
+                    {/* Showcase info */}
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <div className="shrink-0 w-12 aspect-[1.91/1] rounded-md overflow-hidden bg-accent/50">
+                          <ShowcaseImage
+                            url={showcase.og_image_url}
+                            repoKey={showcase.repo_key}
+                            className="w-full h-full"
+                          />
+                        </div>
+                        <div className="min-w-0">
+                          <a
+                            href={showcase.github_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="group flex items-center gap-1.5"
+                          >
+                            <span className="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate">
+                              {showcase.title}
+                            </span>
+                            <ExternalLink className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                          </a>
+                          <p className="text-[10px] text-muted-foreground font-mono">
+                            {showcase.repo_key}
+                          </p>
+                        </div>
+                      </div>
+                    </td>
+
+                    {/* Submitter */}
+                    <td className="px-4 py-3 hidden md:table-cell">
+                      <div className="flex items-center gap-2">
+                        {showcase.user.image ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={showcase.user.image}
+                            alt={displayName}
+                            className="h-6 w-6 rounded-full"
+                          />
+                        ) : (
+                          <div className="h-6 w-6 rounded-full bg-accent flex items-center justify-center">
+                            <span className="text-[10px] font-medium text-muted-foreground">
+                              {displayName.charAt(0).toUpperCase()}
+                            </span>
+                          </div>
+                        )}
+                        <div className="min-w-0">
+                          <p className="text-xs font-medium text-foreground truncate">
+                            {displayName}
+                          </p>
+                          <p className="text-[10px] text-muted-foreground truncate">
+                            {showcase.user.email}
+                          </p>
+                        </div>
+                      </div>
+                    </td>
+
+                    {/* Upvotes */}
+                    <td className="px-4 py-3 text-center">
+                      <span className="inline-flex items-center gap-0.5 text-sm text-muted-foreground tabular-nums">
+                        <ChevronUp className="h-3.5 w-3.5" />
+                        {showcase.upvote_count}
+                      </span>
+                    </td>
+
+                    {/* Status */}
+                    <td className="px-4 py-3 text-center">
+                      {showcase.is_public ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-[10px] font-medium text-success">
+                          <Eye className="h-2.5 w-2.5" />
+                          Public
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          <EyeOff className="h-2.5 w-2.5" />
+                          Hidden
+                        </span>
+                      )}
+                    </td>
+
+                    {/* Actions */}
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          onClick={() => handleToggleVisibility(showcase.id, showcase.is_public)}
+                          disabled={isLoading}
+                          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+                          title={showcase.is_public ? "Hide" : "Show"}
+                        >
+                          {showcase.is_public ? (
+                            <EyeOff className="h-3.5 w-3.5" strokeWidth={1.5} />
+                          ) : (
+                            <Eye className="h-3.5 w-3.5" strokeWidth={1.5} />
+                          )}
+                        </button>
+                        <button
+                          onClick={() => handleDelete(showcase.id)}
+                          disabled={isLoading}
+                          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+                          title="Delete"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" strokeWidth={1.5} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 pt-2">
+          <button
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            disabled={offset === 0 || loading}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-md border border-border transition-colors",
+              offset === 0 || loading
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-accent hover:text-foreground"
+            )}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+
+          <span className="text-sm text-muted-foreground tabular-nums px-2">
+            Page {currentPage} of {totalPages}
+          </span>
+
+          <button
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+            disabled={currentPage >= totalPages || loading}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-md border border-border transition-colors",
+              currentPage >= totalPages || loading
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-accent hover:text-foreground"
+            )}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/(dashboard)/admin/showcases/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/showcases/page.tsx
@@ -1,0 +1,43 @@
+/**
+ * Admin → Showcases moderation page.
+ */
+
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { isAdmin } from "@/lib/admin";
+import { AdminShowcasesContent } from "./admin-showcases-content";
+
+export const metadata = {
+  title: "Showcase Moderation | Admin | pew",
+  description: "Moderate community-submitted showcases.",
+};
+
+export default async function AdminShowcasesPage() {
+  const session = await auth();
+  if (!session?.user?.email || !isAdmin(session.user.email)) {
+    redirect("/");
+  }
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold font-display">Showcase Moderation</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Review and moderate community-submitted GitHub showcases.
+        </p>
+      </div>
+
+      <Suspense
+        fallback={
+          <div className="rounded-xl bg-secondary p-1 animate-pulse">
+            <div className="h-64" />
+          </div>
+        }
+      >
+        <AdminShowcasesContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/packages/web/src/app/(dashboard)/leaderboard/showcases/page.tsx
+++ b/packages/web/src/app/(dashboard)/leaderboard/showcases/page.tsx
@@ -1,0 +1,53 @@
+/**
+ * Leaderboard → Showcases page.
+ *
+ * Public listing of community-submitted GitHub repositories.
+ */
+
+import { Suspense } from "react";
+import { auth } from "@/auth";
+import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
+import { PageHeader } from "@/components/leaderboard/page-header";
+import { ShowcasesContent } from "./showcases-content";
+
+export const metadata = {
+  title: "Showcases | pew",
+  description: "Community-submitted GitHub projects and tools.",
+};
+
+export default async function ShowcasesPage() {
+  const session = await auth();
+  const isLoggedIn = !!session?.user;
+
+  return (
+    <>
+      <PageHeader>
+        <h1 className="text-2xl md:text-3xl font-bold font-display tracking-tight">
+          Showcases
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Community-submitted GitHub projects worth checking out.
+        </p>
+      </PageHeader>
+
+      <main className="flex-1 py-4 space-y-4">
+        <LeaderboardNav />
+
+        <Suspense
+          fallback={
+            <div className="space-y-3 animate-pulse pt-4">
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="h-[120px] rounded-xl bg-secondary"
+                />
+              ))}
+            </div>
+          }
+        >
+          <ShowcasesContent isLoggedIn={isLoggedIn} />
+        </Suspense>
+      </main>
+    </>
+  );
+}

--- a/packages/web/src/app/(dashboard)/leaderboard/showcases/showcases-content.tsx
+++ b/packages/web/src/app/(dashboard)/leaderboard/showcases/showcases-content.tsx
@@ -1,0 +1,171 @@
+/**
+ * Client component for showcases list.
+ */
+
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, RefreshCw, ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useShowcases } from "@/hooks/use-showcases";
+import { ShowcaseCard, ShowcaseFormModal } from "@/components/showcase";
+
+interface ShowcasesContentProps {
+  isLoggedIn: boolean;
+}
+
+const PAGE_SIZE = 20;
+
+export function ShowcasesContent({ isLoggedIn }: ShowcasesContentProps) {
+  const router = useRouter();
+  const [offset, setOffset] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+
+  const { data, loading, refreshing, error, refetch } = useShowcases({
+    limit: PAGE_SIZE,
+    offset,
+  });
+
+  const handleLoginRequired = useCallback(() => {
+    router.push("/login");
+  }, [router]);
+
+  const handleAddSuccess = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="space-y-3 animate-pulse pt-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-[120px] rounded-xl bg-secondary" />
+        ))}
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="rounded-xl bg-destructive/10 p-4 text-sm text-destructive mt-4">
+        Failed to load showcases: {error}
+      </div>
+    );
+  }
+
+  const showcases = data?.showcases ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  return (
+    <div
+      className="space-y-4 animate-fade-up"
+      style={{ animationDelay: "180ms" }}
+    >
+      {/* Toolbar */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">
+            {total} {total === 1 ? "showcase" : "showcases"}
+          </span>
+          <button
+            onClick={() => refetch()}
+            disabled={refreshing}
+            className={cn(
+              "flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors",
+              refreshing && "animate-spin"
+            )}
+            title="Refresh"
+          >
+            <RefreshCw className="h-3.5 w-3.5" strokeWidth={1.5} />
+          </button>
+        </div>
+
+        {isLoggedIn && (
+          <button
+            onClick={() => setShowModal(true)}
+            className="flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            <Plus className="h-4 w-4" strokeWidth={1.5} />
+            Add Showcase
+          </button>
+        )}
+      </div>
+
+      {/* Empty state */}
+      {showcases.length === 0 && (
+        <div className="rounded-xl bg-secondary p-8 text-center">
+          <p className="text-muted-foreground">
+            No showcases yet. Be the first to share a project!
+          </p>
+          {isLoggedIn && (
+            <button
+              onClick={() => setShowModal(true)}
+              className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              <Plus className="h-4 w-4" strokeWidth={1.5} />
+              Add Showcase
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Showcase list */}
+      <div className="space-y-3">
+        {showcases.map((showcase) => (
+          <ShowcaseCard
+            key={showcase.id}
+            showcase={showcase}
+            isLoggedIn={isLoggedIn}
+            onLoginRequired={handleLoginRequired}
+          />
+        ))}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 pt-4">
+          <button
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            disabled={offset === 0}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-md border border-border transition-colors",
+              offset === 0
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-accent hover:text-foreground"
+            )}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+
+          <span className="text-sm text-muted-foreground tabular-nums px-2">
+            Page {currentPage} of {totalPages}
+          </span>
+
+          <button
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+            disabled={currentPage >= totalPages}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-md border border-border transition-colors",
+              currentPage >= totalPages
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-accent hover:text-foreground"
+            )}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Add modal */}
+      <ShowcaseFormModal
+        open={showModal}
+        onOpenChange={setShowModal}
+        onSuccess={handleAddSuccess}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/(dashboard)/settings/showcases/my-showcases-content.tsx
+++ b/packages/web/src/app/(dashboard)/settings/showcases/my-showcases-content.tsx
@@ -1,0 +1,209 @@
+/**
+ * Client component for managing user's own showcases.
+ */
+
+"use client";
+
+import { useState, useCallback } from "react";
+import { Plus, Pencil, Trash2, Eye, EyeOff, ExternalLink, ChevronUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useShowcases, type Showcase } from "@/hooks/use-showcases";
+import { ShowcaseImage, ShowcaseFormModal } from "@/components/showcase";
+
+export function MyShowcasesContent() {
+  const { data, loading, error, refetch } = useShowcases({ mine: true });
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [editShowcase, setEditShowcase] = useState<Showcase | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (!confirm("Are you sure you want to delete this showcase?")) return;
+
+    setDeleting(id);
+    try {
+      const res = await fetch(`/api/showcases/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? "Failed to delete");
+      }
+      refetch();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to delete showcase");
+    } finally {
+      setDeleting(null);
+    }
+  }, [refetch]);
+
+  const handleSuccess = useCallback(() => {
+    refetch();
+    setEditShowcase(null);
+  }, [refetch]);
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="space-y-3 animate-pulse">
+        {[1, 2].map((i) => (
+          <div key={i} className="h-24 rounded-xl bg-secondary" />
+        ))}
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="rounded-xl bg-destructive/10 p-4 text-sm text-destructive">
+        Failed to load showcases: {error}
+      </div>
+    );
+  }
+
+  const showcases = data?.showcases ?? [];
+
+  return (
+    <div className="space-y-4">
+      {/* Add button */}
+      <div className="flex justify-end">
+        <button
+          onClick={() => setShowAddModal(true)}
+          className="flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <Plus className="h-4 w-4" strokeWidth={1.5} />
+          Add Showcase
+        </button>
+      </div>
+
+      {/* Empty state */}
+      {showcases.length === 0 && (
+        <div className="rounded-xl bg-secondary p-8 text-center">
+          <p className="text-muted-foreground">
+            You haven&apos;t submitted any showcases yet.
+          </p>
+          <button
+            onClick={() => setShowAddModal(true)}
+            className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            <Plus className="h-4 w-4" strokeWidth={1.5} />
+            Add Your First Showcase
+          </button>
+        </div>
+      )}
+
+      {/* Showcase list */}
+      <div className="space-y-3">
+        {showcases.map((showcase) => (
+          <div
+            key={showcase.id}
+            className={cn(
+              "flex items-center gap-4 rounded-xl bg-secondary p-4 transition-opacity",
+              deleting === showcase.id && "opacity-50"
+            )}
+          >
+            {/* Thumbnail */}
+            <div className="shrink-0 w-20 aspect-[1.91/1] rounded-lg overflow-hidden bg-accent/50">
+              <ShowcaseImage
+                url={showcase.og_image_url}
+                repoKey={showcase.repo_key}
+                className="w-full h-full"
+              />
+            </div>
+
+            {/* Info */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <a
+                  href={showcase.github_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex items-center gap-1.5"
+                >
+                  <h3 className="text-sm font-semibold text-foreground group-hover:text-primary transition-colors truncate">
+                    {showcase.title}
+                  </h3>
+                  <ExternalLink className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                </a>
+
+                {/* Visibility badge */}
+                {showcase.is_public ? (
+                  <span className="flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-[10px] font-medium text-success">
+                    <Eye className="h-2.5 w-2.5" />
+                    Public
+                  </span>
+                ) : (
+                  <span className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                    <EyeOff className="h-2.5 w-2.5" />
+                    Hidden
+                  </span>
+                )}
+              </div>
+
+              {showcase.tagline && (
+                <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+                  &ldquo;{showcase.tagline}&rdquo;
+                </p>
+              )}
+
+              <div className="flex items-center gap-3 mt-1">
+                <span className="text-[10px] text-muted-foreground font-mono">
+                  {showcase.repo_key}
+                </span>
+                <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground">
+                  <ChevronUp className="h-3 w-3" />
+                  {showcase.upvote_count}
+                </span>
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="shrink-0 flex items-center gap-1">
+              <button
+                onClick={() => setEditShowcase(showcase)}
+                disabled={deleting === showcase.id}
+                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+                title="Edit"
+              >
+                <Pencil className="h-3.5 w-3.5" strokeWidth={1.5} />
+              </button>
+              <button
+                onClick={() => handleDelete(showcase.id)}
+                disabled={deleting === showcase.id}
+                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+                title="Delete"
+              >
+                <Trash2 className="h-3.5 w-3.5" strokeWidth={1.5} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Add modal */}
+      <ShowcaseFormModal
+        open={showAddModal}
+        onOpenChange={setShowAddModal}
+        onSuccess={handleSuccess}
+      />
+
+      {/* Edit modal */}
+      {editShowcase && (
+        <ShowcaseFormModal
+          open={true}
+          onOpenChange={(open) => !open && setEditShowcase(null)}
+          onSuccess={handleSuccess}
+          editMode
+          editData={{
+            id: editShowcase.id,
+            repo_key: editShowcase.repo_key,
+            github_url: editShowcase.github_url,
+            title: editShowcase.title,
+            description: editShowcase.description,
+            og_image_url: editShowcase.og_image_url,
+            tagline: editShowcase.tagline,
+            is_public: editShowcase.is_public,
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/(dashboard)/settings/showcases/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/showcases/page.tsx
@@ -1,0 +1,48 @@
+/**
+ * Settings → Showcases page.
+ *
+ * Manage your submitted showcases.
+ */
+
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { MyShowcasesContent } from "./my-showcases-content";
+
+export const metadata = {
+  title: "My Showcases | Settings | pew",
+  description: "Manage your submitted GitHub showcases.",
+};
+
+export default async function MyShowcasesPage() {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl md:text-3xl font-semibold font-display tracking-tight">
+          My Showcases
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Manage your submitted GitHub projects.
+        </p>
+      </div>
+
+      <Suspense
+        fallback={
+          <div className="space-y-3 animate-pulse">
+            {[1, 2].map((i) => (
+              <div key={i} className="h-24 rounded-xl bg-secondary" />
+            ))}
+          </div>
+        }
+      >
+        <MyShowcasesContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/packages/web/src/app/api/admin/showcases/route.ts
+++ b/packages/web/src/app/api/admin/showcases/route.ts
@@ -1,0 +1,141 @@
+/**
+ * GET /api/admin/showcases — list all showcases (admin only)
+ *
+ * Provides extended user info (email) for moderation purposes.
+ */
+
+import { NextResponse } from "next/server";
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead } from "@/lib/db";
+import { isAdmin } from "@/lib/admin";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ShowcaseRow {
+  id: string;
+  user_id: string;
+  repo_key: string;
+  github_url: string;
+  title: string;
+  description: string | null;
+  tagline: string | null;
+  og_image_url: string | null;
+  is_public: number;
+  created_at: string;
+  refreshed_at: string;
+  // Joined user fields (admin includes email)
+  user_name: string | null;
+  user_nickname: string | null;
+  user_image: string | null;
+  user_slug: string | null;
+  user_email: string;
+  // Computed
+  upvote_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// GET — admin list all showcases
+// ---------------------------------------------------------------------------
+
+export async function GET(request: Request) {
+  const user = await resolveUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isAdmin(user.email)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const isPublicParam = url.searchParams.get("is_public");
+  const userIdParam = url.searchParams.get("user_id");
+  const limit = Math.min(parseInt(url.searchParams.get("limit") || "50", 10), 200);
+  const offset = parseInt(url.searchParams.get("offset") || "0", 10);
+
+  const dbRead = await getDbRead();
+
+  try {
+    // Build WHERE clause
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (isPublicParam !== null) {
+      conditions.push("s.is_public = ?");
+      params.push(isPublicParam === "1" ? 1 : 0);
+    }
+
+    if (userIdParam) {
+      conditions.push("s.user_id = ?");
+      params.push(userIdParam);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    // Get total count
+    const countResult = await dbRead.firstOrNull<{ count: number }>(
+      `SELECT COUNT(*) as count FROM showcases s ${whereClause}`,
+      params
+    );
+    const total = countResult?.count ?? 0;
+
+    // Get showcases
+    const query = `
+      SELECT
+        s.id, s.user_id, s.repo_key, s.github_url, s.title, s.description,
+        s.tagline, s.og_image_url, s.is_public, s.created_at, s.refreshed_at,
+        u.name as user_name, u.nickname as user_nickname, u.image as user_image,
+        u.slug as user_slug, u.email as user_email,
+        (SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = s.id) as upvote_count
+      FROM showcases s
+      JOIN users u ON u.id = s.user_id
+      ${whereClause}
+      ORDER BY s.created_at DESC, s.id DESC
+      LIMIT ? OFFSET ?
+    `;
+    const { results } = await dbRead.query<ShowcaseRow>(query, [
+      ...params,
+      limit,
+      offset,
+    ]);
+
+    return NextResponse.json({
+      showcases: results.map((s) => ({
+        id: s.id,
+        repo_key: s.repo_key,
+        github_url: s.github_url,
+        title: s.title,
+        description: s.description,
+        tagline: s.tagline,
+        og_image_url: s.og_image_url,
+        upvote_count: s.upvote_count,
+        is_public: s.is_public === 1,
+        created_at: s.created_at,
+        refreshed_at: s.refreshed_at,
+        user: {
+          id: s.user_id,
+          email: s.user_email,
+          name: s.user_name,
+          nickname: s.user_nickname,
+          image: s.user_image,
+          slug: s.user_slug,
+        },
+      })),
+      total,
+      limit,
+      offset,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("no such table")) {
+      return NextResponse.json({ showcases: [], total: 0, limit, offset });
+    }
+    console.error("Failed to list showcases:", err);
+    return NextResponse.json(
+      { error: "Failed to list showcases" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/web/src/app/api/showcases/[id]/refresh/route.ts
+++ b/packages/web/src/app/api/showcases/[id]/refresh/route.ts
@@ -1,0 +1,179 @@
+/**
+ * POST /api/showcases/[id]/refresh — re-fetch metadata from GitHub (owner only)
+ *
+ * Updates title, description, og_image_url, refreshed_at.
+ * Handles repo renames/transfers with conflict detection.
+ */
+
+import { NextResponse } from "next/server";
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead, getDbWrite } from "@/lib/db";
+import {
+  fetchGitHubMetadata,
+  buildOgImageUrl,
+  GitHubError,
+  gitHubErrorToStatus,
+  gitHubErrorMessage,
+} from "@/lib/github";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// ---------------------------------------------------------------------------
+// POST — refresh showcase from GitHub
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const user = await resolveUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const dbRead = await getDbRead();
+  const dbWrite = await getDbWrite();
+
+  // Find showcase
+  let showcase: {
+    id: string;
+    user_id: string;
+    repo_key: string;
+    github_url: string;
+  } | null;
+
+  try {
+    showcase = await dbRead.firstOrNull<{
+      id: string;
+      user_id: string;
+      repo_key: string;
+      github_url: string;
+    }>(
+      "SELECT id, user_id, repo_key, github_url FROM showcases WHERE id = ?",
+      [id]
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("no such table")) {
+      return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+    }
+    console.error("Failed to find showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to find showcase" },
+      { status: 500 }
+    );
+  }
+
+  if (!showcase) {
+    return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+  }
+
+  // Access control: owner only
+  if (showcase.user_id !== user.userId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Parse owner/repo from current github_url
+  const urlMatch = showcase.github_url.match(/github\.com\/([^/]+)\/([^/]+)/);
+  if (!urlMatch || !urlMatch[1] || !urlMatch[2]) {
+    return NextResponse.json(
+      { error: "Invalid stored GitHub URL" },
+      { status: 500 }
+    );
+  }
+  const [, currentOwner, currentRepo] = urlMatch;
+
+  // Fetch fresh metadata from GitHub
+  let metadata: {
+    owner: string;
+    name: string;
+    title: string;
+    description: string | null;
+    fullName: string;
+  };
+
+  try {
+    metadata = await fetchGitHubMetadata(currentOwner, currentRepo);
+  } catch (err) {
+    if (err instanceof GitHubError) {
+      if (err.code === "NOT_FOUND") {
+        // Repo was deleted or made private
+        return NextResponse.json(
+          { error: "Repository was deleted or made private" },
+          { status: 410 }
+        );
+      }
+      return NextResponse.json(
+        { error: gitHubErrorMessage(err) },
+        { status: gitHubErrorToStatus(err) }
+      );
+    }
+    console.error("Failed to fetch GitHub metadata:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch repository information" },
+      { status: 500 }
+    );
+  }
+
+  // Check if repo was renamed/transferred
+  const newRepoKey = `${metadata.owner}/${metadata.name}`.toLowerCase();
+  const newGithubUrl = `https://github.com/${metadata.owner}/${metadata.name}`;
+  const ogImageUrl = buildOgImageUrl(metadata.owner, metadata.name);
+  const now = new Date().toISOString();
+
+  if (newRepoKey !== showcase.repo_key) {
+    // Repo was renamed — check for conflict
+    try {
+      const existing = await dbRead.firstOrNull<{ id: string }>(
+        "SELECT id FROM showcases WHERE repo_key = ? AND id != ?",
+        [newRepoKey, id]
+      );
+      if (existing) {
+        return NextResponse.json(
+          {
+            error: `Repository was renamed to ${metadata.owner}/${metadata.name} but that repo is already showcased`,
+          },
+          { status: 409 }
+        );
+      }
+    } catch (err) {
+      console.error("Failed to check for conflict:", err);
+      return NextResponse.json(
+        { error: "Failed to check for conflict" },
+        { status: 500 }
+      );
+    }
+  }
+
+  // Update showcase
+  try {
+    await dbWrite.execute(
+      `UPDATE showcases
+       SET title = ?, description = ?, og_image_url = ?, repo_key = ?, github_url = ?, refreshed_at = ?, updated_at = ?
+       WHERE id = ?`,
+      [
+        metadata.title,
+        metadata.description,
+        ogImageUrl,
+        newRepoKey,
+        newGithubUrl,
+        now,
+        now,
+        id,
+      ]
+    );
+  } catch (err) {
+    console.error("Failed to update showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to update showcase" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    title: metadata.title,
+    description: metadata.description,
+    og_image_url: ogImageUrl,
+    repo_key: newRepoKey,
+    github_url: newGithubUrl,
+    refreshed_at: now,
+  });
+}

--- a/packages/web/src/app/api/showcases/[id]/route.ts
+++ b/packages/web/src/app/api/showcases/[id]/route.ts
@@ -1,0 +1,302 @@
+/**
+ * GET    /api/showcases/[id] — get single showcase
+ * PATCH  /api/showcases/[id] — update showcase (owner or admin)
+ * DELETE /api/showcases/[id] — delete showcase (owner or admin)
+ */
+
+import { NextResponse } from "next/server";
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead, getDbWrite } from "@/lib/db";
+import { isAdmin } from "@/lib/admin";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ShowcaseRow {
+  id: string;
+  user_id: string;
+  repo_key: string;
+  github_url: string;
+  title: string;
+  description: string | null;
+  tagline: string | null;
+  og_image_url: string | null;
+  is_public: number;
+  created_at: string;
+  refreshed_at: string;
+  // Joined user fields
+  user_name: string | null;
+  user_nickname: string | null;
+  user_image: string | null;
+  user_slug: string | null;
+  // Computed
+  upvote_count: number;
+  has_upvoted?: number;
+}
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// ---------------------------------------------------------------------------
+// GET — get single showcase
+// ---------------------------------------------------------------------------
+
+export async function GET(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const user = await resolveUser(request);
+  const admin = user ? isAdmin(user.email) : false;
+
+  const dbRead = await getDbRead();
+
+  try {
+    let showcase: ShowcaseRow | null;
+
+    if (user) {
+      // Authenticated: include has_upvoted
+      showcase = await dbRead.firstOrNull<ShowcaseRow>(
+        `SELECT
+          s.id, s.user_id, s.repo_key, s.github_url, s.title, s.description,
+          s.tagline, s.og_image_url, s.is_public, s.created_at, s.refreshed_at,
+          u.name as user_name, u.nickname as user_nickname, u.image as user_image, u.slug as user_slug,
+          (SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = s.id) as upvote_count,
+          EXISTS(SELECT 1 FROM showcase_upvotes WHERE showcase_id = s.id AND user_id = ?) as has_upvoted
+        FROM showcases s
+        JOIN users u ON u.id = s.user_id
+        WHERE s.id = ?`,
+        [user.userId, id]
+      );
+    } else {
+      // Unauthenticated: no has_upvoted
+      showcase = await dbRead.firstOrNull<ShowcaseRow>(
+        `SELECT
+          s.id, s.user_id, s.repo_key, s.github_url, s.title, s.description,
+          s.tagline, s.og_image_url, s.is_public, s.created_at, s.refreshed_at,
+          u.name as user_name, u.nickname as user_nickname, u.image as user_image, u.slug as user_slug,
+          (SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = s.id) as upvote_count
+        FROM showcases s
+        JOIN users u ON u.id = s.user_id
+        WHERE s.id = ?`,
+        [id]
+      );
+    }
+
+    if (!showcase) {
+      return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+    }
+
+    // Access control: hidden showcases only visible to owner or admin
+    if (showcase.is_public !== 1) {
+      const isOwner = user && showcase.user_id === user.userId;
+      if (!isOwner && !admin) {
+        return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+      }
+    }
+
+    return NextResponse.json({
+      id: showcase.id,
+      repo_key: showcase.repo_key,
+      github_url: showcase.github_url,
+      title: showcase.title,
+      description: showcase.description,
+      tagline: showcase.tagline,
+      og_image_url: showcase.og_image_url,
+      upvote_count: showcase.upvote_count,
+      is_public: showcase.is_public === 1,
+      created_at: showcase.created_at,
+      refreshed_at: showcase.refreshed_at,
+      user: {
+        id: showcase.user_id,
+        name: showcase.user_name,
+        nickname: showcase.user_nickname,
+        image: showcase.user_image,
+        slug: showcase.user_slug,
+      },
+      has_upvoted: showcase.has_upvoted !== undefined ? showcase.has_upvoted === 1 : null,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("no such table")) {
+      return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+    }
+    console.error("Failed to get showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to get showcase" },
+      { status: 500 }
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PATCH — update showcase
+// ---------------------------------------------------------------------------
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const user = await resolveUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const dbRead = await getDbRead();
+  const dbWrite = await getDbWrite();
+  const admin = isAdmin(user.email);
+
+  // Find showcase
+  let showcase: { id: string; user_id: string } | null;
+  try {
+    showcase = await dbRead.firstOrNull<{ id: string; user_id: string }>(
+      "SELECT id, user_id FROM showcases WHERE id = ?",
+      [id]
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("no such table")) {
+      return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+    }
+    console.error("Failed to find showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to find showcase" },
+      { status: 500 }
+    );
+  }
+
+  if (!showcase) {
+    return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+  }
+
+  // Access control: owner or admin
+  const isOwner = showcase.user_id === user.userId;
+  if (!isOwner && !admin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Validate input
+  const { tagline, is_public } = body as { tagline?: string | null; is_public?: boolean };
+
+  if (tagline !== undefined && tagline !== null) {
+    if (typeof tagline !== "string") {
+      return NextResponse.json(
+        { error: "tagline must be a string" },
+        { status: 400 }
+      );
+    }
+    if (tagline.length > 280) {
+      return NextResponse.json(
+        { error: "tagline must be 280 characters or less" },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (is_public !== undefined && typeof is_public !== "boolean") {
+    return NextResponse.json(
+      { error: "is_public must be a boolean" },
+      { status: 400 }
+    );
+  }
+
+  // Build UPDATE statement
+  const updates: string[] = [];
+  const params: unknown[] = [];
+
+  if (tagline !== undefined) {
+    updates.push("tagline = ?");
+    params.push(tagline);
+  }
+
+  if (is_public !== undefined) {
+    updates.push("is_public = ?");
+    params.push(is_public ? 1 : 0);
+  }
+
+  if (updates.length === 0) {
+    return NextResponse.json(
+      { error: "No fields to update" },
+      { status: 400 }
+    );
+  }
+
+  updates.push("updated_at = ?");
+  params.push(new Date().toISOString());
+  params.push(id);
+
+  try {
+    await dbWrite.execute(
+      `UPDATE showcases SET ${updates.join(", ")} WHERE id = ?`,
+      params
+    );
+  } catch (err) {
+    console.error("Failed to update showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to update showcase" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}
+
+// ---------------------------------------------------------------------------
+// DELETE — delete showcase
+// ---------------------------------------------------------------------------
+
+export async function DELETE(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const user = await resolveUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const dbRead = await getDbRead();
+  const dbWrite = await getDbWrite();
+  const admin = isAdmin(user.email);
+
+  // Find showcase
+  let showcase: { id: string; user_id: string } | null;
+  try {
+    showcase = await dbRead.firstOrNull<{ id: string; user_id: string }>(
+      "SELECT id, user_id FROM showcases WHERE id = ?",
+      [id]
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("no such table")) {
+      return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+    }
+    console.error("Failed to find showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to find showcase" },
+      { status: 500 }
+    );
+  }
+
+  if (!showcase) {
+    return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+  }
+
+  // Access control: owner or admin
+  const isOwner = showcase.user_id === user.userId;
+  if (!isOwner && !admin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    // Delete showcase (upvotes cascade due to ON DELETE CASCADE)
+    await dbWrite.execute("DELETE FROM showcases WHERE id = ?", [id]);
+  } catch (err) {
+    console.error("Failed to delete showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to delete showcase" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/packages/web/src/app/api/showcases/[id]/upvote/route.ts
+++ b/packages/web/src/app/api/showcases/[id]/upvote/route.ts
@@ -1,0 +1,113 @@
+/**
+ * POST /api/showcases/[id]/upvote — toggle upvote (auth required)
+ *
+ * Returns new upvote state and fresh count.
+ */
+
+import { NextResponse } from "next/server";
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead, getDbWrite } from "@/lib/db";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// ---------------------------------------------------------------------------
+// POST — toggle upvote
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const user = await resolveUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const dbRead = await getDbRead();
+  const dbWrite = await getDbWrite();
+
+  // Check showcase exists and is public
+  let showcase: { id: string; is_public: number } | null;
+  try {
+    showcase = await dbRead.firstOrNull<{ id: string; is_public: number }>(
+      "SELECT id, is_public FROM showcases WHERE id = ?",
+      [id]
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("no such table")) {
+      return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+    }
+    console.error("Failed to find showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to find showcase" },
+      { status: 500 }
+    );
+  }
+
+  if (!showcase) {
+    return NextResponse.json({ error: "Showcase not found" }, { status: 404 });
+  }
+
+  // Only public showcases can be upvoted
+  if (showcase.is_public !== 1) {
+    return NextResponse.json(
+      { error: "Cannot upvote hidden showcase" },
+      { status: 403 }
+    );
+  }
+
+  // Check current upvote state
+  let existing: { id: number } | null;
+  try {
+    existing = await dbRead.firstOrNull<{ id: number }>(
+      "SELECT id FROM showcase_upvotes WHERE showcase_id = ? AND user_id = ?",
+      [id, user.userId]
+    );
+  } catch (err) {
+    console.error("Failed to check upvote:", err);
+    return NextResponse.json(
+      { error: "Failed to check upvote status" },
+      { status: 500 }
+    );
+  }
+
+  // Toggle upvote
+  try {
+    if (existing) {
+      // Remove upvote
+      await dbWrite.execute(
+        "DELETE FROM showcase_upvotes WHERE showcase_id = ? AND user_id = ?",
+        [id, user.userId]
+      );
+    } else {
+      // Add upvote
+      await dbWrite.execute(
+        "INSERT INTO showcase_upvotes (showcase_id, user_id) VALUES (?, ?)",
+        [id, user.userId]
+      );
+    }
+  } catch (err) {
+    console.error("Failed to toggle upvote:", err);
+    return NextResponse.json(
+      { error: "Failed to toggle upvote" },
+      { status: 500 }
+    );
+  }
+
+  // Get fresh count
+  let upvoteCount = 0;
+  try {
+    const countResult = await dbRead.firstOrNull<{ count: number }>(
+      "SELECT COUNT(*) as count FROM showcase_upvotes WHERE showcase_id = ?",
+      [id]
+    );
+    upvoteCount = countResult?.count ?? 0;
+  } catch (err) {
+    console.error("Failed to get upvote count:", err);
+    // Non-fatal — return the toggle result with count 0
+  }
+
+  return NextResponse.json({
+    upvoted: !existing,
+    upvote_count: upvoteCount,
+  });
+}

--- a/packages/web/src/app/api/showcases/preview/route.ts
+++ b/packages/web/src/app/api/showcases/preview/route.ts
@@ -1,0 +1,108 @@
+/**
+ * POST /api/showcases/preview — fetch GitHub metadata for preview before submit.
+ *
+ * - Auth required
+ * - Validates URL format
+ * - Fetches repo metadata from GitHub API
+ * - Checks if repo already showcased
+ */
+
+import { NextResponse } from "next/server";
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead } from "@/lib/db";
+import {
+  normalizeGitHubUrl,
+  fetchGitHubMetadata,
+  buildOgImageUrl,
+  GitHubError,
+  gitHubErrorToStatus,
+  gitHubErrorMessage,
+} from "@/lib/github";
+
+// ---------------------------------------------------------------------------
+// POST — preview showcase
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request) {
+  const user = await resolveUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { github_url } = body as { github_url?: string };
+  if (!github_url || typeof github_url !== "string") {
+    return NextResponse.json(
+      { error: "github_url is required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate and normalize URL
+  const normalized = normalizeGitHubUrl(github_url);
+  if (!normalized) {
+    return NextResponse.json(
+      { error: "Invalid GitHub repository URL. Must be https://github.com/owner/repo format." },
+      { status: 400 }
+    );
+  }
+
+  const { repoKey, displayUrl, owner, repo } = normalized;
+
+  // Fetch metadata from GitHub
+  let title: string;
+  let description: string | null;
+  try {
+    const metadata = await fetchGitHubMetadata(owner, repo);
+    title = metadata.title;
+    description = metadata.description;
+  } catch (err) {
+    if (err instanceof GitHubError) {
+      return NextResponse.json(
+        { error: gitHubErrorMessage(err) },
+        { status: gitHubErrorToStatus(err) }
+      );
+    }
+    console.error("Failed to fetch GitHub metadata:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch repository information" },
+      { status: 500 }
+    );
+  }
+
+  // Check if already showcased
+  const dbRead = await getDbRead();
+  let alreadyExists = false;
+  try {
+    const existing = await dbRead.firstOrNull<{ id: string }>(
+      "SELECT id FROM showcases WHERE repo_key = ?",
+      [repoKey]
+    );
+    alreadyExists = existing !== null;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (!msg.includes("no such table")) {
+      console.error("Failed to check showcase existence:", err);
+      return NextResponse.json(
+        { error: "Failed to check showcase existence" },
+        { status: 500 }
+      );
+    }
+    // Table doesn't exist yet — that's fine, alreadyExists = false
+  }
+
+  return NextResponse.json({
+    repo_key: repoKey,
+    github_url: displayUrl,
+    title,
+    description,
+    og_image_url: buildOgImageUrl(owner, repo),
+    already_exists: alreadyExists,
+  });
+}

--- a/packages/web/src/app/api/showcases/route.ts
+++ b/packages/web/src/app/api/showcases/route.ts
@@ -1,0 +1,319 @@
+/**
+ * GET /api/showcases — list public showcases (no auth required)
+ * POST /api/showcases — create new showcase (auth required)
+ */
+
+import { NextResponse } from "next/server";
+import { nanoid } from "nanoid";
+import { resolveUser } from "@/lib/auth-helpers";
+import { getDbRead, getDbWrite } from "@/lib/db";
+import {
+  normalizeGitHubUrl,
+  fetchGitHubMetadata,
+  buildOgImageUrl,
+  GitHubError,
+  gitHubErrorToStatus,
+  gitHubErrorMessage,
+} from "@/lib/github";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ShowcaseRow {
+  id: string;
+  user_id: string;
+  repo_key: string;
+  github_url: string;
+  title: string;
+  description: string | null;
+  tagline: string | null;
+  og_image_url: string | null;
+  is_public: number;
+  created_at: string;
+  refreshed_at: string;
+  // Joined user fields
+  user_name: string | null;
+  user_nickname: string | null;
+  user_image: string | null;
+  user_slug: string | null;
+  // Computed
+  upvote_count: number;
+  has_upvoted?: number;
+}
+
+// ---------------------------------------------------------------------------
+// GET — list showcases
+// ---------------------------------------------------------------------------
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const mine = url.searchParams.get("mine") === "1";
+  const limit = Math.min(parseInt(url.searchParams.get("limit") || "20", 10), 100);
+  const offset = parseInt(url.searchParams.get("offset") || "0", 10);
+
+  // Auth check for mine=1
+  const user = await resolveUser(request);
+  if (mine && !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const dbRead = await getDbRead();
+
+  try {
+    let showcases: ShowcaseRow[];
+    let total: number;
+
+    if (mine && user) {
+      // Get current user's showcases (all, including hidden)
+      const countResult = await dbRead.firstOrNull<{ count: number }>(
+        "SELECT COUNT(*) as count FROM showcases WHERE user_id = ?",
+        [user.userId]
+      );
+      total = countResult?.count ?? 0;
+
+      const query = `
+        SELECT
+          s.id, s.user_id, s.repo_key, s.github_url, s.title, s.description,
+          s.tagline, s.og_image_url, s.is_public, s.created_at, s.refreshed_at,
+          u.name as user_name, u.nickname as user_nickname, u.image as user_image, u.slug as user_slug,
+          (SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = s.id) as upvote_count,
+          EXISTS(SELECT 1 FROM showcase_upvotes WHERE showcase_id = s.id AND user_id = ?) as has_upvoted
+        FROM showcases s
+        JOIN users u ON u.id = s.user_id
+        WHERE s.user_id = ?
+        ORDER BY s.created_at DESC, s.id DESC
+        LIMIT ? OFFSET ?
+      `;
+      const { results } = await dbRead.query<ShowcaseRow>(query, [
+        user.userId,
+        user.userId,
+        limit,
+        offset,
+      ]);
+      showcases = results;
+    } else {
+      // Get public showcases
+      const countResult = await dbRead.firstOrNull<{ count: number }>(
+        "SELECT COUNT(*) as count FROM showcases WHERE is_public = 1",
+        []
+      );
+      total = countResult?.count ?? 0;
+
+      if (user) {
+        // Authenticated: include has_upvoted
+        const query = `
+          SELECT
+            s.id, s.user_id, s.repo_key, s.github_url, s.title, s.description,
+            s.tagline, s.og_image_url, s.is_public, s.created_at, s.refreshed_at,
+            u.name as user_name, u.nickname as user_nickname, u.image as user_image, u.slug as user_slug,
+            (SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = s.id) as upvote_count,
+            EXISTS(SELECT 1 FROM showcase_upvotes WHERE showcase_id = s.id AND user_id = ?) as has_upvoted
+          FROM showcases s
+          JOIN users u ON u.id = s.user_id
+          WHERE s.is_public = 1
+          ORDER BY s.created_at DESC, s.id DESC
+          LIMIT ? OFFSET ?
+        `;
+        const { results } = await dbRead.query<ShowcaseRow>(query, [user.userId, limit, offset]);
+        showcases = results;
+      } else {
+        // Unauthenticated: no has_upvoted
+        const query = `
+          SELECT
+            s.id, s.user_id, s.repo_key, s.github_url, s.title, s.description,
+            s.tagline, s.og_image_url, s.is_public, s.created_at, s.refreshed_at,
+            u.name as user_name, u.nickname as user_nickname, u.image as user_image, u.slug as user_slug,
+            (SELECT COUNT(*) FROM showcase_upvotes WHERE showcase_id = s.id) as upvote_count
+          FROM showcases s
+          JOIN users u ON u.id = s.user_id
+          WHERE s.is_public = 1
+          ORDER BY s.created_at DESC, s.id DESC
+          LIMIT ? OFFSET ?
+        `;
+        const { results } = await dbRead.query<ShowcaseRow>(query, [limit, offset]);
+        showcases = results;
+      }
+    }
+
+    return NextResponse.json({
+      showcases: showcases.map((s) => ({
+        id: s.id,
+        repo_key: s.repo_key,
+        github_url: s.github_url,
+        title: s.title,
+        description: s.description,
+        tagline: s.tagline,
+        og_image_url: s.og_image_url,
+        upvote_count: s.upvote_count,
+        is_public: mine ? s.is_public === 1 : true,
+        created_at: s.created_at,
+        user: {
+          id: s.user_id,
+          name: s.user_name,
+          nickname: s.user_nickname,
+          image: s.user_image,
+          slug: s.user_slug,
+        },
+        has_upvoted: s.has_upvoted !== undefined ? s.has_upvoted === 1 : null,
+      })),
+      total,
+      limit,
+      offset,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("no such table")) {
+      return NextResponse.json({ showcases: [], total: 0, limit, offset });
+    }
+    console.error("Failed to list showcases:", err);
+    return NextResponse.json(
+      { error: "Failed to list showcases" },
+      { status: 500 }
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST — create showcase
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request) {
+  const user = await resolveUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { github_url, tagline } = body as { github_url?: string; tagline?: string };
+
+  if (!github_url || typeof github_url !== "string") {
+    return NextResponse.json(
+      { error: "github_url is required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate tagline length
+  if (tagline !== undefined && tagline !== null) {
+    if (typeof tagline !== "string") {
+      return NextResponse.json(
+        { error: "tagline must be a string" },
+        { status: 400 }
+      );
+    }
+    if (tagline.length > 280) {
+      return NextResponse.json(
+        { error: "tagline must be 280 characters or less" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Validate and normalize URL
+  const normalized = normalizeGitHubUrl(github_url);
+  if (!normalized) {
+    return NextResponse.json(
+      { error: "Invalid GitHub repository URL. Must be https://github.com/owner/repo format." },
+      { status: 400 }
+    );
+  }
+
+  const { repoKey, displayUrl, owner, repo } = normalized;
+
+  // Fetch metadata from GitHub
+  let title: string;
+  let description: string | null;
+  try {
+    const metadata = await fetchGitHubMetadata(owner, repo);
+    title = metadata.title;
+    description = metadata.description;
+  } catch (err) {
+    if (err instanceof GitHubError) {
+      return NextResponse.json(
+        { error: gitHubErrorMessage(err) },
+        { status: gitHubErrorToStatus(err) }
+      );
+    }
+    console.error("Failed to fetch GitHub metadata:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch repository information" },
+      { status: 500 }
+    );
+  }
+
+  const dbRead = await getDbRead();
+  const dbWrite = await getDbWrite();
+
+  // Check if already exists
+  try {
+    const existing = await dbRead.firstOrNull<{ id: string }>(
+      "SELECT id FROM showcases WHERE repo_key = ?",
+      [repoKey]
+    );
+    if (existing) {
+      return NextResponse.json(
+        { error: "This repository has already been showcased" },
+        { status: 409 }
+      );
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (!msg.includes("no such table")) {
+      console.error("Failed to check showcase existence:", err);
+      return NextResponse.json(
+        { error: "Failed to check showcase existence" },
+        { status: 500 }
+      );
+    }
+    // Table doesn't exist yet — will be created with first insert or migration
+  }
+
+  // Insert showcase
+  const id = nanoid();
+  const ogImageUrl = buildOgImageUrl(owner, repo);
+  const now = new Date().toISOString();
+
+  try {
+    await dbWrite.execute(
+      `INSERT INTO showcases (id, user_id, repo_key, github_url, title, description, tagline, og_image_url, is_public, refreshed_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`,
+      [id, user.userId, repoKey, displayUrl, title, description, tagline || null, ogImageUrl, now, now, now]
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("UNIQUE constraint failed")) {
+      return NextResponse.json(
+        { error: "This repository has already been showcased" },
+        { status: 409 }
+      );
+    }
+    console.error("Failed to create showcase:", err);
+    return NextResponse.json(
+      { error: "Failed to create showcase" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      id,
+      repo_key: repoKey,
+      github_url: displayUrl,
+      title,
+      description,
+      tagline: tagline || null,
+      og_image_url: ogImageUrl,
+      is_public: true,
+      upvote_count: 0,
+      created_at: now,
+    },
+    { status: 201 }
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -26,6 +26,7 @@ import {
   FolderKanban,
   FolderGit2,
   Database,
+  Star,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { APP_VERSION } from "@/lib/version";
@@ -67,6 +68,7 @@ const ICON_MAP: Record<string, ElementType> = {
   FolderKanban,
   FolderGit2,
   Database,
+  Star,
 };
 
 interface NavItem {

--- a/packages/web/src/components/leaderboard/leaderboard-nav.tsx
+++ b/packages/web/src/components/leaderboard/leaderboard-nav.tsx
@@ -12,6 +12,7 @@ const TABS = [
   { href: "/leaderboard", label: "Individual" },
   { href: "/leaderboard/seasons", label: "Seasons" },
   { href: "/leaderboard/achievements", label: "Achievements" },
+  { href: "/leaderboard/showcases", label: "Showcases" },
 ] as const;
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/components/showcase/index.ts
+++ b/packages/web/src/components/showcase/index.ts
@@ -1,0 +1,4 @@
+export { ShowcaseCard } from "./showcase-card";
+export { ShowcaseImage } from "./showcase-image";
+export { ShowcaseFormModal } from "./showcase-form-modal";
+export { UpvoteButton } from "./upvote-button";

--- a/packages/web/src/components/showcase/showcase-card.tsx
+++ b/packages/web/src/components/showcase/showcase-card.tsx
@@ -1,0 +1,106 @@
+/**
+ * Showcase card for list display (ProductHunt-style).
+ */
+
+"use client";
+
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { ShowcaseImage } from "./showcase-image";
+import { UpvoteButton } from "./upvote-button";
+import type { Showcase } from "@/hooks/use-showcases";
+
+interface ShowcaseCardProps {
+  showcase: Showcase;
+  isLoggedIn: boolean;
+  onLoginRequired?: () => void;
+}
+
+export function ShowcaseCard({ showcase, isLoggedIn, onLoginRequired }: ShowcaseCardProps) {
+  const displayName = showcase.user.nickname || showcase.user.name || "Anonymous";
+
+  return (
+    <article className="group relative flex gap-4 rounded-xl bg-secondary p-4 transition-all hover:bg-secondary/80">
+      {/* OG Image */}
+      <Link
+        href={showcase.github_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="relative shrink-0 w-[180px] aspect-[1.91/1] rounded-lg overflow-hidden bg-accent/50"
+      >
+        <ShowcaseImage
+          url={showcase.og_image_url}
+          repoKey={showcase.repo_key}
+          className="w-full h-full"
+        />
+        <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
+      </Link>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0 flex flex-col justify-between py-0.5">
+        <div>
+          {/* Title + External Link */}
+          <div className="flex items-start gap-2">
+            <Link
+              href={showcase.github_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group/title flex items-center gap-1.5"
+            >
+              <h3 className="text-base font-semibold text-foreground group-hover/title:text-primary transition-colors line-clamp-1">
+                {showcase.title}
+              </h3>
+              <ExternalLink className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover/title:opacity-100 transition-opacity shrink-0" />
+            </Link>
+          </div>
+
+          {/* Tagline */}
+          {showcase.tagline && (
+            <p className="mt-0.5 text-sm text-primary/80 line-clamp-1">
+              &ldquo;{showcase.tagline}&rdquo;
+            </p>
+          )}
+
+          {/* Description */}
+          {showcase.description && (
+            <p className="mt-1.5 text-xs text-muted-foreground line-clamp-2">
+              {showcase.description}
+            </p>
+          )}
+        </div>
+
+        {/* Footer: Submitter */}
+        <div className="mt-2 flex items-center gap-2">
+          {showcase.user.image ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={showcase.user.image}
+              alt={displayName}
+              className="h-5 w-5 rounded-full"
+            />
+          ) : (
+            <div className="h-5 w-5 rounded-full bg-accent flex items-center justify-center">
+              <span className="text-[10px] font-medium text-muted-foreground">
+                {displayName.charAt(0).toUpperCase()}
+              </span>
+            </div>
+          )}
+          <span className="text-xs text-muted-foreground truncate">
+            {displayName}
+          </span>
+        </div>
+      </div>
+
+      {/* Upvote Button */}
+      <div className="shrink-0 self-center">
+        <UpvoteButton
+          showcaseId={showcase.id}
+          initialCount={showcase.upvote_count}
+          initialUpvoted={showcase.has_upvoted}
+          isLoggedIn={isLoggedIn}
+          onLoginRequired={onLoginRequired}
+        />
+      </div>
+    </article>
+  );
+}

--- a/packages/web/src/components/showcase/showcase-form-modal.tsx
+++ b/packages/web/src/components/showcase/showcase-form-modal.tsx
@@ -1,0 +1,404 @@
+/**
+ * Modal for adding or editing a showcase.
+ */
+
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { Dialog } from "radix-ui";
+import { X, Loader2, ExternalLink, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ShowcaseImage } from "./showcase-image";
+import { useShowcasePreview, type ShowcasePreview } from "@/hooks/use-showcases";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ShowcaseFormModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+  // For edit mode
+  editMode?: boolean;
+  editData?: {
+    id: string;
+    repo_key: string;
+    github_url: string;
+    title: string;
+    description: string | null;
+    og_image_url: string | null;
+    tagline: string | null;
+    is_public: boolean;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ShowcaseFormModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  editMode = false,
+  editData,
+}: ShowcaseFormModalProps) {
+  // Form state
+  const [githubUrl, setGithubUrl] = useState("");
+  const [tagline, setTagline] = useState("");
+  const [isPublic, setIsPublic] = useState(true);
+
+  // Preview state (for add mode)
+  const { preview, loading: previewLoading, error: previewError, fetchPreview, reset: resetPreview } = useShowcasePreview();
+
+  // Submit state
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Refresh state (for edit mode)
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshedData, setRefreshedData] = useState<{
+    title: string;
+    description: string | null;
+    og_image_url: string;
+  } | null>(null);
+
+  // Initialize form for edit mode
+  useEffect(() => {
+    if (editMode && editData && open) {
+      setGithubUrl(editData.github_url);
+      setTagline(editData.tagline || "");
+      setIsPublic(editData.is_public);
+      setRefreshedData(null);
+    } else if (!open) {
+      // Reset on close
+      setGithubUrl("");
+      setTagline("");
+      setIsPublic(true);
+      setSubmitError(null);
+      resetPreview();
+      setRefreshedData(null);
+    }
+  }, [editMode, editData, open, resetPreview]);
+
+  // Handle preview fetch
+  const handlePreview = useCallback(async () => {
+    if (!githubUrl.trim()) return;
+    await fetchPreview(githubUrl.trim());
+  }, [githubUrl, fetchPreview]);
+
+  // Handle refresh from GitHub (edit mode)
+  const handleRefresh = useCallback(async () => {
+    if (!editData) return;
+    setRefreshing(true);
+    setSubmitError(null);
+
+    try {
+      const res = await fetch(`/api/showcases/${editData.id}/refresh`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      setRefreshedData({
+        title: data.title,
+        description: data.description,
+        og_image_url: data.og_image_url,
+      });
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Failed to refresh");
+    } finally {
+      setRefreshing(false);
+    }
+  }, [editData]);
+
+  // Handle submit
+  const handleSubmit = useCallback(async () => {
+    setSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      if (editMode && editData) {
+        // Update showcase
+        const res = await fetch(`/api/showcases/${editData.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            tagline: tagline.trim() || null,
+            is_public: isPublic,
+          }),
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
+        }
+      } else {
+        // Create showcase
+        const res = await fetch("/api/showcases", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            github_url: githubUrl.trim(),
+            tagline: tagline.trim() || undefined,
+          }),
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
+        }
+      }
+
+      onSuccess?.();
+      onOpenChange(false);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [editMode, editData, githubUrl, tagline, isPublic, onSuccess, onOpenChange]);
+
+  // Computed display data
+  const displayData: ShowcasePreview | null = editMode && editData
+    ? {
+        repo_key: editData.repo_key,
+        github_url: editData.github_url,
+        title: refreshedData?.title ?? editData.title,
+        description: refreshedData?.description ?? editData.description,
+        og_image_url: refreshedData?.og_image_url ?? editData.og_image_url ?? "",
+        already_exists: false,
+      }
+    : preview;
+
+  const canSubmit = editMode
+    ? !submitting && !refreshing
+    : !submitting && preview && !preview.already_exists;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-lg max-h-[90vh] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl bg-card p-6 shadow-lg data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95">
+          {/* Close button */}
+          <Dialog.Close asChild>
+            <button className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors">
+              <X className="h-4 w-4" />
+            </button>
+          </Dialog.Close>
+
+          {/* Title */}
+          <Dialog.Title className="text-xl font-semibold text-foreground mb-1">
+            {editMode ? "Edit Showcase" : "Add Showcase"}
+          </Dialog.Title>
+          <Dialog.Description className="text-sm text-muted-foreground mb-5">
+            {editMode
+              ? "Update your showcase details."
+              : "Share a GitHub repository with the community."}
+          </Dialog.Description>
+
+          {/* Error */}
+          {submitError && (
+            <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive mb-4 flex items-start gap-2">
+              <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+              <span>{submitError}</span>
+            </div>
+          )}
+
+          {/* GitHub URL input (add mode only) */}
+          {!editMode && (
+            <div className="mb-4">
+              <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                GitHub Repository URL
+              </label>
+              <div className="flex gap-2">
+                <input
+                  type="url"
+                  value={githubUrl}
+                  onChange={(e) => setGithubUrl(e.target.value)}
+                  placeholder="https://github.com/owner/repo"
+                  className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring/20 transition-shadow"
+                  disabled={submitting}
+                />
+                <button
+                  onClick={handlePreview}
+                  disabled={!githubUrl.trim() || previewLoading || submitting}
+                  className={cn(
+                    "rounded-lg border border-border px-4 py-2 text-sm font-medium transition-colors",
+                    previewLoading
+                      ? "opacity-50 cursor-not-allowed"
+                      : "hover:bg-accent hover:text-foreground"
+                  )}
+                >
+                  {previewLoading ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    "Preview"
+                  )}
+                </button>
+              </div>
+              {previewError && (
+                <p className="mt-1.5 text-xs text-destructive">{previewError}</p>
+              )}
+            </div>
+          )}
+
+          {/* Preview card */}
+          {displayData && (
+            <div className="rounded-lg border border-border bg-background p-4 mb-4">
+              <div className="flex gap-4">
+                {/* Image */}
+                <div className="shrink-0 w-[120px] aspect-[1.91/1] rounded-lg overflow-hidden bg-accent/50">
+                  <ShowcaseImage
+                    url={displayData.og_image_url}
+                    repoKey={displayData.repo_key}
+                    className="w-full h-full"
+                  />
+                </div>
+
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <a
+                    href={displayData.github_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1.5 group"
+                  >
+                    <h4 className="text-sm font-semibold text-foreground group-hover:text-primary transition-colors truncate">
+                      {displayData.title}
+                    </h4>
+                    <ExternalLink className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                  </a>
+                  <p className="text-xs text-muted-foreground font-mono mt-0.5">
+                    {displayData.repo_key}
+                  </p>
+                  {displayData.description && (
+                    <p className="text-xs text-muted-foreground mt-1.5 line-clamp-2">
+                      {displayData.description}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* Already exists warning */}
+              {!editMode && displayData.already_exists && (
+                <div className="mt-3 rounded-md bg-warning/10 px-3 py-2 text-xs text-warning flex items-center gap-2">
+                  <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                  This repository has already been showcased.
+                </div>
+              )}
+
+              {/* Refresh button (edit mode) */}
+              {editMode && (
+                <div className="mt-3 flex items-center justify-between">
+                  <p className="text-[10px] text-muted-foreground">
+                    Title and description are synced from GitHub.
+                  </p>
+                  <button
+                    onClick={handleRefresh}
+                    disabled={refreshing || submitting}
+                    className={cn(
+                      "text-xs text-primary hover:text-primary/80 transition-colors",
+                      (refreshing || submitting) && "opacity-50 cursor-not-allowed"
+                    )}
+                  >
+                    {refreshing ? (
+                      <span className="flex items-center gap-1">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        Refreshing...
+                      </span>
+                    ) : (
+                      "Refresh from GitHub"
+                    )}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Tagline input */}
+          {(editMode || displayData) && (
+            <div className="mb-4">
+              <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                Your Recommendation (optional)
+              </label>
+              <textarea
+                value={tagline}
+                onChange={(e) => setTagline(e.target.value)}
+                placeholder="Why do you recommend this project?"
+                maxLength={280}
+                rows={2}
+                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring/20 transition-shadow resize-none"
+                disabled={submitting}
+              />
+              <p className="mt-1 text-right text-[10px] text-muted-foreground">
+                {tagline.length}/280
+              </p>
+            </div>
+          )}
+
+          {/* Visibility toggle (edit mode) */}
+          {editMode && (
+            <div className="mb-5 flex items-center justify-between">
+              <div>
+                <label className="block text-xs font-medium text-foreground">
+                  Public
+                </label>
+                <p className="text-[10px] text-muted-foreground">
+                  Show this showcase on the public leaderboard.
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={isPublic}
+                onClick={() => setIsPublic(!isPublic)}
+                disabled={submitting}
+                className={cn(
+                  "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+                  isPublic ? "bg-primary" : "bg-border",
+                  submitting && "opacity-50 cursor-not-allowed"
+                )}
+              >
+                <span
+                  className={cn(
+                    "pointer-events-none inline-block h-4 w-4 transform rounded-full bg-background shadow-sm ring-0 transition-transform",
+                    isPublic ? "translate-x-4" : "translate-x-0"
+                  )}
+                />
+              </button>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-2">
+            <Dialog.Close asChild>
+              <button
+                disabled={submitting}
+                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Cancel
+              </button>
+            </Dialog.Close>
+            <button
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className={cn(
+                "flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors",
+                !canSubmit && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+              {editMode ? "Save Changes" : "Add Showcase"}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/web/src/components/showcase/showcase-image.tsx
+++ b/packages/web/src/components/showcase/showcase-image.tsx
@@ -1,0 +1,40 @@
+/**
+ * Showcase OG image with gradient fallback on error.
+ */
+
+"use client";
+
+import { useState } from "react";
+
+interface ShowcaseImageProps {
+  url: string | null;
+  repoKey: string;
+  className?: string;
+}
+
+export function ShowcaseImage({ url, repoKey, className = "" }: ShowcaseImageProps) {
+  const [error, setError] = useState(false);
+
+  if (!url || error) {
+    return (
+      <div
+        className={`bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center ${className}`}
+      >
+        <span className="text-muted-foreground text-sm font-mono truncate px-2">
+          {repoKey}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={url}
+      alt={repoKey}
+      className={`object-cover ${className}`}
+      onError={() => setError(true)}
+      loading="lazy"
+    />
+  );
+}

--- a/packages/web/src/components/showcase/upvote-button.tsx
+++ b/packages/web/src/components/showcase/upvote-button.tsx
@@ -1,0 +1,98 @@
+/**
+ * Upvote button with optimistic toggle.
+ */
+
+"use client";
+
+import { useState, useCallback } from "react";
+import { ChevronUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface UpvoteButtonProps {
+  showcaseId: string;
+  initialCount: number;
+  initialUpvoted: boolean | null;
+  isLoggedIn: boolean;
+  onLoginRequired?: (() => void) | undefined;
+  disabled?: boolean;
+}
+
+export function UpvoteButton({
+  showcaseId,
+  initialCount,
+  initialUpvoted,
+  isLoggedIn,
+  onLoginRequired,
+  disabled = false,
+}: UpvoteButtonProps) {
+  const [count, setCount] = useState(initialCount);
+  const [upvoted, setUpvoted] = useState(initialUpvoted === true);
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    if (!isLoggedIn) {
+      onLoginRequired?.();
+      return;
+    }
+
+    if (loading || disabled) return;
+
+    // Optimistic update
+    const prevCount = count;
+    const prevUpvoted = upvoted;
+    setUpvoted(!upvoted);
+    setCount(upvoted ? count - 1 : count + 1);
+    setLoading(true);
+
+    try {
+      const res = await fetch(`/api/showcases/${showcaseId}/upvote`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        // Rollback on error
+        setUpvoted(prevUpvoted);
+        setCount(prevCount);
+        return;
+      }
+
+      const data = (await res.json()) as { upvoted: boolean; upvote_count: number };
+      // Sync with server state
+      setUpvoted(data.upvoted);
+      setCount(data.upvote_count);
+    } catch {
+      // Rollback on network error
+      setUpvoted(prevUpvoted);
+      setCount(prevCount);
+    } finally {
+      setLoading(false);
+    }
+  }, [showcaseId, count, upvoted, loading, disabled, isLoggedIn, onLoginRequired]);
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={loading || disabled}
+      className={cn(
+        "flex flex-col items-center justify-center gap-0.5 rounded-lg border px-3 py-2 min-w-[56px] transition-all",
+        upvoted
+          ? "border-primary bg-primary/10 text-primary"
+          : "border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground",
+        (loading || disabled) && "opacity-50 cursor-not-allowed",
+        !isLoggedIn && "hover:border-warning/50"
+      )}
+      title={!isLoggedIn ? "Login to upvote" : upvoted ? "Remove upvote" : "Upvote"}
+    >
+      <ChevronUp
+        className={cn(
+          "h-4 w-4 transition-transform",
+          upvoted && "text-primary"
+        )}
+        strokeWidth={2}
+      />
+      <span className={cn("text-xs font-semibold tabular-nums", upvoted && "text-primary")}>
+        {count}
+      </span>
+    </button>
+  );
+}

--- a/packages/web/src/hooks/use-showcases.ts
+++ b/packages/web/src/hooks/use-showcases.ts
@@ -1,0 +1,173 @@
+/**
+ * Hook for fetching showcases list.
+ */
+
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ShowcaseUser {
+  id: string;
+  name: string | null;
+  nickname: string | null;
+  image: string | null;
+  slug: string | null;
+}
+
+export interface Showcase {
+  id: string;
+  repo_key: string;
+  github_url: string;
+  title: string;
+  description: string | null;
+  tagline: string | null;
+  og_image_url: string | null;
+  upvote_count: number;
+  is_public: boolean;
+  created_at: string;
+  refreshed_at?: string;
+  user: ShowcaseUser;
+  has_upvoted: boolean | null;
+}
+
+export interface ShowcasesResponse {
+  showcases: Showcase[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface UseShowcasesOptions {
+  mine?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface UseShowcasesResult {
+  data: ShowcasesResponse | null;
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useShowcases(options: UseShowcasesOptions = {}): UseShowcasesResult {
+  const { mine = false, limit = 20, offset = 0 } = options;
+
+  const [data, setData] = useState<ShowcasesResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (data === null) {
+      setLoading(true);
+    } else {
+      setRefreshing(true);
+    }
+    setError(null);
+
+    try {
+      const params = new URLSearchParams();
+      if (mine) params.set("mine", "1");
+      params.set("limit", String(limit));
+      params.set("offset", String(offset));
+
+      const res = await fetch(`/api/showcases?${params.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error ?? `HTTP ${res.status}`
+        );
+      }
+
+      const json = (await res.json()) as ShowcasesResponse;
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [mine, limit, offset, data]);
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mine, limit, offset]);
+
+  return { data, loading, refreshing, error, refetch: fetchData };
+}
+
+// ---------------------------------------------------------------------------
+// Preview Hook
+// ---------------------------------------------------------------------------
+
+export interface ShowcasePreview {
+  repo_key: string;
+  github_url: string;
+  title: string;
+  description: string | null;
+  og_image_url: string;
+  already_exists: boolean;
+}
+
+export interface UseShowcasePreviewResult {
+  preview: ShowcasePreview | null;
+  loading: boolean;
+  error: string | null;
+  fetchPreview: (url: string) => Promise<ShowcasePreview | null>;
+  reset: () => void;
+}
+
+export function useShowcasePreview(): UseShowcasePreviewResult {
+  const [preview, setPreview] = useState<ShowcasePreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPreview = useCallback(async (url: string): Promise<ShowcasePreview | null> => {
+    setLoading(true);
+    setError(null);
+    setPreview(null);
+
+    try {
+      const res = await fetch("/api/showcases/preview", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ github_url: url }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error ?? `HTTP ${res.status}`
+        );
+      }
+
+      const json = (await res.json()) as ShowcasePreview;
+      setPreview(json);
+      return json;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setPreview(null);
+    setError(null);
+  }, []);
+
+  return { preview, loading, error, fetchPreview, reset };
+}

--- a/packages/web/src/lib/github.ts
+++ b/packages/web/src/lib/github.ts
@@ -1,0 +1,218 @@
+/**
+ * GitHub integration helpers for Showcase feature.
+ *
+ * - URL validation and normalization
+ * - Repository metadata fetching
+ * - OG image URL construction
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NormalizedGitHubUrl {
+  repoKey: string;    // "owner/repo" lowercase
+  displayUrl: string; // "https://github.com/Owner/Repo" original casing
+  owner: string;      // original casing
+  repo: string;       // original casing
+}
+
+export interface GitHubMetadata {
+  owner: string;           // current owner (may differ if renamed)
+  name: string;            // current repo name (may differ if renamed)
+  title: string;           // repo name for display
+  description: string | null;
+  fullName: string;        // "owner/repo" from API (current)
+}
+
+export type GitHubErrorCode =
+  | "NOT_FOUND"
+  | "RATE_LIMITED"
+  | "FORBIDDEN"
+  | "UPSTREAM_ERROR"
+  | "NETWORK_ERROR"
+  | "TIMEOUT";
+
+export class GitHubError extends Error {
+  constructor(
+    public readonly code: GitHubErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "GitHubError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// URL Validation & Normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex for valid GitHub repository URLs.
+ * Accepts: https://github.com/owner/repo or http://... with optional trailing slash.
+ * Rejects: file paths, issue URLs, user/org pages, etc.
+ */
+const GITHUB_REPO_PATTERN =
+  /^https?:\/\/github\.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)\/?$/;
+
+/**
+ * Validate and normalize a GitHub repository URL.
+ *
+ * @param url - Raw URL string from user input
+ * @returns Normalized URL info, or null if invalid
+ *
+ * @example
+ * normalizeGitHubUrl("https://github.com/Owner/Repo/")
+ * // => { repoKey: "owner/repo", displayUrl: "https://github.com/Owner/Repo", owner: "Owner", repo: "Repo" }
+ */
+export function normalizeGitHubUrl(url: string): NormalizedGitHubUrl | null {
+  const trimmed = url.trim();
+  const match = trimmed.match(GITHUB_REPO_PATTERN);
+  if (!match || !match[1] || !match[2]) return null;
+
+  const owner = match[1];
+  const repo = match[2];
+  return {
+    repoKey: `${owner}/${repo}`.toLowerCase(),
+    displayUrl: `https://github.com/${owner}/${repo}`,
+    owner,
+    repo,
+  };
+}
+
+/**
+ * Check if a string is a valid GitHub repository URL.
+ */
+export function isValidGitHubRepoUrl(url: string): boolean {
+  return normalizeGitHubUrl(url) !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Metadata Fetching
+// ---------------------------------------------------------------------------
+
+const FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * Fetch repository metadata from GitHub API.
+ *
+ * @param owner - Repository owner (case-insensitive)
+ * @param repo - Repository name (case-insensitive)
+ * @returns Metadata including current owner/name (handles renames)
+ * @throws GitHubError on failure
+ */
+export async function fetchGitHubMetadata(
+  owner: string,
+  repo: string
+): Promise<GitHubMetadata> {
+  const url = `https://api.github.com/repos/${owner}/${repo}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: {
+        "User-Agent": "pew-showcase/1.0",
+        Accept: "application/vnd.github.v3+json",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      throw new GitHubError("TIMEOUT", "GitHub API request timed out");
+    }
+    throw new GitHubError("NETWORK_ERROR", "Failed to connect to GitHub");
+  }
+
+  if (res.status === 404) {
+    throw new GitHubError("NOT_FOUND", "Repository not found or is private");
+  }
+
+  if (res.status === 403) {
+    const remaining = res.headers.get("X-RateLimit-Remaining");
+    if (remaining === "0") {
+      throw new GitHubError(
+        "RATE_LIMITED",
+        "GitHub API rate limit exceeded. Try again later."
+      );
+    }
+    throw new GitHubError("FORBIDDEN", "Cannot access repository");
+  }
+
+  if (!res.ok) {
+    throw new GitHubError(
+      "UPSTREAM_ERROR",
+      `GitHub API error: ${res.status}`
+    );
+  }
+
+  const data = await res.json();
+
+  return {
+    owner: data.owner?.login || owner,
+    name: data.name || repo,
+    title: data.name || `${owner}/${repo}`,
+    description: data.description || null,
+    fullName: data.full_name || `${owner}/${repo}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// OG Image
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct GitHub OG image URL for a repository.
+ *
+ * Uses opengraph.githubassets.com which generates dynamic preview images.
+ * The "1" is a placeholder hash that GitHub accepts.
+ *
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ */
+export function buildOgImageUrl(owner: string, repo: string): string {
+  return `https://opengraph.githubassets.com/1/${owner}/${repo}`;
+}
+
+// ---------------------------------------------------------------------------
+// Error Mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map GitHubError to HTTP status code for API responses.
+ */
+export function gitHubErrorToStatus(error: GitHubError): number {
+  switch (error.code) {
+    case "NOT_FOUND":
+      return 404;
+    case "RATE_LIMITED":
+    case "FORBIDDEN":
+    case "UPSTREAM_ERROR":
+    case "NETWORK_ERROR":
+    case "TIMEOUT":
+      return 422;
+    default:
+      return 500;
+  }
+}
+
+/**
+ * Get user-friendly error message for GitHubError.
+ */
+export function gitHubErrorMessage(error: GitHubError): string {
+  switch (error.code) {
+    case "NOT_FOUND":
+      return "Repository not found or is private";
+    case "RATE_LIMITED":
+      return "GitHub API rate limit exceeded. Try again later.";
+    case "FORBIDDEN":
+      return "Cannot access repository";
+    case "UPSTREAM_ERROR":
+      return "GitHub is temporarily unavailable. Try again later.";
+    case "NETWORK_ERROR":
+      return "Failed to connect to GitHub";
+    case "TIMEOUT":
+      return "GitHub API request timed out. Try again later.";
+    default:
+      return "Unknown error occurred";
+  }
+}

--- a/packages/web/src/lib/navigation.ts
+++ b/packages/web/src/lib/navigation.ts
@@ -57,6 +57,7 @@ export const BASE_NAV_GROUPS: NavGroupDef[] = [
       { href: "/teams", label: "Teams", icon: "Users" },
       { href: "/manage-projects", label: "Projects", icon: "FolderKanban" },
       { href: "/manage-devices", label: "Devices", icon: "MonitorSmartphone" },
+      { href: "/settings/showcases", label: "Showcases", icon: "Star" },
       { href: "/settings", label: "General", icon: "Settings" },
     ],
   },
@@ -69,6 +70,7 @@ export const ADMIN_NAV_GROUP: NavGroupDef = {
     { href: "/admin/pricing", label: "Token Pricing", icon: "DollarSign" },
     { href: "/admin/invites", label: "Invite Codes", icon: "Ticket" },
     { href: "/admin/seasons", label: "Seasons", icon: "Trophy" },
+    { href: "/admin/showcases", label: "Showcases", icon: "Star" },
     { href: "/admin/storage", label: "Storage", icon: "Database" },
   ],
 };
@@ -94,6 +96,7 @@ export const ROUTE_LABELS: Record<string, string> = {
   devices: "By Device",
   "manage-devices": "Devices",
   leaderboard: "Leaderboard",
+  showcases: "Showcases",
   admin: "Admin",
   seasons: "Seasons",
   storage: "Storage",

--- a/scripts/migrations/016-showcases.sql
+++ b/scripts/migrations/016-showcases.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- Showcases (user-submitted GitHub projects)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS showcases (
+  id              TEXT PRIMARY KEY,                         -- nanoid
+  user_id         TEXT NOT NULL REFERENCES users(id),       -- submitter
+  repo_key        TEXT NOT NULL,                            -- normalized: "owner/repo" lowercase
+  github_url      TEXT NOT NULL,                            -- display URL (original casing)
+  title           TEXT NOT NULL,                            -- fetched from GitHub
+  description     TEXT,                                     -- fetched from GitHub
+  tagline         TEXT,                                     -- user-provided recommendation (editable)
+  og_image_url    TEXT,                                     -- GitHub OG image URL
+  is_public       INTEGER NOT NULL DEFAULT 1,               -- 1=visible, 0=hidden
+  refreshed_at    TEXT NOT NULL DEFAULT (datetime('now')),  -- last GitHub metadata sync
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(repo_key)                                          -- one submission per repo (normalized)
+);
+
+CREATE INDEX IF NOT EXISTS idx_showcases_user ON showcases(user_id);
+CREATE INDEX IF NOT EXISTS idx_showcases_public_sort ON showcases(is_public, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_showcases_created ON showcases(created_at DESC);
+
+-- ============================================================
+-- Showcase Upvotes (one per user per showcase)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS showcase_upvotes (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  showcase_id  TEXT NOT NULL REFERENCES showcases(id) ON DELETE CASCADE,
+  user_id      TEXT NOT NULL REFERENCES users(id),
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(showcase_id, user_id)                              -- one upvote per user
+);
+
+CREATE INDEX IF NOT EXISTS idx_showcase_upvotes_showcase ON showcase_upvotes(showcase_id);
+CREATE INDEX IF NOT EXISTS idx_showcase_upvotes_user ON showcase_upvotes(user_id);


### PR DESCRIPTION
## Summary

- Add complete Showcase system allowing users to submit GitHub projects for community discovery
- ProductHunt-style card layout with OG images, upvotes, and pagination
- Three view modes: public leaderboard, user's own showcases, admin moderation

## What's Included

### Database (Phase 1)
- `showcases` table with GitHub metadata (title, description, OG image URL)
- `showcase_upvotes` table for toggle-style voting
- Unique constraint on normalized `repo_key` (lowercase owner/repo)

### API Endpoints (Phase 1)
- `GET/POST /api/showcases` — list public & create new
- `GET/PATCH/DELETE /api/showcases/[id]` — single CRUD
- `POST /api/showcases/[id]/refresh` — re-fetch from GitHub
- `POST /api/showcases/[id]/upvote` — toggle upvote
- `POST /api/showcases/preview` — preview before submit
- `GET /api/admin/showcases` — admin list all

### Frontend (Phase 2)
- `/leaderboard/showcases` — public browse with upvote toggle
- `/settings/showcases` — manage your submitted showcases
- `/admin/showcases` — moderation page (approve/hide/delete)
- Reusable components: ShowcaseCard, ShowcaseImage, UpvoteButton, ShowcaseFormModal
- Optimistic upvote toggle with rollback on error

## Test plan

- [ ] Browse `/leaderboard/showcases` without login — see showcases, upvote button disabled
- [ ] Login → upvote → count updates optimistically
- [ ] Add showcase from leaderboard "Add Showcase" button
- [ ] Go to `/settings/showcases` → see your submissions
- [ ] Edit tagline, toggle visibility, delete showcase
- [ ] Admin: view hidden showcases, hide/unhide, delete
- [ ] Verify duplicate repo submission blocked (409)

🤖 Generated with [Claude Code](https://claude.com/claude-code)