### PR TITLE
fix(web): WoW integration fixes and comprehensive usage-helpers tests

### DIFF
--- a/packages/web/src/__tests__/usage-helpers.test.ts
+++ b/packages/web/src/__tests__/usage-helpers.test.ts
@@ -7,7 +7,22 @@ import {
   sourceLabel,
   type UsageRow,
 } from "@/hooks/use-usage-data";
-import { toLocalDailyBuckets, compareWeekdayWeekend, computeMoMGrowth, computeWoWGrowth, computeStreak, toSourceTrendPoints, toDominantSourceTimeline } from "@/lib/usage-helpers";
+import {
+  toLocalDailyBuckets,
+  compareWeekdayWeekend,
+  computeMoMGrowth,
+  computeWoWGrowth,
+  computeStreak,
+  toSourceTrendPoints,
+  toDominantSourceTimeline,
+  groupByModel,
+  groupByAgent,
+  groupByDate,
+  extractSources,
+  extractModels,
+  toHourlyWeekdayWeekend,
+  toLocalDateStr,
+} from "@/lib/usage-helpers";
 import { getDefaultPricingMap } from "@/lib/pricing";
 import type { PricingMap } from "@/lib/pricing";
 
@@ -1093,5 +1108,407 @@ describe("toDominantSourceTimeline", () => {
     expect(result[0]!.dominantSource).toBe("claude-code");
     expect(result[0]!.sources["claude-code"]).toBe(5000);
     expect(result[0]!.sources["gemini-cli"]).toBe(1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupByModel
+// ---------------------------------------------------------------------------
+
+describe("groupByModel", () => {
+  function makePricingMap(): PricingMap {
+    return getDefaultPricingMap();
+  }
+
+  it("should return empty array for empty input", () => {
+    expect(groupByModel([], makePricingMap())).toEqual([]);
+  });
+
+  it("should group records by model and compute aggregates", () => {
+    const rows = [
+      makeRow({ model: "claude-sonnet-4-20250514", source: "claude-code", input_tokens: 1000, output_tokens: 500, cached_input_tokens: 200, total_tokens: 1700 }),
+      makeRow({ model: "claude-sonnet-4-20250514", source: "opencode", input_tokens: 2000, output_tokens: 1000, cached_input_tokens: 400, total_tokens: 3400 }),
+      makeRow({ model: "gpt-4.1", source: "opencode", input_tokens: 500, output_tokens: 250, cached_input_tokens: 100, total_tokens: 850 }),
+    ];
+
+    const result = groupByModel(rows, makePricingMap());
+
+    expect(result).toHaveLength(2);
+    // Sorted by totalTokens descending
+    expect(result[0]!.model).toBe("claude-sonnet-4-20250514");
+    expect(result[0]!.totalTokens).toBe(5100);
+    expect(result[0]!.inputTokens).toBe(3000);
+    expect(result[0]!.outputTokens).toBe(1500);
+    expect(result[0]!.cachedTokens).toBe(600);
+    expect(result[0]!.sources).toContain("claude-code");
+    expect(result[0]!.sources).toContain("opencode");
+    expect(result[0]!.estimatedCost).toBeGreaterThan(0);
+
+    expect(result[1]!.model).toBe("gpt-4.1");
+    expect(result[1]!.totalTokens).toBe(850);
+  });
+
+  it("should compute pctOfTotal correctly", () => {
+    const rows = [
+      makeRow({ model: "model-a", total_tokens: 7500, input_tokens: 5000, output_tokens: 2500, cached_input_tokens: 0 }),
+      makeRow({ model: "model-b", total_tokens: 2500, input_tokens: 2000, output_tokens: 500, cached_input_tokens: 0 }),
+    ];
+
+    const result = groupByModel(rows, makePricingMap());
+
+    // model-a: 7500 / 10000 = 75%
+    expect(result[0]!.pctOfTotal).toBeCloseTo(75, 0);
+    // model-b: 2500 / 10000 = 25%
+    expect(result[1]!.pctOfTotal).toBeCloseTo(25, 0);
+  });
+
+  it("should handle single record", () => {
+    const rows = [
+      makeRow({ model: "test-model", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+    ];
+
+    const result = groupByModel(rows, makePricingMap());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.pctOfTotal).toBeCloseTo(100, 0);
+  });
+
+  it("should return 0 pctOfTotal when grandTotal is 0", () => {
+    const rows = [
+      makeRow({ model: "test-model", total_tokens: 0, input_tokens: 0, output_tokens: 0, cached_input_tokens: 0 }),
+    ];
+
+    const result = groupByModel(rows, makePricingMap());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.pctOfTotal).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupByAgent
+// ---------------------------------------------------------------------------
+
+describe("groupByAgent", () => {
+  function makePricingMap(): PricingMap {
+    return getDefaultPricingMap();
+  }
+
+  it("should return empty array for empty input", () => {
+    expect(groupByAgent([], makePricingMap())).toEqual([]);
+  });
+
+  it("should group records by source and compute aggregates", () => {
+    const rows = [
+      makeRow({ source: "claude-code", model: "sonnet-4", input_tokens: 1000, output_tokens: 500, cached_input_tokens: 200, total_tokens: 1700 }),
+      makeRow({ source: "claude-code", model: "opus-4", input_tokens: 2000, output_tokens: 1000, cached_input_tokens: 400, total_tokens: 3400 }),
+      makeRow({ source: "opencode", model: "gpt-4.1", input_tokens: 500, output_tokens: 250, cached_input_tokens: 100, total_tokens: 850 }),
+    ];
+
+    const result = groupByAgent(rows, makePricingMap());
+
+    expect(result).toHaveLength(2);
+    // Sorted by totalTokens descending
+    expect(result[0]!.source).toBe("claude-code");
+    expect(result[0]!.label).toBe("Claude Code");
+    expect(result[0]!.totalTokens).toBe(5100);
+    expect(result[0]!.inputTokens).toBe(3000);
+    expect(result[0]!.outputTokens).toBe(1500);
+    expect(result[0]!.cachedTokens).toBe(600);
+    expect(result[0]!.records).toHaveLength(2);
+    expect(result[0]!.estimatedCost).toBeGreaterThan(0);
+
+    expect(result[1]!.source).toBe("opencode");
+    expect(result[1]!.totalTokens).toBe(850);
+  });
+
+  it("should include nested models breakdown sorted by total descending", () => {
+    const rows = [
+      makeRow({ source: "claude-code", model: "sonnet-4", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ source: "claude-code", model: "opus-4", total_tokens: 3000, input_tokens: 2400, output_tokens: 600, cached_input_tokens: 300 }),
+      makeRow({ source: "claude-code", model: "haiku-4", total_tokens: 500, input_tokens: 400, output_tokens: 100, cached_input_tokens: 50 }),
+    ];
+
+    const result = groupByAgent(rows, makePricingMap());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.models).toHaveLength(3);
+    // Sorted by total descending
+    expect(result[0]!.models[0]!.model).toBe("opus-4");
+    expect(result[0]!.models[0]!.total).toBe(3000);
+    expect(result[0]!.models[1]!.model).toBe("sonnet-4");
+    expect(result[0]!.models[1]!.total).toBe(1000);
+    expect(result[0]!.models[2]!.model).toBe("haiku-4");
+    expect(result[0]!.models[2]!.total).toBe(500);
+  });
+
+  it("should aggregate multiple records of same model within same source", () => {
+    const rows = [
+      makeRow({ source: "claude-code", model: "sonnet-4", input_tokens: 100, output_tokens: 50, cached_input_tokens: 10, total_tokens: 160 }),
+      makeRow({ source: "claude-code", model: "sonnet-4", input_tokens: 200, output_tokens: 100, cached_input_tokens: 20, total_tokens: 320 }),
+    ];
+
+    const result = groupByAgent(rows, makePricingMap());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.models).toHaveLength(1);
+    expect(result[0]!.models[0]!.input).toBe(300);
+    expect(result[0]!.models[0]!.output).toBe(150);
+    expect(result[0]!.models[0]!.cached).toBe(30);
+    expect(result[0]!.models[0]!.total).toBe(480);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupByDate
+// ---------------------------------------------------------------------------
+
+describe("groupByDate", () => {
+  function makePricingMap(): PricingMap {
+    return getDefaultPricingMap();
+  }
+
+  it("should return empty array for empty input", () => {
+    expect(groupByDate([], makePricingMap())).toEqual([]);
+  });
+
+  it("should group records by date and compute aggregates", () => {
+    const rows = [
+      makeRow({ hour_start: "2026-03-07T10:00:00Z", input_tokens: 1000, output_tokens: 500, cached_input_tokens: 200, total_tokens: 1700 }),
+      makeRow({ hour_start: "2026-03-07T14:00:00Z", input_tokens: 500, output_tokens: 250, cached_input_tokens: 100, total_tokens: 850 }),
+      makeRow({ hour_start: "2026-03-08T10:00:00Z", input_tokens: 2000, output_tokens: 1000, cached_input_tokens: 400, total_tokens: 3400 }),
+    ];
+
+    const result = groupByDate(rows, makePricingMap());
+
+    expect(result).toHaveLength(2);
+    // Sorted by date descending (newest first)
+    expect(result[0]!.date).toBe("2026-03-08");
+    expect(result[0]!.totalTokens).toBe(3400);
+    expect(result[0]!.inputTokens).toBe(2000);
+    expect(result[0]!.outputTokens).toBe(1000);
+    expect(result[0]!.cachedTokens).toBe(400);
+    expect(result[0]!.records).toHaveLength(1);
+    expect(result[0]!.estimatedCost).toBeGreaterThan(0);
+
+    expect(result[1]!.date).toBe("2026-03-07");
+    expect(result[1]!.totalTokens).toBe(2550);
+    expect(result[1]!.records).toHaveLength(2);
+  });
+
+  it("should apply tzOffset to shift dates across midnight", () => {
+    // 2026-03-08T03:00Z → 2026-03-07T19:00 PST → local date 2026-03-07
+    const rows = [
+      makeRow({ hour_start: "2026-03-07T20:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ hour_start: "2026-03-08T03:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+    ];
+
+    const result = groupByDate(rows, makePricingMap(), 480); // UTC-8
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.date).toBe("2026-03-07");
+    expect(result[0]!.totalTokens).toBe(3000);
+  });
+
+  it("should handle bare date strings (day-granularity queries)", () => {
+    const rows = [
+      makeRow({ hour_start: "2026-03-07", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ hour_start: "2026-03-08", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+    ];
+
+    // Even with tzOffset, bare dates should NOT be shifted
+    const result = groupByDate(rows, makePricingMap(), 480);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.date).toBe("2026-03-08");
+    expect(result[1]!.date).toBe("2026-03-07");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSources
+// ---------------------------------------------------------------------------
+
+describe("extractSources", () => {
+  it("should return empty array for empty input", () => {
+    expect(extractSources([])).toEqual([]);
+  });
+
+  it("should extract unique sources sorted alphabetically", () => {
+    const rows = [
+      makeRow({ source: "opencode" }),
+      makeRow({ source: "claude-code" }),
+      makeRow({ source: "gemini-cli" }),
+      makeRow({ source: "claude-code" }), // duplicate
+    ];
+
+    const result = extractSources(rows);
+
+    expect(result).toEqual(["claude-code", "gemini-cli", "opencode"]);
+  });
+
+  it("should handle single source", () => {
+    const rows = [
+      makeRow({ source: "claude-code" }),
+      makeRow({ source: "claude-code" }),
+    ];
+
+    const result = extractSources(rows);
+
+    expect(result).toEqual(["claude-code"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractModels
+// ---------------------------------------------------------------------------
+
+describe("extractModels", () => {
+  it("should return empty array for empty input", () => {
+    expect(extractModels([])).toEqual([]);
+  });
+
+  it("should extract unique models sorted alphabetically", () => {
+    const rows = [
+      makeRow({ model: "sonnet-4" }),
+      makeRow({ model: "gpt-4.1" }),
+      makeRow({ model: "opus-4" }),
+      makeRow({ model: "sonnet-4" }), // duplicate
+    ];
+
+    const result = extractModels(rows);
+
+    expect(result).toEqual(["gpt-4.1", "opus-4", "sonnet-4"]);
+  });
+
+  it("should handle single model", () => {
+    const rows = [
+      makeRow({ model: "sonnet-4" }),
+      makeRow({ model: "sonnet-4" }),
+    ];
+
+    const result = extractModels(rows);
+
+    expect(result).toEqual(["sonnet-4"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toHourlyWeekdayWeekend
+// ---------------------------------------------------------------------------
+
+describe("toHourlyWeekdayWeekend", () => {
+  it("should return 24 hourly buckets for empty input", () => {
+    const result = toHourlyWeekdayWeekend([], { from: "2026-03-02", to: "2026-03-08" });
+
+    expect(result).toHaveLength(24);
+    expect(result[0]!.hour).toBe(0);
+    expect(result[0]!.weekday).toBe(0);
+    expect(result[0]!.weekend).toBe(0);
+    expect(result[23]!.hour).toBe(23);
+  });
+
+  it("should compute average hourly usage for weekdays and weekends", () => {
+    // 2026-03-02 (Mon) to 2026-03-08 (Sun) = 5 weekdays + 2 weekend days
+    // Add data at 10:00 on a weekday and a weekend day
+    const rows = [
+      // Weekday usage at 10:00 (March 2 is Monday)
+      makeRow({ hour_start: "2026-03-02T10:00:00Z", total_tokens: 5000, input_tokens: 4000, output_tokens: 1000, cached_input_tokens: 500 }),
+      // Weekend usage at 10:00 (March 7 is Saturday)
+      makeRow({ hour_start: "2026-03-07T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+    ];
+
+    const result = toHourlyWeekdayWeekend(rows, { from: "2026-03-02", to: "2026-03-08" });
+
+    // Hour 10: weekday avg = 5000/5 = 1000, weekend avg = 2000/2 = 1000
+    expect(result[10]!.weekday).toBe(1000);
+    expect(result[10]!.weekend).toBe(1000);
+
+    // Other hours should be 0
+    expect(result[9]!.weekday).toBe(0);
+    expect(result[9]!.weekend).toBe(0);
+  });
+
+  it("should accumulate multiple records in the same hour", () => {
+    // 2026-03-02 (Mon) to 2026-03-02 (Mon) = 1 weekday
+    const rows = [
+      makeRow({ hour_start: "2026-03-02T14:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ hour_start: "2026-03-02T14:30:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+    ];
+
+    const result = toHourlyWeekdayWeekend(rows, { from: "2026-03-02", to: "2026-03-02" });
+
+    // Hour 14: 3000 tokens / 1 weekday = 3000
+    expect(result[14]!.weekday).toBe(3000);
+    expect(result[14]!.weekend).toBe(0);
+  });
+
+  it("should apply tzOffset to shift hours and days", () => {
+    // 2026-03-02T01:00Z → PST = 2026-03-01T17:00 → hour 17, Sunday (prev day)
+    // But our range is 2026-03-02 to 2026-03-02, so Sunday is not in the range
+    // Let's use a simpler test: shift hour across midnight
+    // 2026-03-07 (Sat) in UTC, but 2026-03-08T03:00Z → 2026-03-07T19:00 PST = hour 19, Saturday
+    const rows = [
+      makeRow({ hour_start: "2026-03-08T03:00:00Z", total_tokens: 4800, input_tokens: 3840, output_tokens: 960, cached_input_tokens: 480 }),
+    ];
+
+    const result = toHourlyWeekdayWeekend(rows, { from: "2026-03-07", to: "2026-03-07" }, 480); // UTC-8
+
+    // In PST: hour 19 on Saturday (weekend), range has 0 weekdays, 1 weekend day
+    expect(result[19]!.weekend).toBe(4800);
+    expect(result[19]!.weekday).toBe(0);
+  });
+
+  it("should return 0 averages when range has no weekdays or weekends", () => {
+    // 2026-03-07 (Sat) to 2026-03-08 (Sun) = 0 weekdays, 2 weekend days
+    const rows = [
+      makeRow({ hour_start: "2026-03-07T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+    ];
+
+    const result = toHourlyWeekdayWeekend(rows, { from: "2026-03-07", to: "2026-03-08" });
+
+    // No weekdays in range → weekday average = 0
+    expect(result[10]!.weekday).toBe(0);
+    expect(result[10]!.weekend).toBe(1000); // 2000 / 2 weekend days
+  });
+
+  it("should handle range with only weekdays", () => {
+    // 2026-03-02 (Mon) to 2026-03-06 (Fri) = 5 weekdays, 0 weekend days
+    const rows = [
+      makeRow({ hour_start: "2026-03-03T08:00:00Z", total_tokens: 5000, input_tokens: 4000, output_tokens: 1000, cached_input_tokens: 500 }),
+    ];
+
+    const result = toHourlyWeekdayWeekend(rows, { from: "2026-03-02", to: "2026-03-06" });
+
+    // Hour 8: 5000 / 5 weekdays = 1000
+    expect(result[8]!.weekday).toBe(1000);
+    // No weekend days → weekend average = 0
+    expect(result[8]!.weekend).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toLocalDateStr (edge cases)
+// ---------------------------------------------------------------------------
+
+describe("toLocalDateStr", () => {
+  it("should return bare date as-is (no shift)", () => {
+    // Bare dates from day-granularity queries should not be shifted
+    expect(toLocalDateStr("2026-03-07", 480)).toBe("2026-03-07");
+    expect(toLocalDateStr("2026-03-07", -540)).toBe("2026-03-07");
+  });
+
+  it("should return date portion when tzOffset is 0", () => {
+    expect(toLocalDateStr("2026-03-07T14:30:00Z", 0)).toBe("2026-03-07");
+  });
+
+  it("should shift date for positive tzOffset (west of UTC)", () => {
+    // 2026-03-08T03:00Z → UTC-8 = 2026-03-07T19:00 → date 2026-03-07
+    expect(toLocalDateStr("2026-03-08T03:00:00Z", 480)).toBe("2026-03-07");
+  });
+
+  it("should shift date for negative tzOffset (east of UTC)", () => {
+    // 2026-03-07T20:00Z → UTC+9 = 2026-03-08T05:00 → date 2026-03-08
+    expect(toLocalDateStr("2026-03-07T20:00:00Z", -540)).toBe("2026-03-08");
   });
 });

--- a/packages/web/src/__tests__/usage-helpers.test.ts
+++ b/packages/web/src/__tests__/usage-helpers.test.ts
@@ -609,8 +609,9 @@ describe("computeWoWGrowth", () => {
   }
 
   // 2026-03-18 is a Wednesday
-  // Current week Mon: 2026-03-16
-  // Previous week Mon: 2026-03-09, Sun: 2026-03-15
+  // With Sunday-start weeks:
+  // Current week Sun: 2026-03-15 → Sat: 2026-03-21
+  // Previous week Sun: 2026-03-08 → Sat: 2026-03-14
 
   it("should return zeros for empty input", () => {
     const result = computeWoWGrowth([], makePricingMap(), new Date("2026-03-18T12:00:00Z"));
@@ -631,11 +632,13 @@ describe("computeWoWGrowth", () => {
   });
 
   it("should split rows into current and previous week", () => {
+    // With Sunday-start: current week = Sun Mar 15 → Wed Mar 18
+    // Previous week = Sun Mar 8 → Sat Mar 14
     const rows = [
-      // Previous week: Mon Mar 9 – Sun Mar 15
+      // Previous week: Sun Mar 8 – Sat Mar 14
       makeRow({ hour_start: "2026-03-10T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
       makeRow({ hour_start: "2026-03-12T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
-      // Current week: Mon Mar 16 – Wed Mar 18
+      // Current week: Sun Mar 15 – Wed Mar 18
       makeRow({ hour_start: "2026-03-17T10:00:00Z", total_tokens: 4000, input_tokens: 3200, output_tokens: 800, cached_input_tokens: 400 }),
     ];
 
@@ -678,12 +681,13 @@ describe("computeWoWGrowth", () => {
   });
 
   it("should count distinct active days per week", () => {
+    // With Sunday-start: prev week = Sun Mar 8 – Sat Mar 14, cur week = Sun Mar 15 – Wed Mar 18
     const rows = [
       // Same day in prev week — should count as 1 day
       makeRow({ hour_start: "2026-03-10T08:00:00Z", total_tokens: 500, input_tokens: 400, output_tokens: 100, cached_input_tokens: 50 }),
       makeRow({ hour_start: "2026-03-10T16:00:00Z", total_tokens: 500, input_tokens: 400, output_tokens: 100, cached_input_tokens: 50 }),
-      // Two days in current week
-      makeRow({ hour_start: "2026-03-16T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      // Two days in current week (Sun Mar 15 and Tue Mar 17)
+      makeRow({ hour_start: "2026-03-15T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
       makeRow({ hour_start: "2026-03-17T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
     ];
 
@@ -694,14 +698,18 @@ describe("computeWoWGrowth", () => {
   });
 
   it("should compute same-day comparison (previous week up to same day-of-week)", () => {
-    // ref = Wed Mar 18 → same-day cutoff = Wed of prev week = Mar 11
-    // Previous week: Mon Mar 9 (included), Tue Mar 10 (included), Wed Mar 11 (included), Thu Mar 12 (excluded)
+    // ref = Wed Mar 18, dow=3 (Sun=0, Mon=1, Tue=2, Wed=3)
+    // With Sunday-start: current week = Sun Mar 15 → Wed Mar 18
+    // Previous week = Sun Mar 8 → Sat Mar 14
+    // Same-day cutoff = prev Sun + 3 = Wed Mar 11
+    // So same-day subset includes: Sun Mar 8, Mon Mar 9, Tue Mar 10, Wed Mar 11
     const rows = [
-      makeRow({ hour_start: "2026-03-09T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      // Previous week: Sun Mar 8 (included in same-day), Wed Mar 11 (included in same-day), Fri Mar 13 (excluded from same-day)
+      makeRow({ hour_start: "2026-03-08T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
       makeRow({ hour_start: "2026-03-11T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
       makeRow({ hour_start: "2026-03-13T10:00:00Z", total_tokens: 3000, input_tokens: 2400, output_tokens: 600, cached_input_tokens: 300 }),
-      // Current week
-      makeRow({ hour_start: "2026-03-16T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+      // Current week: Sun Mar 15, Wed Mar 18
+      makeRow({ hour_start: "2026-03-15T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
       makeRow({ hour_start: "2026-03-18T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
     ];
 
@@ -712,7 +720,7 @@ describe("computeWoWGrowth", () => {
     expect(result.currentWeek.tokens).toBe(4000);
     expect(result.tokenGrowth).toBeCloseTo(-20);
 
-    // Same-day (Mon-Wed only): prev=2000, cur=4000 → sameDayTokenGrowth = +100%
+    // Same-day (Sun-Wed only): prev=2000 (Mar 8 + Mar 11), cur=4000 → sameDayTokenGrowth = +100%
     expect(result.previousWeekSameDay.tokens).toBe(2000);
     expect(result.previousWeekSameDay.days).toBe(2);
     expect(result.sameDayTokenGrowth).toBeCloseTo(100);
@@ -720,9 +728,11 @@ describe("computeWoWGrowth", () => {
 
   it("should include same day-of-week in same-day subset (boundary test)", () => {
     // ref = Wed Mar 18 → prev week Wed = Mar 11 should be INCLUDED
+    // With Sunday-start: prev week = Sun Mar 8 – Sat Mar 14
     const rows = [
       makeRow({ hour_start: "2026-03-11T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
-      makeRow({ hour_start: "2026-03-16T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+      // Current week (Sun Mar 15)
+      makeRow({ hour_start: "2026-03-15T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
     ];
 
     const result = computeWoWGrowth(rows, makePricingMap(), new Date("2026-03-18T12:00:00Z"));
@@ -732,66 +742,71 @@ describe("computeWoWGrowth", () => {
   });
 
   it("should return zero same-day growth when no previous same-day data", () => {
-    // ref = Mon Mar 16 (isoDow=0) → same-day cutoff = Mon of prev week = Mar 9
-    // All prev week data is after Monday
+    // ref = Sun Mar 15 (dow=0) → same-day cutoff = Sun of prev week = Mar 8
+    // With Sunday-start: prev week = Sun Mar 8 – Sat Mar 14
+    // All prev week data is after Sunday (Mar 12)
     const rows = [
       makeRow({ hour_start: "2026-03-12T10:00:00Z", total_tokens: 3000, input_tokens: 2400, output_tokens: 600, cached_input_tokens: 300 }),
-      makeRow({ hour_start: "2026-03-16T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ hour_start: "2026-03-15T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
     ];
 
-    const result = computeWoWGrowth(rows, makePricingMap(), new Date("2026-03-16T12:00:00Z"));
+    const result = computeWoWGrowth(rows, makePricingMap(), new Date("2026-03-15T12:00:00Z"));
 
     // Full week comparison still works
     expect(result.previousWeek.tokens).toBe(3000);
     expect(result.tokenGrowth).toBeCloseTo(-66.67, 1);
 
-    // Same-day: only Mon Mar 9 would count, but no data there → growth = 0
+    // Same-day: only Sun Mar 8 would count, but no data there → growth = 0
     expect(result.previousWeekSameDay.tokens).toBe(0);
     expect(result.sameDayTokenGrowth).toBe(0);
   });
 
-  it("should handle Sunday reference (full previous week is same-day subset)", () => {
-    // 2026-03-15 is a Sunday, isoDow=6
-    // Current week Mon: 2026-03-09, Previous week Mon: 2026-03-02
-    // Same-day cutoff = prev Mon + 6 = prev Sun = 2026-03-08
+  it("should handle Saturday reference (full previous week is same-day subset)", () => {
+    // 2026-03-14 is a Saturday, dow=6 (last day of the week in Sunday-start)
+    // With Sunday-start: current week = Sun Mar 8 → Sat Mar 14
+    // Previous week = Sun Mar 1 → Sat Mar 7
+    // Same-day cutoff = prev Sun + 6 = prev Sat = Mar 7 (entire prev week)
     const rows = [
       makeRow({ hour_start: "2026-03-03T10:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
       makeRow({ hour_start: "2026-03-07T10:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
       makeRow({ hour_start: "2026-03-10T10:00:00Z", total_tokens: 5000, input_tokens: 4000, output_tokens: 1000, cached_input_tokens: 500 }),
     ];
 
-    const result = computeWoWGrowth(rows, makePricingMap(), new Date("2026-03-15T12:00:00Z"));
+    const result = computeWoWGrowth(rows, makePricingMap(), new Date("2026-03-14T12:00:00Z"));
 
-    // Previous week: Mon Mar 2 – Sun Mar 8 → 1000 + 2000 = 3000
+    // Previous week: Sun Mar 1 – Sat Mar 7 → 1000 + 2000 = 3000
     expect(result.previousWeek.tokens).toBe(3000);
-    // Same-day subset = entire previous week (isoDow=6, cutoff = Sun)
+    // Same-day subset = entire previous week (dow=6, cutoff = Sat)
     expect(result.previousWeekSameDay.tokens).toBe(3000);
-    // Current week: Mon Mar 9 – Sun Mar 15 → 5000
+    // Current week: Sun Mar 8 – Sat Mar 14 → 5000
     expect(result.currentWeek.tokens).toBe(5000);
   });
 
   it("should assign UTC midnight row to previous week for west-of-UTC timezone (tzOffset=480, PST)", () => {
-    // 2026-03-16T01:00:00Z → PST local = 2026-03-15T17:00:00 → Sunday → previous week
+    // 2026-03-15T01:00:00Z → PST local = 2026-03-14T17:00:00 → Saturday → previous week
+    // ref = 2026-03-18 (Wed), with Sunday-start: current week = Sun Mar 15 → Sat Mar 21
+    // Previous week = Sun Mar 8 → Sat Mar 14
     const rows = [
-      makeRow({ hour_start: "2026-03-16T01:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
+      makeRow({ hour_start: "2026-03-15T01:00:00Z", total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached_input_tokens: 100 }),
     ];
 
     const result = computeWoWGrowth(rows, makePricingMap(), new Date("2026-03-18T12:00:00Z"), 480);
 
-    // Should be assigned to previous week (Sunday in PST), not current week
+    // Should be assigned to previous week (Saturday in PST = Mar 14), not current week
     expect(result.previousWeek.tokens).toBe(1000);
     expect(result.currentWeek.tokens).toBe(0);
   });
 
   it("should keep row in current week for east-of-UTC timezone (tzOffset=-540, JST)", () => {
-    // 2026-03-15T20:00:00Z → JST local = 2026-03-16T05:00:00 → Monday → current week
+    // 2026-03-14T20:00:00Z → JST local = 2026-03-15T05:00:00 → Sunday → current week start
+    // ref = 2026-03-18 (Wed), with Sunday-start: current week = Sun Mar 15 → Sat Mar 21
     const rows = [
-      makeRow({ hour_start: "2026-03-15T20:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
+      makeRow({ hour_start: "2026-03-14T20:00:00Z", total_tokens: 2000, input_tokens: 1600, output_tokens: 400, cached_input_tokens: 200 }),
     ];
 
     const result = computeWoWGrowth(rows, makePricingMap(), new Date("2026-03-18T12:00:00Z"), -540);
 
-    // Should be assigned to current week (Monday in JST), not previous week
+    // Should be assigned to current week (Sunday in JST = Mar 15), not previous week
     expect(result.currentWeek.tokens).toBe(2000);
     expect(result.previousWeek.tokens).toBe(0);
   });

--- a/packages/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/web/src/app/(dashboard)/dashboard/page.tsx
@@ -53,12 +53,18 @@ export default function DashboardPage() {
   });
   const yearData = useUsageData({ days: 365 });
 
-  // Half-hour granularity fetch for weekday/weekend + streak analysis
+  // Half-hour granularity fetch for weekday/weekend analysis (period-bounded)
   const halfHourData = useUsageData({
     from,
     ...(to ? { to } : {}),
     granularity: "half-hour",
   });
+
+  // Fixed 14-day window for WoW comparison (ensures both weeks are present)
+  const wowData = useUsageData({ days: 14, granularity: "half-hour" });
+
+  // Fixed 62-day window for MoM comparison (ensures both months are present)
+  const momData = useUsageData({ days: 62, granularity: "half-hour" });
   // Half-hour granularity for streak (needs 365 days of data)
   const yearHalfHourData = useUsageData({ days: 365, granularity: "half-hour" });
 
@@ -116,17 +122,16 @@ export default function DashboardPage() {
     [data, tzOffset, today],
   );
 
-  // MoM growth (needs 2 months of data — use half-hour records)
-
+  // MoM growth (fixed 62-day window ensures both months are present)
   const mom = useMemo(
-    () => (halfHourData.data ? computeMoMGrowth(halfHourData.data.records, pricingMap, undefined, tzOffset) : null),
-    [halfHourData.data, pricingMap, tzOffset],
+    () => (momData.data ? computeMoMGrowth(momData.data.records, pricingMap, undefined, tzOffset) : null),
+    [momData.data, pricingMap, tzOffset],
   );
 
-  // WoW growth (needs 2 weeks of data — use half-hour records)
+  // WoW growth (fixed 14-day window ensures both weeks are present)
   const wow = useMemo(
-    () => (halfHourData.data ? computeWoWGrowth(halfHourData.data.records, pricingMap, undefined, tzOffset) : null),
-    [halfHourData.data, pricingMap, tzOffset],
+    () => (wowData.data ? computeWoWGrowth(wowData.data.records, pricingMap, undefined, tzOffset) : null),
+    [wowData.data, pricingMap, tzOffset],
   );
 
   // Weekday vs weekend comparison

--- a/packages/web/src/lib/usage-helpers.ts
+++ b/packages/web/src/lib/usage-helpers.ts
@@ -614,13 +614,13 @@ export function computeMoMGrowth(
 /**
  * Compute week-over-week growth for tokens and cost.
  *
- * Weeks start on Monday (ISO 8601). Splits rows by local date into current
- * week (Monday → today) and previous week (Mon−7 → Sun), computes totals,
- * and calculates percentage change.
+ * Weeks start on Sunday by default (US convention, matching periodToDateRange).
+ * Splits rows by local date into current week (Sunday → today) and previous
+ * week (Sun−7 → Sat), computes totals, and calculates percentage change.
  *
  * The "same-day" comparison only includes previous week data up to the same
  * day-of-week as the reference date (e.g. if today is Wednesday, include
- * previous week Mon–Wed).
+ * previous week Sun–Wed).
  *
  * Returns 0 growth when previous week has no data (avoids Infinity).
  *
@@ -643,22 +643,21 @@ export function computeWoWGrowth(
   const todayStr = localRef.toISOString().slice(0, 10);
 
   // Day of week: getUTCDay() → 0=Sun, 1=Mon, …, 6=Sat
-  // Convert to ISO week day: Mon=0, Tue=1, …, Sun=6
+  // Use Sunday-start week (US convention): Sun=0, Mon=1, …, Sat=6
   const dow = localRef.getUTCDay();
-  const isoDow = dow === 0 ? 6 : dow - 1;
 
-  // Current week Monday (as YYYY-MM-DD)
-  const curWeekStartMs = new Date(todayStr + "T00:00:00Z").getTime() - isoDow * 86_400_000;
+  // Current week Sunday (as YYYY-MM-DD)
+  const curWeekStartMs = new Date(todayStr + "T00:00:00Z").getTime() - dow * 86_400_000;
   const curWeekStart = new Date(curWeekStartMs).toISOString().slice(0, 10);
 
-  // Previous week Monday and Sunday
+  // Previous week Sunday and Saturday
   const prevWeekStartMs = curWeekStartMs - 7 * 86_400_000;
   const prevWeekStart = new Date(prevWeekStartMs).toISOString().slice(0, 10);
   const prevWeekEndMs = curWeekStartMs - 86_400_000;
   const prevWeekEnd = new Date(prevWeekEndMs).toISOString().slice(0, 10);
 
-  // Previous week same-day cutoff: Mon of prev week + isoDow days
-  const prevWeekSameDayEndMs = prevWeekStartMs + isoDow * 86_400_000;
+  // Previous week same-day cutoff: Sunday of prev week + dow days
+  const prevWeekSameDayEndMs = prevWeekStartMs + dow * 86_400_000;
   const prevWeekSameDayEnd = new Date(prevWeekSameDayEndMs).toISOString().slice(0, 10);
 
   let curTokens = 0;


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #33 (WoW comparison feature) to address integration issues discovered during code review, plus comprehensive test coverage for previously untested functions.

## Changes

### 1. Fixed data window issue (High severity)
The WoW/MoM calculations were using period-bounded data (`halfHourData`), which meant:
- Selecting "This Week" would exclude previous week data needed for WoW comparison
- Selecting "This Month" early in the month would miss previous week data

**Fix:** Use dedicated fixed-window fetches:
- WoW: 14-day window (ensures both weeks are present)
- MoM: 62-day window (ensures both months are present)

### 2. Aligned week start to Sunday (Medium severity)
`computeWoWGrowth` used Monday-start (ISO 8601) while `periodToDateRange("week")` uses Sunday-start (US convention). This caused the trend percentage to describe different data than the card value.

**Fix:** Changed `computeWoWGrowth` to use Sunday-start weeks.

### 3. Comprehensive tests for usage-helpers.ts
Added 29 tests for previously untested functions:
- `groupByModel`: 4 tests
- `groupByAgent`: 4 tests
- `groupByDate`: 4 tests
- `extractSources`: 3 tests
- `extractModels`: 3 tests
- `toHourlyWeekdayWeekend`: 6 tests
- `toLocalDateStr`: 4 tests

## Test plan
- [x] All 2533 unit tests pass
- [x] Lint clean (0 warnings)
- [x] WoW tests updated for Sunday-start week definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)