### PR TITLE
feat(web): unify chart tooltip styling across all visualizations

### DIFF
--- a/packages/web/src/components/dashboard/cache-rate-chart.tsx
+++ b/packages/web/src/components/dashboard/cache-rate-chart.tsx
@@ -14,6 +14,7 @@ import { formatTokens } from "@/lib/utils";
 import { chart, chartAxis } from "@/lib/palette";
 import type { DailyCacheRate } from "@/lib/cost-helpers";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import { ChartTooltip, ChartTooltipSubtitle } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -63,17 +64,14 @@ function CacheRateTooltip({
   const point = (payload[0] as (typeof payload)[number]).payload;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
-      <p className="text-sm font-semibold text-foreground">
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
+      <p className="text-sm font-semibold text-popover-foreground">
         {point.cacheRate.toFixed(1)}%
       </p>
-      <p className="text-xs text-muted-foreground">
+      <ChartTooltipSubtitle>
         {formatTokens(point.cachedTokens)} cached / {formatTokens(point.inputTokens)} input
-      </p>
-    </div>
+      </ChartTooltipSubtitle>
+    </ChartTooltip>
   );
 }
 

--- a/packages/web/src/components/dashboard/chart-tooltip.tsx
+++ b/packages/web/src/components/dashboard/chart-tooltip.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// ChartTooltip — unified tooltip wrapper for all Recharts charts
+// ---------------------------------------------------------------------------
+
+interface ChartTooltipProps {
+  /** Optional title displayed at the top of the tooltip */
+  title?: string;
+  /** Tooltip content (rows, dividers, etc.) */
+  children: React.ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Unified tooltip container for Recharts charts.
+ *
+ * Features:
+ * - Consistent styling across all charts
+ * - Shadow and ring for visual prominence
+ * - Dark mode support via CSS variables
+ * - 12px (text-xs) base font size
+ */
+export function ChartTooltip({ title, children, className }: ChartTooltipProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-[var(--radius-widget)] bg-popover p-2.5 shadow-lg ring-1 ring-border/50",
+        className
+      )}
+    >
+      {title && (
+        <p className="mb-1.5 text-xs font-medium text-popover-foreground">
+          {title}
+        </p>
+      )}
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChartTooltipRow — a single data row with color indicator
+// ---------------------------------------------------------------------------
+
+interface ChartTooltipRowProps {
+  /** Color for the indicator dot */
+  color: string;
+  /** Label text (e.g., "Input", "Output") */
+  label: string;
+  /** Formatted value (e.g., "1.2M", "$4.50") */
+  value: string;
+  /** Use tabular-nums for numeric alignment */
+  tabularNums?: boolean;
+}
+
+/**
+ * A single row in the chart tooltip showing color indicator, label, and value.
+ */
+export function ChartTooltipRow({
+  color,
+  label,
+  value,
+  tabularNums = false,
+}: ChartTooltipRowProps) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <div
+        className="h-2 w-2 shrink-0 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      <span className="text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "ml-auto font-medium text-popover-foreground",
+          tabularNums && "tabular-nums"
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChartTooltipDivider — horizontal separator
+// ---------------------------------------------------------------------------
+
+/**
+ * A subtle horizontal divider for separating sections in the tooltip.
+ */
+export function ChartTooltipDivider() {
+  return <div className="my-1 border-b border-border/50" />;
+}
+
+// ---------------------------------------------------------------------------
+// ChartTooltipSummary — summary row (e.g., Total)
+// ---------------------------------------------------------------------------
+
+interface ChartTooltipSummaryProps {
+  /** Label text (e.g., "Total") */
+  label: string;
+  /** Formatted value */
+  value: string;
+}
+
+/**
+ * A summary row with divider, typically used for totals.
+ */
+export function ChartTooltipSummary({ label, value }: ChartTooltipSummaryProps) {
+  return (
+    <>
+      <ChartTooltipDivider />
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="ml-auto font-medium text-popover-foreground">
+          {value}
+        </span>
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChartTooltipSubtitle — secondary info line
+// ---------------------------------------------------------------------------
+
+interface ChartTooltipSubtitleProps {
+  children: React.ReactNode;
+}
+
+/**
+ * A subtitle line for additional context (e.g., source info).
+ */
+export function ChartTooltipSubtitle({ children }: ChartTooltipSubtitleProps) {
+  return (
+    <p className="mb-1 text-xs text-muted-foreground">{children}</p>
+  );
+}

--- a/packages/web/src/components/dashboard/chart-tooltip.tsx
+++ b/packages/web/src/components/dashboard/chart-tooltip.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 
 interface ChartTooltipProps {
   /** Optional title displayed at the top of the tooltip */
-  title?: string;
+  title?: string | undefined;
   /** Tooltip content (rows, dividers, etc.) */
   children: React.ReactNode;
   /** Additional CSS classes */

--- a/packages/web/src/components/dashboard/cost-per-token-chart.tsx
+++ b/packages/web/src/components/dashboard/cost-per-token-chart.tsx
@@ -16,6 +16,7 @@ import { shortModel } from "@/lib/model-helpers";
 import { sourceLabel } from "@/hooks/use-usage-data";
 import type { ModelCostEfficiency } from "@/lib/cost-helpers";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import { ChartTooltip, ChartTooltipSubtitle } from "./chart-tooltip";
 
 // Color scale: green (cheap) → amber (mid) → red (expensive)
 const colorCheap = chartPositive;
@@ -74,30 +75,29 @@ function CostPerTokenTooltip({
   if (!d) return null;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-0.5 text-xs font-medium text-foreground">{d.model}</p>
-      <p className="mb-1.5 text-xs text-muted-foreground">{d.sourceLabel}</p>
+    <ChartTooltip title={d.model}>
+      <ChartTooltipSubtitle>{d.sourceLabel}</ChartTooltipSubtitle>
       <div className="space-y-0.5 text-xs">
         <div className="flex items-center justify-between gap-4">
           <span className="text-muted-foreground">Cost/1K tokens</span>
-          <span className="font-medium text-foreground">
+          <span className="font-medium text-popover-foreground">
             {formatCost(d.costPer1K)}
           </span>
         </div>
         <div className="flex items-center justify-between gap-4">
           <span className="text-muted-foreground">Total cost</span>
-          <span className="font-medium text-foreground">
+          <span className="font-medium text-popover-foreground">
             {formatCost(d.totalCost)}
           </span>
         </div>
         <div className="flex items-center justify-between gap-4">
           <span className="text-muted-foreground">Total tokens</span>
-          <span className="font-medium text-foreground">
+          <span className="font-medium text-popover-foreground">
             {d.totalTokens.toLocaleString()}
           </span>
         </div>
       </div>
-    </div>
+    </ChartTooltip>
   );
 }
 

--- a/packages/web/src/components/dashboard/cost-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/cost-trend-chart.tsx
@@ -13,6 +13,11 @@ import { formatCost } from "@/lib/pricing";
 import { chart, chartAxis, CHART_COLORS, chartMuted } from "@/lib/palette";
 import type { DailyCostPoint } from "@/lib/cost-helpers";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import {
+  ChartTooltip,
+  ChartTooltipRow,
+  ChartTooltipSummary,
+} from "./chart-tooltip";
 
 // Stable color references
 const colorOutput = CHART_COLORS[1] as string;
@@ -52,7 +57,7 @@ function fmtAxisCost(value: number): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function CostTooltip({
+function CostTrendTooltip({
   active,
   payload,
   label,
@@ -73,35 +78,21 @@ function CostTooltip({
   const orderedKeys = ["inputCost", "outputCost", "cachedCost"] as const;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
-      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
-        <span className="text-muted-foreground">Total</span>
-        <span className="ml-auto font-medium text-foreground">
-          {formatCost(total)}
-        </span>
-      </div>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {orderedKeys.map((key) => {
         const entry = payload.find((e) => e.dataKey === key);
         if (!entry) return null;
         return (
-          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-            <div
-              className="h-2 w-2 rounded-full"
-              style={{ backgroundColor: entry.color }}
-            />
-            <span className="text-muted-foreground">
-              {labels[entry.dataKey] ?? entry.dataKey}
-            </span>
-            <span className="ml-auto font-medium text-foreground">
-              {formatCost(entry.value)}
-            </span>
-          </div>
+          <ChartTooltipRow
+            key={entry.dataKey}
+            color={entry.color}
+            label={labels[entry.dataKey] ?? entry.dataKey}
+            value={formatCost(entry.value)}
+          />
         );
       })}
-    </div>
+      <ChartTooltipSummary label="Total" value={formatCost(total)} />
+    </ChartTooltip>
   );
 }
 
@@ -197,7 +188,7 @@ export function CostTrendChart({ data, className }: CostTrendChartProps) {
               tickLine={false}
               width={52}
             />
-            <Tooltip content={<CostTooltip />} isAnimationActive={false} />
+            <Tooltip content={<CostTrendTooltip />} isAnimationActive={false} />
             <Area
               type="monotone"
               dataKey="inputCost"

--- a/packages/web/src/components/dashboard/device-breakdown-chart.tsx
+++ b/packages/web/src/components/dashboard/device-breakdown-chart.tsx
@@ -13,6 +13,11 @@ import { chart, chartAxis, CHART_COLORS } from "@/lib/palette";
 import { deviceLabel } from "@/lib/device-helpers";
 import type { DeviceAggregate } from "@pew/core";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import {
+  ChartTooltip,
+  ChartTooltipRow,
+  ChartTooltipSummary,
+} from "./chart-tooltip";
 
 // Safe color references
 const colorOutput = CHART_COLORS[1] as string;
@@ -55,37 +60,24 @@ function DeviceBreakdownTooltip({
 
   const deviceData = payload[0]?.payload;
   const total = deviceData?.total_tokens ?? 0;
-
   const orderedKeys = ["input_tokens", "output_tokens", "cached_input_tokens"] as const;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-0.5 text-xs font-medium text-foreground">{label}</p>
-      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
-        <span className="text-muted-foreground">Total</span>
-        <span className="ml-auto font-medium text-foreground">
-          {formatTokens(total)}
-        </span>
-      </div>
+    <ChartTooltip title={label}>
       {orderedKeys.map((key) => {
         const entry = payload.find((e) => e.dataKey === key);
         if (!entry) return null;
         return (
-          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-            <div
-              className="h-2 w-2 rounded-full"
-              style={{ backgroundColor: entry.color }}
-            />
-            <span className="text-muted-foreground">
-              {labels[entry.dataKey] ?? entry.dataKey}
-            </span>
-            <span className="ml-auto font-medium text-foreground">
-              {formatTokens(entry.value)}
-            </span>
-          </div>
+          <ChartTooltipRow
+            key={entry.dataKey}
+            color={entry.color}
+            label={labels[entry.dataKey] ?? entry.dataKey}
+            value={formatTokens(entry.value)}
+          />
         );
       })}
-    </div>
+      <ChartTooltipSummary label="Total" value={formatTokens(total)} />
+    </ChartTooltip>
   );
 }
 

--- a/packages/web/src/components/dashboard/device-share-chart.tsx
+++ b/packages/web/src/components/dashboard/device-share-chart.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/device-helpers";
 import type { DeviceAggregate, DeviceTimelinePoint } from "@pew/core";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -49,7 +50,7 @@ function fmtPct(value: number): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function ShareTooltip({
+function DeviceShareTooltip({
   active,
   payload,
   label,
@@ -65,25 +66,16 @@ function ShareTooltip({
   const items = [...payload].reverse();
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {items.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {labelMap.get(entry.dataKey) ?? entry.dataKey}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {entry.value.toFixed(1)}%
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={entry.dataKey}
+          color={entry.color}
+          label={labelMap.get(entry.dataKey) ?? entry.dataKey}
+          value={`${entry.value.toFixed(1)}%`}
+        />
       ))}
-    </div>
+    </ChartTooltip>
   );
 }
 
@@ -206,7 +198,7 @@ export function DeviceShareChart({
               width={44}
               domain={[0, 100]}
             />
-            <Tooltip content={<ShareTooltip labelMap={labelMap} />} isAnimationActive={false} />
+            <Tooltip content={<DeviceShareTooltip labelMap={labelMap} />} isAnimationActive={false} />
             {deviceKeys.map((deviceId, i) => (
               <Area
                 key={deviceId}

--- a/packages/web/src/components/dashboard/device-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/device-trend-chart.tsx
@@ -17,6 +17,11 @@ import {
 } from "@/lib/device-helpers";
 import type { DeviceAggregate, DeviceTimelinePoint } from "@pew/core";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import {
+  ChartTooltip,
+  ChartTooltipRow,
+  ChartTooltipSummary,
+} from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -73,33 +78,19 @@ function DeviceTrendTooltip({
   const total = visible.reduce((sum, e) => sum + e.value, 0);
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {visible.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {labelMap.get(entry.dataKey) ?? entry.dataKey}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {formatTokens(entry.value)}
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={entry.dataKey}
+          color={entry.color}
+          label={labelMap.get(entry.dataKey) ?? entry.dataKey}
+          value={formatTokens(entry.value)}
+        />
       ))}
       {visible.length > 1 && (
-        <div className="mt-1.5 border-t border-border pt-1.5 flex items-center justify-between text-xs">
-          <span className="text-muted-foreground">Total</span>
-          <span className="font-medium text-foreground">
-            {formatTokens(total)}
-          </span>
-        </div>
+        <ChartTooltipSummary label="Total" value={formatTokens(total)} />
       )}
-    </div>
+    </ChartTooltip>
   );
 }
 

--- a/packages/web/src/components/dashboard/hourly-chart.tsx
+++ b/packages/web/src/components/dashboard/hourly-chart.tsx
@@ -14,6 +14,7 @@ import { chart, chartAxis, chartMuted } from "@/lib/palette";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 import type { HourlyWeekdayWeekendPoint } from "@/lib/usage-helpers";
 import { Clock } from "lucide-react";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,7 +41,7 @@ function fmtHour(hour: number): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function ChartTooltip({
+function HourlyTooltip({
   active,
   payload,
   label,
@@ -56,25 +57,17 @@ function ChartTooltip({
     : "";
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {hourRange}
-      </p>
+    <ChartTooltip title={hourRange}>
       {payload.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {entry.dataKey === "weekday" ? "Weekday" : "Weekend"}
-          </span>
-          <span className="ml-auto font-medium text-foreground tabular-nums">
-            {formatTokens(entry.value)}
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={entry.dataKey}
+          color={entry.color}
+          label={entry.dataKey === "weekday" ? "Weekday" : "Weekend"}
+          value={formatTokens(entry.value)}
+          tabularNums
+        />
       ))}
-    </div>
+    </ChartTooltip>
   );
 }
 
@@ -177,7 +170,7 @@ export function HourlyChart({ data, className }: HourlyChartProps) {
               tickLine={false}
               width={48}
             />
-            <Tooltip content={<ChartTooltip />} isAnimationActive={false} />
+            <Tooltip content={<HourlyTooltip />} isAnimationActive={false} />
             <Bar
               dataKey="weekday"
               fill={chart.violet}

--- a/packages/web/src/components/dashboard/io-ratio-chart.tsx
+++ b/packages/web/src/components/dashboard/io-ratio-chart.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { formatTokens } from "@/lib/utils";
 import { chart } from "@/lib/palette";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,7 +29,7 @@ const SLICE_COLORS = [chart.violet, chart.magenta] as const;
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function IoTooltip({
+function IoRatioTooltip({
   active,
   payload,
 }: {
@@ -43,18 +44,13 @@ function IoTooltip({
   const item = payload[0] as (typeof payload)[number];
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <div className="flex items-center gap-2">
-        <div
-          className="h-3 w-3 rounded-full"
-          style={{ backgroundColor: item.payload.fill }}
-        />
-        <span className="text-sm font-medium text-foreground">{item.name}</span>
-      </div>
-      <div className="text-sm text-muted-foreground">
-        {formatTokens(item.value)} ({(item.payload.percent * 100).toFixed(1)}%)
-      </div>
-    </div>
+    <ChartTooltip>
+      <ChartTooltipRow
+        color={item.payload.fill}
+        label={item.name}
+        value={`${formatTokens(item.value)} (${(item.payload.percent * 100).toFixed(1)}%)`}
+      />
+    </ChartTooltip>
   );
 }
 
@@ -133,7 +129,7 @@ export function IoRatioChart({
                   <Cell key={entry.name} fill={SLICE_COLORS[i] as string} />
                 ))}
               </Pie>
-              <Tooltip content={<IoTooltip />} isAnimationActive={false} />
+              <Tooltip content={<IoRatioTooltip />} isAnimationActive={false} />
             </PieChart>
           </DashboardResponsiveContainer>
           {/* Center label showing I/O ratio */}

--- a/packages/web/src/components/dashboard/message-stats-chart.tsx
+++ b/packages/web/src/components/dashboard/message-stats-chart.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { chartAxis, CHART_COLORS } from "@/lib/palette";
 import type { MessageDailyStat } from "@/lib/session-helpers";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -43,7 +44,7 @@ function fmtDate(dateStr: string): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function ChartTooltip({
+function MessageStatsTooltip({
   active,
   payload,
   label,
@@ -60,25 +61,16 @@ function ChartTooltip({
   };
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {payload.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {labels[entry.dataKey] ?? entry.dataKey}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {entry.value.toLocaleString()}
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={entry.dataKey}
+          color={entry.color}
+          label={labels[entry.dataKey] ?? entry.dataKey}
+          value={entry.value.toLocaleString()}
+        />
       ))}
-    </div>
+    </ChartTooltip>
   );
 }
 
@@ -155,7 +147,7 @@ export function MessageStatsChart({ data, className }: MessageStatsChartProps) {
               tickLine={false}
               width={36}
             />
-            <Tooltip content={<ChartTooltip />} isAnimationActive={false} />
+            <Tooltip content={<MessageStatsTooltip />} isAnimationActive={false} />
             <Bar
               dataKey="user"
               stackId="1"

--- a/packages/web/src/components/dashboard/model-breakdown-chart.tsx
+++ b/packages/web/src/components/dashboard/model-breakdown-chart.tsx
@@ -15,6 +15,12 @@ import { shortModel } from "@/lib/model-helpers";
 import type { ModelAggregate } from "@/hooks/use-usage-data";
 import { sourceLabel } from "@/hooks/use-usage-data";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import {
+  ChartTooltip,
+  ChartTooltipRow,
+  ChartTooltipSummary,
+  ChartTooltipSubtitle,
+} from "./chart-tooltip";
 
 // Safe color references
 const colorOutput = CHART_COLORS[1] as string;
@@ -33,7 +39,7 @@ interface ModelBreakdownChartProps {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function ModelTooltip({
+function ModelBreakdownTooltip({
   active,
   payload,
   label,
@@ -57,44 +63,29 @@ function ModelTooltip({
 
   const modelData = payload[0]?.payload;
   const total = modelData?.total ?? 0;
-
   const orderedKeys = ["input", "output", "cached"] as const;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-0.5 text-xs font-medium text-foreground">
-        {label}
-      </p>
+    <ChartTooltip title={label}>
       {modelData && (
-        <p className="mb-1 text-xs text-muted-foreground">
-          {modelData.sourceLabel} &middot; {formatTokens(modelData.total)} total
-        </p>
+        <ChartTooltipSubtitle>
+          {modelData.sourceLabel}
+        </ChartTooltipSubtitle>
       )}
-      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
-        <span className="text-muted-foreground">Total</span>
-        <span className="ml-auto font-medium text-foreground">
-          {formatTokens(total)}
-        </span>
-      </div>
       {orderedKeys.map((key) => {
         const entry = payload.find((e) => e.dataKey === key);
         if (!entry) return null;
         return (
-          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-            <div
-              className="h-2 w-2 rounded-full"
-              style={{ backgroundColor: entry.color }}
-            />
-            <span className="text-muted-foreground">
-              {labels[entry.dataKey] ?? entry.dataKey}
-            </span>
-            <span className="ml-auto font-medium text-foreground">
-              {formatTokens(entry.value)}
-            </span>
-          </div>
+          <ChartTooltipRow
+            key={entry.dataKey}
+            color={entry.color}
+            label={labels[entry.dataKey] ?? entry.dataKey}
+            value={formatTokens(entry.value)}
+          />
         );
       })}
-    </div>
+      <ChartTooltipSummary label="Total" value={formatTokens(total)} />
+    </ChartTooltip>
   );
 }
 
@@ -226,7 +217,7 @@ export function ModelBreakdownChart({
               tickLine={false}
               width={140}
             />
-            <Tooltip content={<ModelTooltip />} isAnimationActive={false} />
+            <Tooltip content={<ModelBreakdownTooltip />} isAnimationActive={false} />
             <Bar
               dataKey="input"
               stackId="1"

--- a/packages/web/src/components/dashboard/model-evolution-chart.tsx
+++ b/packages/web/src/components/dashboard/model-evolution-chart.tsx
@@ -15,6 +15,7 @@ import { modelColor } from "@/lib/palette";
 import { shortModel } from "@/lib/model-helpers";
 import type { ModelEra } from "@/lib/model-helpers";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,7 +62,7 @@ function fmtPct(value: number): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function EvolutionTooltip({
+function ModelEvolutionTooltip({
   active,
   payload,
   label,
@@ -76,25 +77,16 @@ function EvolutionTooltip({
   const items = [...payload].reverse();
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {items.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {shortModel(entry.dataKey)}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {entry.value.toFixed(1)}%
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={entry.dataKey}
+          color={entry.color}
+          label={shortModel(entry.dataKey)}
+          value={`${entry.value.toFixed(1)}%`}
+        />
       ))}
-    </div>
+    </ChartTooltip>
   );
 }
 
@@ -225,7 +217,7 @@ export function ModelEvolutionChart({
               domain={[0, 100]}
             />
             <Tooltip
-              content={<EvolutionTooltip />}
+              content={<ModelEvolutionTooltip />}
               isAnimationActive={false}
             />
             {modelKeys.map((model) => (

--- a/packages/web/src/components/dashboard/project-breakdown-chart.tsx
+++ b/packages/web/src/components/dashboard/project-breakdown-chart.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 import { chart, chartAxis, CHART_COLORS } from "@/lib/palette";
 import type { ProjectBreakdownItem } from "@/lib/session-helpers";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -26,7 +27,7 @@ function formatHours(h: number): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function ProjectTooltip({
+function ProjectBreakdownTooltip({
   active,
   payload,
 }: {
@@ -45,43 +46,23 @@ function ProjectTooltip({
   if (!d) return null;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1 text-xs font-medium text-foreground">
-        {d.projectName}
-      </p>
-      <div className="space-y-0.5">
-        <div className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: chart.violet }}
-          />
-          <span className="text-muted-foreground">Sessions</span>
-          <span className="ml-auto font-medium text-foreground">
-            {d.sessions}
-          </span>
-        </div>
-        <div className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: CHART_COLORS[1] }}
-          />
-          <span className="text-muted-foreground">Hours</span>
-          <span className="ml-auto font-medium text-foreground">
-            {formatHours(d.totalHours)}
-          </span>
-        </div>
-        <div className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: CHART_COLORS[2] }}
-          />
-          <span className="text-muted-foreground">Messages</span>
-          <span className="ml-auto font-medium text-foreground">
-            {d.totalMessages.toLocaleString()}
-          </span>
-        </div>
-      </div>
-    </div>
+    <ChartTooltip title={d.projectName}>
+      <ChartTooltipRow
+        color={chart.violet}
+        label="Sessions"
+        value={String(d.sessions)}
+      />
+      <ChartTooltipRow
+        color={CHART_COLORS[1] as string}
+        label="Hours"
+        value={formatHours(d.totalHours)}
+      />
+      <ChartTooltipRow
+        color={CHART_COLORS[2] as string}
+        label="Messages"
+        value={d.totalMessages.toLocaleString()}
+      />
+    </ChartTooltip>
   );
 }
 
@@ -161,7 +142,7 @@ export function ProjectBreakdownChart({
               tickLine={false}
               width={140}
             />
-            <Tooltip content={<ProjectTooltip />} isAnimationActive={false} />
+            <Tooltip content={<ProjectBreakdownTooltip />} isAnimationActive={false} />
             <Bar
               dataKey="sessions"
               fill={chart.violet}

--- a/packages/web/src/components/dashboard/project-share-chart.tsx
+++ b/packages/web/src/components/dashboard/project-share-chart.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 import { chartAxis, CHART_COLORS } from "@/lib/palette";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 import type { ProjectTimelinePoint } from "./project-trend-chart";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -58,7 +59,7 @@ function toSharePoints(
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function ShareTooltip({
+function ProjectShareTooltip({
   active,
   payload,
   label,
@@ -72,23 +73,16 @@ function ShareTooltip({
   const items = [...payload].reverse();
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {items.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">{entry.dataKey}</span>
-          <span className="ml-auto font-medium text-foreground">
-            {entry.value.toFixed(1)}%
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={entry.dataKey}
+          color={entry.color}
+          label={entry.dataKey}
+          value={`${entry.value.toFixed(1)}%`}
+        />
       ))}
-    </div>
+    </ChartTooltip>
   );
 }
 
@@ -206,7 +200,7 @@ export function ProjectShareChart({
               width={44}
               domain={[0, 100]}
             />
-            <Tooltip content={<ShareTooltip />} isAnimationActive={false} />
+            <Tooltip content={<ProjectShareTooltip />} isAnimationActive={false} />
             {projectKeys.map((name, i) => (
               <Area
                 key={name}

--- a/packages/web/src/components/dashboard/project-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/project-trend-chart.tsx
@@ -12,6 +12,11 @@ import {
 import { cn } from "@/lib/utils";
 import { chartAxis, CHART_COLORS } from "@/lib/palette";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import {
+  ChartTooltip,
+  ChartTooltipRow,
+  ChartTooltipSummary,
+} from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -63,29 +68,19 @@ function ProjectTrendTooltip({
   const total = visible.reduce((sum, e) => sum + e.value, 0);
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {visible.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">{entry.dataKey}</span>
-          <span className="ml-auto font-medium text-foreground">
-            {entry.value}
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={entry.dataKey}
+          color={entry.color}
+          label={entry.dataKey}
+          value={String(entry.value)}
+        />
       ))}
       {visible.length > 1 && (
-        <div className="mt-1.5 border-t border-border pt-1.5 flex items-center justify-between text-xs">
-          <span className="text-muted-foreground">Total</span>
-          <span className="font-medium text-foreground">{total}</span>
-        </div>
+        <ChartTooltipSummary label="Total" value={String(total)} />
       )}
-    </div>
+    </ChartTooltip>
   );
 }
 

--- a/packages/web/src/components/dashboard/recent-bar-chart.tsx
+++ b/packages/web/src/components/dashboard/recent-bar-chart.tsx
@@ -11,6 +11,11 @@ import {
 import { cn, formatTokens } from "@/lib/utils";
 import { chart, chartAxis, CHART_COLORS } from "@/lib/palette";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import {
+  ChartTooltip,
+  ChartTooltipRow,
+  ChartTooltipSummary,
+} from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,7 +70,7 @@ function fmtSlotFull(slot: string): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function ChartTooltip({
+function RecentBarTooltip({
   active,
   payload,
   label,
@@ -82,39 +87,24 @@ function ChartTooltip({
   };
 
   const total = payload.reduce((sum, e) => sum + e.value, 0);
-
   const orderedKeys = ["input", "output"] as const;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtSlotFull(label) : ""}
-      </p>
-      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
-        <span className="text-muted-foreground">Total</span>
-        <span className="ml-auto font-medium text-foreground">
-          {formatTokens(total)}
-        </span>
-      </div>
+    <ChartTooltip title={label ? fmtSlotFull(label) : undefined}>
       {orderedKeys.map((key) => {
         const entry = payload.find((e) => e.dataKey === key);
         if (!entry) return null;
         return (
-          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-            <div
-              className="h-2 w-2 rounded-full"
-              style={{ backgroundColor: entry.color }}
-            />
-            <span className="text-muted-foreground">
-              {labels[entry.dataKey] ?? entry.dataKey}
-            </span>
-            <span className="ml-auto font-medium text-foreground">
-              {formatTokens(entry.value)}
-            </span>
-          </div>
+          <ChartTooltipRow
+            key={entry.dataKey}
+            color={entry.color}
+            label={labels[entry.dataKey] ?? entry.dataKey}
+            value={formatTokens(entry.value)}
+          />
         );
       })}
-    </div>
+      <ChartTooltipSummary label="Total" value={formatTokens(total)} />
+    </ChartTooltip>
   );
 }
 
@@ -198,7 +188,7 @@ export function RecentBarChart({ data, className }: RecentBarChartProps) {
               tickLine={false}
               width={48}
             />
-            <Tooltip content={<ChartTooltip />} isAnimationActive={false} />
+            <Tooltip content={<RecentBarTooltip />} isAnimationActive={false} />
             <Bar
               dataKey="input"
               stackId="1"

--- a/packages/web/src/components/dashboard/salary-estimator-card.tsx
+++ b/packages/web/src/components/dashboard/salary-estimator-card.tsx
@@ -13,6 +13,7 @@ import { Banknote, ExternalLink, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { chart, chartAxis, chartMuted } from "@/lib/palette";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -396,30 +397,21 @@ function SalaryTooltip({
   };
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {["actual", "upper", "lower"].map((key) => {
         const entry = payload.find((e) => e.dataKey === key);
         if (!entry) return null;
         return (
-          <div key={key} className="flex items-center gap-2 text-xs">
-            <div
-              className="h-2 w-2 rounded-full"
-              style={{
-                backgroundColor: key === "actual" ? chart.violet : chartMuted,
-                opacity: key === "actual" ? 1 : 0.6,
-              }}
-            />
-            <span className="text-muted-foreground">{labels[key]}</span>
-            <span className="ml-auto font-medium text-foreground tabular-nums">
-              {formatSalary(entry.value)}/yr
-            </span>
-          </div>
+          <ChartTooltipRow
+            key={key}
+            color={key === "actual" ? chart.violet : chartMuted}
+            label={labels[key] ?? key}
+            value={`${formatSalary(entry.value)}/yr`}
+            tabularNums
+          />
         );
       })}
-    </div>
+    </ChartTooltip>
   );
 }
 

--- a/packages/web/src/components/dashboard/source-donut-chart.tsx
+++ b/packages/web/src/components/dashboard/source-donut-chart.tsx
@@ -11,6 +11,7 @@ import { formatTokens } from "@/lib/utils";
 import { agentColor } from "@/lib/palette";
 import type { SourceAggregate } from "@/hooks/use-usage-data";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import { ChartTooltip, ChartTooltipRow } from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,7 +26,7 @@ interface SourceDonutChartProps {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function DonutTooltip({
+function SourceDonutTooltip({
   active,
   payload,
 }: {
@@ -40,18 +41,13 @@ function DonutTooltip({
   const item = payload[0] as (typeof payload)[number];
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <div className="flex items-center gap-2">
-        <div
-          className="h-3 w-3 rounded-full"
-          style={{ backgroundColor: item.payload.fill }}
-        />
-        <span className="text-sm font-medium text-foreground">{item.name}</span>
-      </div>
-      <div className="text-sm text-muted-foreground">
-        {formatTokens(item.value)} ({(item.payload.percent * 100).toFixed(1)}%)
-      </div>
-    </div>
+    <ChartTooltip>
+      <ChartTooltipRow
+        color={item.payload.fill}
+        label={item.name}
+        value={`${formatTokens(item.value)} (${(item.payload.percent * 100).toFixed(1)}%)`}
+      />
+    </ChartTooltip>
   );
 }
 
@@ -111,7 +107,7 @@ export function SourceDonutChart({ data, className }: SourceDonutChartProps) {
                   <Cell key={entry.name} fill={entry.fill} />
                 ))}
               </Pie>
-              <Tooltip content={<DonutTooltip />} isAnimationActive={false} />
+              <Tooltip content={<SourceDonutTooltip />} isAnimationActive={false} />
             </PieChart>
           </DashboardResponsiveContainer>
         </div>

--- a/packages/web/src/components/dashboard/source-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/source-trend-chart.tsx
@@ -15,6 +15,11 @@ import { agentColor } from "@/lib/palette";
 import { sourceLabel } from "@/hooks/use-usage-data";
 import type { SourceTrendPoint } from "@/lib/usage-helpers";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import {
+  ChartTooltip,
+  ChartTooltipRow,
+  ChartTooltipSummary,
+} from "./chart-tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -51,7 +56,7 @@ function fmtAxisTokens(value: number): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function SourceTooltip({
+function SourceTrendTooltip({
   active,
   payload,
   label,
@@ -70,33 +75,19 @@ function SourceTooltip({
   const total = visible.reduce((sum, e) => sum + e.value, 0);
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1.5 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {visible.map((entry) => (
-        <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-          <div
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: entry.color }}
-          />
-          <span className="text-muted-foreground">
-            {sourceLabel(entry.dataKey)}
-          </span>
-          <span className="ml-auto font-medium text-foreground">
-            {formatTokens(entry.value)}
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={entry.dataKey}
+          color={entry.color}
+          label={sourceLabel(entry.dataKey)}
+          value={formatTokens(entry.value)}
+        />
       ))}
       {visible.length > 1 && (
-        <div className="mt-1.5 border-t border-border pt-1.5 flex items-center justify-between text-xs">
-          <span className="text-muted-foreground">Total</span>
-          <span className="font-medium text-foreground">
-            {formatTokens(total)}
-          </span>
-        </div>
+        <ChartTooltipSummary label="Total" value={formatTokens(total)} />
       )}
-    </div>
+    </ChartTooltip>
   );
 }
 
@@ -218,7 +209,7 @@ export function SourceTrendChart({ data, className }: SourceTrendChartProps) {
               width={52}
             />
             <Tooltip
-              content={<SourceTooltip hiddenSources={hiddenSources} />}
+              content={<SourceTrendTooltip hiddenSources={hiddenSources} />}
               isAnimationActive={false}
             />
             {sourceKeys.map((source) => (

--- a/packages/web/src/components/dashboard/usage-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/usage-trend-chart.tsx
@@ -13,6 +13,11 @@ import { formatTokens } from "@/lib/utils";
 import { chart, chartAxis, CHART_COLORS, chartMuted } from "@/lib/palette";
 import type { DailyPoint } from "@/hooks/use-usage-data";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
+import {
+  ChartTooltip,
+  ChartTooltipRow,
+  ChartTooltipSummary,
+} from "./chart-tooltip";
 
 // Safe color references (CHART_COLORS is guaranteed 8 elements)
 const colorOutput = CHART_COLORS[1] as string;
@@ -44,7 +49,7 @@ function fmtDate(dateStr: string): string {
 // Custom tooltip
 // ---------------------------------------------------------------------------
 
-function ChartTooltip({
+function UsageTrendTooltip({
   active,
   payload,
   label,
@@ -65,35 +70,21 @@ function ChartTooltip({
   const orderedKeys = ["input", "output", "cached"] as const;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary p-2.5">
-      <p className="mb-1 text-xs font-medium text-foreground">
-        {label ? fmtDate(label) : ""}
-      </p>
-      <div className="mb-1 border-b border-border/50 pb-1 flex items-center gap-2 text-xs">
-        <span className="text-muted-foreground">Total</span>
-        <span className="ml-auto font-medium text-foreground">
-          {formatTokens(total)}
-        </span>
-      </div>
+    <ChartTooltip title={label ? fmtDate(label) : undefined}>
       {orderedKeys.map((key) => {
         const entry = payload.find((e) => e.dataKey === key);
         if (!entry) return null;
         return (
-          <div key={entry.dataKey} className="flex items-center gap-2 text-xs">
-            <div
-              className="h-2 w-2 rounded-full"
-              style={{ backgroundColor: entry.color }}
-            />
-            <span className="text-muted-foreground">
-              {labels[entry.dataKey] ?? entry.dataKey}
-            </span>
-            <span className="ml-auto font-medium text-foreground">
-              {formatTokens(entry.value)}
-            </span>
-          </div>
+          <ChartTooltipRow
+            key={entry.dataKey}
+            color={entry.color}
+            label={labels[entry.dataKey] ?? entry.dataKey}
+            value={formatTokens(entry.value)}
+          />
         );
       })}
-    </div>
+      <ChartTooltipSummary label="Total" value={formatTokens(total)} />
+    </ChartTooltip>
   );
 }
 
@@ -205,7 +196,7 @@ export function UsageTrendChart({ data, className }: UsageTrendChartProps) {
               tickLine={false}
               width={48}
             />
-            <Tooltip content={<ChartTooltip />} isAnimationActive={false} />
+            <Tooltip content={<UsageTrendTooltip />} isAnimationActive={false} />
             <Area
               type="monotone"
               dataKey="input"

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -32,7 +32,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 4,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -42,13 +42,12 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-[var(--radius-widget)] bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg ring-1 ring-border/50 fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
## Summary

- Add unified `ChartTooltip` component system for Recharts charts
- Update Radix Tooltip to match chart tooltip visual style
- Migrate all 19 chart components to use the new tooltip system

### Changes

1. **New `chart-tooltip.tsx`**: Reusable tooltip components
   - `ChartTooltip`: Main container with shadow, ring, dark mode support
   - `ChartTooltipRow`: Data row with color indicator
   - `ChartTooltipDivider`, `ChartTooltipSummary`, `ChartTooltipSubtitle`

2. **Unified styling**:
   - `bg-popover` for light/dark compatibility
   - `shadow-lg + ring-1 ring-border/50` for visual prominence
   - `text-xs` (12px) consistent font size
   - `radius-widget` (10px) rounded corners

3. **Charts updated**: usage-trend, source-trend, source-donut, cost-trend, cost-per-token, cache-rate, model-breakdown, model-evolution, device-breakdown, device-share, device-trend, project-breakdown, project-share, project-trend, hourly, recent-bar, io-ratio, message-stats, salary-estimator

## Test plan

- [x] Build passes
- [x] 2922 unit tests pass
- [x] Lint clean (0 warnings)
- [ ] Visual check: tooltips display correctly in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)