### PR TITLE
fix: OpenClaw plugin install + login URL fallback for WSL/headless environments

### DIFF
--- a/packages/cli/src/__tests__/openclaw-hook.test.ts
+++ b/packages/cli/src/__tests__/openclaw-hook.test.ts
@@ -44,7 +44,7 @@ describe("OpenClaw hook installer", () => {
     expect(spawn).toHaveBeenNthCalledWith(
       1,
       "openclaw",
-      ["plugins", "install", "--link", pluginDir],
+      ["plugins", "install", "--link", "--dangerously-force-unsafe-install", pluginDir],
       expect.any(Object),
     );
     expect(spawn).toHaveBeenNthCalledWith(

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -99,6 +99,7 @@ export async function executeLogin(options: LoginOptions): Promise<LoginResult> 
     timeoutMs,
     generateNonce,
     accentColor: PEW_ACCENT_COLOR,
+    log: (msg: string) => console.log(msg),
   });
 
   return {

--- a/packages/cli/src/notifier/openclaw-hook.ts
+++ b/packages/cli/src/notifier/openclaw-hook.ts
@@ -44,7 +44,7 @@ export async function installOpenClawHook(
   try {
     const installResult = spawn(
       "openclaw",
-      ["plugins", "install", "--link", pluginDir],
+      ["plugins", "install", "--link", "--dangerously-force-unsafe-install", pluginDir],
       { cwd: pluginDir },
     );
     const enableResult = spawn(


### PR DESCRIPTION
## Summary

Two small fixes that improve `pew` usability in WSL and headless environments.

## Changes

### 1. `fix(openclaw-hook)`: Add `--dangerously-force-unsafe-install` flag

**File:** `packages/cli/src/notifier/openclaw-hook.ts`

**Problem:** `pew init` fails to install the OpenClaw plugin because the plugin's `index.js` uses `child_process.spawn` for triggering sync. OpenClaw's security checker detects this as dangerous code and blocks installation.

**Fix:** Add `--dangerously-force-unsafe-install` to the `openclaw plugins install --link` command. This is safe because the plugin is generated by pew itself and only spawns the notify handler.

### 2. `fix(login)`: Pass `log` callback to `performLogin`

**File:** `packages/cli/src/commands/login.ts`

**Problem:** In WSL/headless environments, `openBrowser()` fails silently. `performLogin` from `@nocoo/cli-base` supports a `log` callback to print the auth URL as a fallback, but `executeLogin` was not passing it. Users see "Opening browser..." and nothing else — no URL, no way to authenticate.

**Fix:** Pass `log: (msg) => console.log(msg)` so the URL prints to the terminal when the browser cannot open. Users can then copy-paste it into their browser manually.

## Testing

Tested on WSL2 (Ubuntu 22.04) where:
- `pew init` now succeeds with `✓ openclaw  OpenClaw plugin installed`
- `pew login` now prints the auth URL when browser fails to open