### PR TITLE
feat(vscode-copilot): support v3 JSON session format

### DIFF
--- a/packages/cli/src/__tests__/vscode-copilot-v3-parser.test.ts
+++ b/packages/cli/src/__tests__/vscode-copilot-v3-parser.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseVscodeCopilotV3File,
+  type VscodeCopilotV3ParseOpts,
+} from "../parsers/vscode-copilot-v3.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeV3Session(requests: unknown[], overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    version: 3,
+    responderUsername: "GitHub Copilot",
+    initialLocation: "panel",
+    requests,
+    ...overrides,
+  });
+}
+
+function makeV3Request(
+  modelId: string,
+  timestamp: number,
+  promptTokens: number,
+  outputTokens: number,
+  overrides: Record<string, unknown> = {},
+  toolCallRounds: unknown[] = [],
+): Record<string, unknown> {
+  return {
+    requestId: `request_${timestamp}`,
+    timestamp,
+    modelId,
+    result: {
+      timings: { firstProgress: 1000, totalElapsed: 5000 },
+      metadata: {
+        promptTokens,
+        outputTokens,
+        toolCallRounds,
+        renderedUserMessage: [],
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe("parseVscodeCopilotV3File", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "pew-vscode-v3-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should parse a single request with tokens", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      makeV3Request("copilot/claude-opus-4.6", 1775652693236, 36533, 937),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+
+    expect(result.deltas).toHaveLength(1);
+    expect(result.deltas[0].source).toBe("vscode-copilot");
+    expect(result.deltas[0].model).toBe("claude-opus-4.6");
+    expect(result.deltas[0].tokens.inputTokens).toBe(36533);
+    expect(result.deltas[0].tokens.outputTokens).toBe(937);
+    expect(result.deltas[0].tokens.cachedInputTokens).toBe(0);
+    expect(result.deltas[0].tokens.reasoningOutputTokens).toBe(0);
+    expect(result.deltas[0].timestamp).toBe(new Date(1775652693236).toISOString());
+  });
+
+  it("should parse multiple requests", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      makeV3Request("copilot/claude-opus-4.6", 1775652693236, 10000, 500),
+      makeV3Request("copilot/gpt-4o", 1775652793236, 20000, 1000),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+
+    expect(result.deltas).toHaveLength(2);
+    expect(result.deltas[0].model).toBe("claude-opus-4.6");
+    expect(result.deltas[1].model).toBe("gpt-4o");
+  });
+
+  it("should strip copilot/ prefix from model ID", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      makeV3Request("copilot/claude-opus-4.6-1m", 1775652693236, 5000, 300),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas[0].model).toBe("claude-opus-4.6-1m");
+  });
+
+  it("should keep model ID as-is when no copilot/ prefix", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      makeV3Request("gpt-4o", 1775652693236, 5000, 300),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas[0].model).toBe("gpt-4o");
+  });
+
+  it("should skip requests with zero tokens", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      makeV3Request("copilot/claude-opus-4.6", 1775652693236, 10000, 500),
+      makeV3Request("copilot/claude-opus-4.6", 1775652793236, 0, 0),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(1);
+    expect(result.deltas[0].tokens.inputTokens).toBe(10000);
+  });
+
+  it("should skip requests without result", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      { requestId: "req_1", timestamp: 1775652693236, modelId: "copilot/gpt-4o" },
+      makeV3Request("copilot/claude-opus-4.6", 1775652793236, 5000, 300),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(1);
+    expect(result.deltas[0].model).toBe("claude-opus-4.6");
+  });
+
+  it("should skip requests without metadata in result", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      {
+        requestId: "req_1",
+        timestamp: 1775652693236,
+        modelId: "copilot/gpt-4o",
+        result: { timings: { totalElapsed: 1000 } },
+      },
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("should add tool args estimate to outputTokens", async () => {
+    const filePath = join(tempDir, "session.json");
+    const toolCallRounds = [
+      { toolCalls: [{ name: "read_file", arguments: "a".repeat(800) }] },
+    ];
+    await writeFile(filePath, makeV3Session([
+      makeV3Request("copilot/claude-sonnet-4.6", 1775652693236, 50000, 100, {}, toolCallRounds),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(1);
+    // 100 + floor(800/4) = 300
+    expect(result.deltas[0].tokens.outputTokens).toBe(300);
+  });
+
+  it("should add thinking text estimate to reasoningOutputTokens", async () => {
+    const filePath = join(tempDir, "session.json");
+    const toolCallRounds = [
+      { thinking: { text: "t".repeat(1200), tokens: 0 } },
+    ];
+    await writeFile(filePath, makeV3Session([
+      makeV3Request("copilot/claude-opus-4.6", 1775652693236, 30000, 50, {}, toolCallRounds),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(1);
+    expect(result.deltas[0].tokens.reasoningOutputTokens).toBe(300);
+  });
+
+  it("should handle empty requests array", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("should handle missing file", async () => {
+    const result = await parseVscodeCopilotV3File({
+      filePath: join(tempDir, "nonexistent.json"),
+    });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("should handle invalid JSON", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, "not valid json{{{");
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("should ignore non-v3 JSON files", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, JSON.stringify({ version: 2, data: [] }));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("should not skip result with only tool args tokens", async () => {
+    const filePath = join(tempDir, "session.json");
+    const toolCallRounds = [
+      { toolCalls: [{ name: "grep", arguments: "x".repeat(400) }] },
+    ];
+    await writeFile(filePath, makeV3Session([
+      makeV3Request("copilot/claude-sonnet-4.6", 1775652693236, 0, 0, {}, toolCallRounds),
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(1);
+    expect(result.deltas[0].tokens.outputTokens).toBe(100); // floor(400/4)
+  });
+
+  it("should skip requests without modelId", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      {
+        requestId: "req_1",
+        timestamp: 1775652693236,
+        result: { metadata: { promptTokens: 100, outputTokens: 50 } },
+      },
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(0);
+  });
+
+  it("should skip requests without timestamp", async () => {
+    const filePath = join(tempDir, "session.json");
+    await writeFile(filePath, makeV3Session([
+      {
+        requestId: "req_1",
+        modelId: "copilot/gpt-4o",
+        result: { metadata: { promptTokens: 100, outputTokens: 50 } },
+      },
+    ]));
+
+    const result = await parseVscodeCopilotV3File({ filePath });
+    expect(result.deltas).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/discovery/sources.ts
+++ b/packages/cli/src/discovery/sources.ts
@@ -218,7 +218,7 @@ export async function discoverVscodeCopilotFiles(
   const results: string[] = [];
 
   for (const baseDir of baseDirs) {
-    // 1. globalStorage/emptyWindowChatSessions/*.jsonl
+    // 1. globalStorage/emptyWindowChatSessions/*.jsonl + *.json
     const globalChatDir = join(baseDir, "globalStorage", "emptyWindowChatSessions");
     let globalEntries: import("node:fs").Dirent[];
     try {
@@ -227,7 +227,7 @@ export async function discoverVscodeCopilotFiles(
       globalEntries = [];
     }
     for (const entry of globalEntries) {
-      if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      if (entry.isFile() && (entry.name.endsWith(".jsonl") || entry.name.endsWith(".json"))) {
         results.push(join(globalChatDir, entry.name));
       }
     }
@@ -251,7 +251,7 @@ export async function discoverVscodeCopilotFiles(
         continue;
       }
       for (const chatEntry of chatEntries) {
-        if (chatEntry.isFile() && chatEntry.name.endsWith(".jsonl")) {
+        if (chatEntry.isFile() && (chatEntry.name.endsWith(".jsonl") || chatEntry.name.endsWith(".json"))) {
           results.push(join(chatSessionsDir, chatEntry.name));
         }
       }

--- a/packages/cli/src/drivers/token/vscode-copilot-token-driver.ts
+++ b/packages/cli/src/drivers/token/vscode-copilot-token-driver.ts
@@ -10,6 +10,7 @@
 import type { VscodeCopilotCursor } from "@pew/core";
 import { discoverVscodeCopilotFiles } from "../../discovery/sources.js";
 import { parseVscodeCopilotFile } from "../../parsers/vscode-copilot.js";
+import { parseVscodeCopilotV3File } from "../../parsers/vscode-copilot-v3.js";
 import { fileUnchanged } from "../../utils/file-changed.js";
 import type {
   FileTokenDriver,
@@ -56,6 +57,18 @@ export const vscodeCopilotTokenDriver: FileTokenDriver<VscodeCopilotCursor> = {
   },
 
   async parse(filePath: string, resume: ResumeState): Promise<VscodeCopilotParseResult> {
+    // v3 JSON files: full parse each time (no incremental offset)
+    if (filePath.endsWith(".json")) {
+      const result = await parseVscodeCopilotV3File({ filePath });
+      return {
+        deltas: result.deltas,
+        endOffset: 0,
+        requestMeta: {},
+        processedRequestIndices: [],
+      };
+    }
+
+    // CRDT JSONL files: incremental byte-offset parsing
     const r = resume as VscodeCopilotResumeState;
     const result = await parseVscodeCopilotFile({
       filePath,

--- a/packages/cli/src/parsers/vscode-copilot-v3.ts
+++ b/packages/cli/src/parsers/vscode-copilot-v3.ts
@@ -1,0 +1,125 @@
+/**
+ * VSCode Copilot Chat v3 JSON parser.
+ *
+ * Parses the newer JSON session format introduced in VS Code 1.108+.
+ * Unlike the CRDT JSONL format, v3 files are plain JSON with a
+ * `"version": 3` field and a top-level `requests` array.
+ *
+ * Each request contains model/timestamp metadata alongside result
+ * metadata (promptTokens, outputTokens, toolCallRounds).
+ *
+ * Since v3 files are not append-only, they are fully parsed each time
+ * (no incremental byte-offset tracking).
+ */
+
+import { readFile } from "node:fs/promises";
+import type { Source } from "@pew/core";
+import type { ParsedDelta } from "./claude.js";
+import { normalizeModelId, estimateToolRoundTokens } from "./vscode-copilot.js";
+import { toNonNegInt } from "../utils/token-delta.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VscodeCopilotV3ParseOpts {
+  filePath: string;
+}
+
+export interface VscodeCopilotV3FileResult {
+  deltas: ParsedDelta[];
+}
+
+// ---------------------------------------------------------------------------
+// Main parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a VSCode Copilot Chat v3 JSON file.
+ *
+ * Strategy:
+ * 1. Read and parse the entire JSON file
+ * 2. Validate version field (must be 3)
+ * 3. Iterate requests array, extract tokens from each request's result.metadata
+ * 4. Skip requests without token data or with zero tokens
+ */
+export async function parseVscodeCopilotV3File(
+  opts: VscodeCopilotV3ParseOpts,
+): Promise<VscodeCopilotV3FileResult> {
+  const { filePath } = opts;
+  const deltas: ParsedDelta[] = [];
+
+  let raw: string;
+  try {
+    raw = await readFile(filePath, "utf8");
+  } catch {
+    return { deltas };
+  }
+
+  let session: Record<string, unknown>;
+  try {
+    session = JSON.parse(raw);
+  } catch {
+    return { deltas };
+  }
+
+  if (!session || typeof session !== "object" || Array.isArray(session)) {
+    return { deltas };
+  }
+
+  // Only handle version 3
+  if (session.version !== 3) {
+    return { deltas };
+  }
+
+  const requests = session.requests;
+  if (!Array.isArray(requests)) {
+    return { deltas };
+  }
+
+  for (const req of requests) {
+    if (!req || typeof req !== "object") continue;
+    const r = req as Record<string, unknown>;
+
+    // Extract model and timestamp
+    const rawModelId = r.modelId;
+    const rawTimestamp = r.timestamp;
+
+    if (typeof rawModelId !== "string" || !rawModelId) continue;
+    if (typeof rawTimestamp !== "number" || !Number.isFinite(rawTimestamp)) continue;
+
+    const modelId = normalizeModelId(rawModelId);
+    const timestamp = new Date(rawTimestamp).toISOString();
+
+    // Extract result metadata
+    const result = r.result as Record<string, unknown> | undefined;
+    if (!result || typeof result !== "object") continue;
+
+    const metadata = result.metadata as Record<string, unknown> | undefined;
+    if (!metadata || typeof metadata !== "object") continue;
+
+    const promptTokens = toNonNegInt(metadata.promptTokens);
+    const outputTokens = toNonNegInt(metadata.outputTokens);
+    const toolCallRounds = Array.isArray(metadata.toolCallRounds) ? metadata.toolCallRounds : [];
+    const { toolArgsTokens, thinkingTokens } = estimateToolRoundTokens(toolCallRounds);
+
+    // Skip zero-token results
+    if (promptTokens === 0 && outputTokens === 0 && toolArgsTokens === 0 && thinkingTokens === 0) {
+      continue;
+    }
+
+    deltas.push({
+      source: "vscode-copilot" as Source,
+      model: modelId,
+      timestamp,
+      tokens: {
+        inputTokens: promptTokens,
+        outputTokens: outputTokens + toolArgsTokens,
+        cachedInputTokens: 0,
+        reasoningOutputTokens: thinkingTokens,
+      },
+    });
+  }
+
+  return { deltas };
+}

--- a/packages/cli/src/parsers/vscode-copilot.ts
+++ b/packages/cli/src/parsers/vscode-copilot.ts
@@ -71,7 +71,7 @@ export interface VscodeCopilotFileResult {
 // ---------------------------------------------------------------------------
 
 /** Strip "copilot/" prefix from model IDs (e.g. "copilot/claude-opus-4.6" → "claude-opus-4.6") */
-function normalizeModelId(raw: string): string {
+export function normalizeModelId(raw: string): string {
   return raw.startsWith("copilot/") ? raw.slice(8) : raw;
 }
 


### PR DESCRIPTION
## Summary

Fixes #36.

VS Code 1.108+ stores chat sessions as `.json` files with a `version: 3` schema instead of the CRDT `.jsonl` format. This PR adds support for parsing the new format.

## Changes

- **New v3 JSON parser** (`parseVscodeCopilotV3File`): Reads the entire JSON file, validates `version: 3`, iterates `requests[]` to extract tokens from `result.metadata`
- **Discovery**: `discoverVscodeCopilotFiles` now matches both `.jsonl` and `.json` files
- **Token driver routing**: `.json` files → v3 parser (full parse), `.jsonl` files → existing CRDT parser (incremental)
- **Shared utilities**: Exported `normalizeModelId` from existing parser for reuse

## Design decisions

- **Source isolation**: v3 parser is a separate file, completely independent from CRDT parser
- **Full parse**: v3 files are plain JSON (not append-only), so no byte-offset tracking needed. Skip gate uses `inode+mtime+size` via existing `fileUnchanged()`
- **Reuse**: `estimateToolRoundTokens` and `normalizeModelId` shared with CRDT parser
- **v3 cursor**: No `requestMeta`/`processedRequestIndices` (CRDT-specific fields), just `offset=0` with standard fingerprint

## Tests

16 new tests covering: single/multiple requests, model ID normalization, zero-token skip, missing result/metadata, tool args estimation, thinking token estimation, empty/missing/invalid files, non-v3 rejection.