### PR TITLE
fix(cli): support hermes multi-profile token syncing

### DIFF
--- a/packages/cli/src/__tests__/drivers/token/hermes-token-driver.test.ts
+++ b/packages/cli/src/__tests__/drivers/token/hermes-token-driver.test.ts
@@ -27,18 +27,30 @@ describe("hermesSqliteTokenDriver", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it("has correct kind and source", () => {
+  it("has correct kind, source, and dbKey", () => {
     const driver = createHermesSqliteTokenDriver({
       dbPath,
+      dbKey: "default",
       openHermesDb: () => null,
     });
     expect(driver.kind).toBe("db");
     expect(driver.source).toBe("hermes");
+    expect(driver.dbKey).toBe("default");
+  });
+
+  it("has correct dbKey for profile databases", () => {
+    const driver = createHermesSqliteTokenDriver({
+      dbPath,
+      dbKey: "profiles/tomato",
+      openHermesDb: () => null,
+    });
+    expect(driver.dbKey).toBe("profiles/tomato");
   });
 
   it("returns empty result when openHermesDb returns null", async () => {
     const driver = createHermesSqliteTokenDriver({
       dbPath,
+      dbKey: "default",
       openHermesDb: () => null,
     });
 
@@ -66,6 +78,7 @@ describe("hermesSqliteTokenDriver", () => {
     let closeCalled = false;
     const driver = createHermesSqliteTokenDriver({
       dbPath,
+      dbKey: "default",
       openHermesDb: () => ({
         querySessions: mockSessions(sessions),
         close: () => { closeCalled = true; },
@@ -127,6 +140,7 @@ describe("hermesSqliteTokenDriver", () => {
 
     const driver = createHermesSqliteTokenDriver({
       dbPath,
+      dbKey: "default",
       openHermesDb: () => ({
         querySessions: mockSessions(sessions),
         close: () => {},
@@ -177,6 +191,7 @@ describe("hermesSqliteTokenDriver", () => {
 
     const driver = createHermesSqliteTokenDriver({
       dbPath,
+      dbKey: "default",
       openHermesDb: () => ({
         querySessions: mockSessions(sessions),
         close: () => {},
@@ -229,6 +244,7 @@ describe("hermesSqliteTokenDriver", () => {
 
     const driver = createHermesSqliteTokenDriver({
       dbPath,
+      dbKey: "default",
       openHermesDb: () => ({
         querySessions: mockSessions(sessions),
         close: () => {},

--- a/packages/cli/src/__tests__/paths.test.ts
+++ b/packages/cli/src/__tests__/paths.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolveDefaultPaths } from "../utils/paths.js";
 
 describe("resolveDefaultPaths", () => {
   let savedHermesHome: string | undefined;
   let savedCodexHome: string | undefined;
+  let tempDir: string | null = null;
 
   beforeEach(() => {
     savedHermesHome = process.env.HERMES_HOME;
@@ -23,6 +27,10 @@ describe("resolveDefaultPaths", () => {
       process.env.CODEX_HOME = savedCodexHome;
     } else {
       delete process.env.CODEX_HOME;
+    }
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
     }
   });
 
@@ -76,7 +84,7 @@ describe("resolveDefaultPaths", () => {
     expect(paths.hermesDbPath).toBe(join("/fakehome", ".hermes", "state.db"));
   });
 
-  it("should return exactly 14 path properties", () => {
+  it("should return exactly 15 path properties", () => {
     const keys = [
       "stateDir",
       "binDir",
@@ -86,6 +94,7 @@ describe("resolveDefaultPaths", () => {
       "copilotCliLogsDir",
       "geminiDir",
       "hermesDbPath",
+      "hermesProfileDbPaths",
       "kosmosDataDirs",
       "openCodeDbPath",
       "openCodeMessageDir",
@@ -100,5 +109,53 @@ describe("resolveDefaultPaths", () => {
         ...keys,
       ]),
     );
+  });
+
+  it("should return empty hermesProfileDbPaths when no profiles exist", () => {
+    const paths = resolveDefaultPaths("/fakehome");
+    expect(paths.hermesProfileDbPaths).toEqual([]);
+  });
+
+  it("should discover hermes profile databases", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "pew-paths-test-"));
+    const hermesDir = join(tempDir, ".hermes");
+    const profilesDir = join(hermesDir, "profiles");
+    const tomatoDir = join(profilesDir, "tomato");
+    const potatoDir = join(profilesDir, "potato");
+
+    // Create profile directories with state.db files
+    mkdirSync(tomatoDir, { recursive: true });
+    mkdirSync(potatoDir, { recursive: true });
+    writeFileSync(join(tomatoDir, "state.db"), "fake-db");
+    writeFileSync(join(potatoDir, "state.db"), "fake-db");
+
+    const paths = resolveDefaultPaths(tempDir);
+    expect(paths.hermesProfileDbPaths).toHaveLength(2);
+    expect(paths.hermesProfileDbPaths).toContainEqual({
+      dbPath: join(tomatoDir, "state.db"),
+      dbKey: "profiles/tomato",
+    });
+    expect(paths.hermesProfileDbPaths).toContainEqual({
+      dbPath: join(potatoDir, "state.db"),
+      dbKey: "profiles/potato",
+    });
+  });
+
+  it("should skip profiles without state.db", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "pew-paths-test-"));
+    const hermesDir = join(tempDir, ".hermes");
+    const profilesDir = join(hermesDir, "profiles");
+    const tomatoDir = join(profilesDir, "tomato");
+    const emptyDir = join(profilesDir, "empty");
+
+    // Create one profile with state.db, one without
+    mkdirSync(tomatoDir, { recursive: true });
+    mkdirSync(emptyDir, { recursive: true });
+    writeFileSync(join(tomatoDir, "state.db"), "fake-db");
+    // emptyDir has no state.db
+
+    const paths = resolveDefaultPaths(tempDir);
+    expect(paths.hermesProfileDbPaths).toHaveLength(1);
+    expect(paths.hermesProfileDbPaths[0].dbKey).toBe("profiles/tomato");
   });
 });

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -2537,12 +2537,12 @@ describe("executeSync", () => {
     });
     expect(r1.totalDeltas).toBe(2);
 
-    // Tamper cursor: change the hermesSqlite inode to force mismatch
+    // Tamper cursor: change the hermesSqlite.default inode to force mismatch
     const { CursorStore } = await import("../storage/cursor-store.js");
     const cursorStore = new CursorStore(stateDir);
     const cursors = await cursorStore.load();
-    const hermesCursor = (cursors as Record<string, unknown>).hermesSqlite as Record<string, unknown>;
-    hermesCursor.inode = 999999; // fake inode
+    const hermesCursors = (cursors as Record<string, unknown>).hermesSqlite as Record<string, Record<string, unknown>>;
+    hermesCursors["default"]!.inode = 999999; // fake inode
     await cursorStore.save(cursors);
 
     const events: Array<{ source: string; phase: string; message?: string }> = [];

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -195,6 +195,7 @@ const syncCommand = defineCommand({
       openCodeDbPath: paths.openCodeDbPath,
       openMessageDb,
       hermesDbPath: paths.hermesDbPath,
+      hermesProfileDbPaths: paths.hermesProfileDbPaths,
       openHermesDb,
       openclawDir: paths.openclawDir,
       piSessionsDir: paths.piSessionsDir,

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -3,6 +3,7 @@ import type {
   CursorState,
   FileCursor,
   FileCursorBase,
+  HermesSqliteCursor,
   QueueRecord,
   Source,
   TokenDelta,
@@ -46,6 +47,8 @@ export interface SyncOptions {
   copilotCliLogsDir?: string;
   /** Override: Hermes Agent database path (~/.hermes/state.db) */
   hermesDbPath?: string;
+  /** Override: Hermes profile database paths (~/.hermes/profiles/<name>/state.db) */
+  hermesProfileDbPaths?: Array<{ dbPath: string; dbKey: string }>;
   /** Factory for opening the Hermes SQLite DB (DI for testability) */
   openHermesDb?: (dbPath: string) => { querySessions: QuerySessionsFn; close: () => void } | null;
   /** Override: Kosmos data directories (kosmos-app + pm-studio-app) */
@@ -133,12 +136,32 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
   const queue = new LocalQueue(stateDir, opts.onCorruptLine);
   const cursors = await cursorStore.load();
 
+  // Migrate hermesSqlite from flat object (pre-multi-profile) to Record format.
+  // Old cursors.json: { hermesSqlite: { sessionTotals: {...}, inode: N, updatedAt: "..." } }
+  // New cursors.json: { hermesSqlite: { "default": { sessionTotals: {...}, ... } } }
+  // Detection: if hermesSqlite exists and has `sessionTotals` at top level, it's old format.
+  if (cursors.hermesSqlite && "sessionTotals" in cursors.hermesSqlite) {
+    const oldCursor = cursors.hermesSqlite as unknown as HermesSqliteCursor;
+    cursors.hermesSqlite = { default: oldCursor };
+    onProgress?.({
+      source: "hermes",
+      phase: "warn",
+      message: "Migrating Hermes cursor to multi-profile format",
+    });
+  }
+
+  // Helper to check if hermesSqlite Record is effectively empty
+  const isHermesCursorsEmpty = () => {
+    if (!cursors.hermesSqlite) return true;
+    return Object.keys(cursors.hermesSqlite).length === 0;
+  };
+
   // Full-scan detection: if cursors were completely empty at start (first run
   // or after `pew reset`), all records represent the complete picture.
   const initialCursorEmpty =
     Object.keys(cursors.files).length === 0 &&
     !cursors.openCodeSqlite &&
-    !cursors.hermesSqlite;
+    isHermesCursorsEmpty();
 
   // Upgrade detection: cursors.json created before knownFilePaths was added
   // (pre-v1.6.0). We can't distinguish "cursor lost" from "new file" without
@@ -167,11 +190,16 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
   // If cursors are empty (first run / post-reset), {} is safe because
   // there's nothing to double-count.
   if (!cursors.knownDbSources) {
-    const dbCursorsExist = cursors.openCodeSqlite || cursors.hermesSqlite;
+    const dbCursorsExist = cursors.openCodeSqlite || !isHermesCursorsEmpty();
     if (dbCursorsExist) {
       cursors.knownDbSources = {};
       if (cursors.openCodeSqlite) cursors.knownDbSources.openCodeSqlite = true;
-      if (cursors.hermesSqlite) cursors.knownDbSources.hermesSqlite = true;
+      // Track each Hermes DB key (e.g. "hermesSqlite:default", "hermesSqlite:profiles/tomato")
+      if (cursors.hermesSqlite) {
+        for (const dbKey of Object.keys(cursors.hermesSqlite)) {
+          cursors.knownDbSources[`hermesSqlite:${dbKey}`] = true;
+        }
+      }
     } else if (!initialCursorEmpty) {
       onProgress?.({
         source: "all",
@@ -418,53 +446,70 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
     }
   }
 
-  // Hermes pre-check (parallel to OpenCode)
+  // Hermes pre-check: validate all Hermes DBs (default + profiles)
+  // Build a list of valid DB paths for filtering drivers
+  const validHermesDbKeys = new Set<string>();
+  const allHermesDbs: Array<{ dbPath: string; dbKey: string }> = [];
   if (opts.hermesDbPath) {
-    const dbStat = await stat(opts.hermesDbPath).catch(() => null);
+    allHermesDbs.push({ dbPath: opts.hermesDbPath, dbKey: "default" });
+  }
+  if (opts.hermesProfileDbPaths) {
+    allHermesDbs.push(...opts.hermesProfileDbPaths);
+  }
+
+  for (const { dbPath, dbKey } of allHermesDbs) {
+    const dbStat = await stat(dbPath).catch(() => null);
     if (dbStat) {
       if (!opts.openHermesDb) {
-        // Case 1: DB file exists but SQLite adapter is missing (native module not available)
-        onProgress?.({
-          source: "hermes",
-          phase: "discover",
-          message: "Checking Hermes SQLite database...",
-        });
+        // Case 1: DB file exists but SQLite adapter is missing
         onProgress?.({
           source: "hermes",
           phase: "warn",
-          message: `Hermes SQLite database found at ${opts.hermesDbPath} but SQLite is not available — Hermes token data will NOT be synced`,
+          message: `Hermes SQLite database found at ${dbPath} but SQLite is not available — Hermes token data will NOT be synced`,
         });
-        // Skip only Hermes driver, keep other DB drivers (e.g. OpenCode)
-        activeDbDrivers = activeDbDrivers.filter((d) => d.source !== "hermes");
+        // Don't add to validHermesDbKeys - driver will be filtered out
       } else {
         // Case 2: Both provided — pre-probe if factory returns null
-        const handle = opts.openHermesDb(opts.hermesDbPath);
+        const handle = opts.openHermesDb(dbPath);
         if (!handle) {
           onProgress?.({
             source: "hermes",
-            phase: "discover",
-            message: "Checking Hermes SQLite database...",
-          });
-          onProgress?.({
-            source: "hermes",
             phase: "warn",
-            message: `Failed to open Hermes SQLite database at ${opts.hermesDbPath} — Hermes token data will NOT be synced`,
+            message: `Failed to open Hermes SQLite database at ${dbPath} — Hermes token data will NOT be synced`,
           });
-          // Skip only Hermes driver, keep other DB drivers (e.g. OpenCode)
-          activeDbDrivers = activeDbDrivers.filter((d) => d.source !== "hermes");
+          // Don't add to validHermesDbKeys - driver will be filtered out
         } else {
           handle.close();
+          validHermesDbKeys.add(dbKey);
         }
       }
     }
   }
 
+  // Filter out Hermes drivers that failed pre-check
+  activeDbDrivers = activeDbDrivers.filter((d) => {
+    if (d.source !== "hermes") return true;
+    // Hermes drivers have dbKey property
+    const hermesDriver = d as typeof d & { dbKey?: string };
+    return hermesDriver.dbKey && validHermesDbKeys.has(hermesDriver.dbKey);
+  });
+
   for (const driver of activeDbDrivers) {
     const key = sourceKey(driver.source);
-    // Map driver.source to cursor field name
-    const dbCursorKey = driver.source === "opencode" ? "openCodeSqlite" : "hermesSqlite";
-    const dbSourceKey = driver.source === "opencode" ? "openCodeSqlite" : "hermesSqlite";
-    const displayName = driver.source === "opencode" ? "OpenCode SQLite" : "Hermes SQLite";
+    const isOpenCode = driver.source === "opencode";
+    const isHermes = driver.source === "hermes";
+
+    // For Hermes, extract dbKey from the driver instance
+    const hermesDbKey = isHermes
+      ? (driver as typeof driver & { dbKey: string }).dbKey
+      : null;
+
+    // Display name for progress messages
+    const displayName = isOpenCode
+      ? "OpenCode SQLite"
+      : hermesDbKey
+        ? `Hermes SQLite (${hermesDbKey})`
+        : "Hermes SQLite";
 
     onProgress?.({
       source: driver.source,
@@ -472,17 +517,28 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
       message: `Checking ${displayName} database...`,
     });
 
-    const prevCursor = cursors[dbCursorKey] as unknown;
+    // Get previous cursor based on driver type
+    let prevCursor: unknown;
+    if (isOpenCode) {
+      prevCursor = cursors.openCodeSqlite;
+    } else if (isHermes && hermesDbKey) {
+      // Hermes uses Record<dbKey, HermesSqliteCursor>
+      prevCursor = cursors.hermesSqlite?.[hermesDbKey];
+    }
 
     // Detect DB cursor loss (parallel to file-based knownFilePaths logic):
     // If the DB was previously synced (tracked in knownDbSources) but the
     // cursor entry is missing, the driver will replay from rowId 0 — SUM'ing
     // that with the existing queue would double-count. Trigger full rescan.
+    const dbSourceKey = isOpenCode
+      ? "openCodeSqlite"
+      : `hermesSqlite:${hermesDbKey}`;
+
     if (!initialCursorEmpty && !prevCursor && cursors.knownDbSources?.[dbSourceKey]) {
       onProgress?.({
         source: driver.source,
         phase: "warn",
-        message: "SQLite cursor entry lost — restarting as full scan",
+        message: `${displayName} cursor entry lost — restarting as full scan`,
       });
       await cursorStore.save({
         version: 1,
@@ -516,7 +572,7 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
       onProgress?.({
         source: driver.source,
         phase: "warn",
-        message: "SQLite database inode changed — restarting full scan",
+        message: `${displayName} inode changed — restarting full scan`,
       });
       await cursorStore.save({
         version: 1,
@@ -526,11 +582,15 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
       return executeSync(opts);
     }
 
-    // Write cursor back to the correct field (type-safe cast via index signature)
-    if (dbCursorKey === "openCodeSqlite") {
+    // Write cursor back to the correct field
+    if (isOpenCode) {
       cursors.openCodeSqlite = result.cursor as CursorState["openCodeSqlite"];
-    } else {
-      cursors.hermesSqlite = result.cursor as CursorState["hermesSqlite"];
+    } else if (isHermes && hermesDbKey) {
+      // Initialize hermesSqlite Record if needed
+      if (!cursors.hermesSqlite) {
+        cursors.hermesSqlite = {};
+      }
+      cursors.hermesSqlite[hermesDbKey] = result.cursor as HermesSqliteCursor;
     }
 
     // Track this DB source as "previously synced" for cursor-loss detection

--- a/packages/cli/src/drivers/registry.ts
+++ b/packages/cli/src/drivers/registry.ts
@@ -71,7 +71,10 @@ export interface TokenDriverRegistryOpts {
   copilotCliLogsDir?: string;
   openCodeDbPath?: string;
   openMessageDb?: OpenCodeSqliteTokenDriverOpts["openMessageDb"];
+  /** Default Hermes DB path (~/.hermes/state.db) */
   hermesDbPath?: string;
+  /** Additional Hermes profile DBs (e.g. ~/.hermes/profiles/<name>/state.db) */
+  hermesProfileDbPaths?: Array<{ dbPath: string; dbKey: string }>;
   openHermesDb?: HermesSqliteTokenDriverOpts["openHermesDb"];
 }
 
@@ -121,13 +124,30 @@ export function createTokenDrivers(opts: TokenDriverRegistryOpts): TokenDriverSe
   }
 
   // DB drivers (alphabetical by source)
-  if (opts.hermesDbPath && opts.openHermesDb) {
-    dbDrivers.push(
-      createHermesSqliteTokenDriver({
-        dbPath: opts.hermesDbPath,
-        openHermesDb: opts.openHermesDb,
-      }),
-    );
+  // Hermes: create driver for default DB + all profile DBs
+  if (opts.openHermesDb) {
+    // Default DB at ~/.hermes/state.db (or $HERMES_HOME/state.db)
+    if (opts.hermesDbPath) {
+      dbDrivers.push(
+        createHermesSqliteTokenDriver({
+          dbPath: opts.hermesDbPath,
+          dbKey: "default",
+          openHermesDb: opts.openHermesDb,
+        }),
+      );
+    }
+    // Profile DBs at ~/.hermes/profiles/<name>/state.db
+    if (opts.hermesProfileDbPaths) {
+      for (const { dbPath, dbKey } of opts.hermesProfileDbPaths) {
+        dbDrivers.push(
+          createHermesSqliteTokenDriver({
+            dbPath,
+            dbKey,
+            openHermesDb: opts.openHermesDb,
+          }),
+        );
+      }
+    }
   }
   if (opts.openCodeDbPath && opts.openMessageDb) {
     dbDrivers.push(

--- a/packages/cli/src/drivers/token/hermes-token-driver.ts
+++ b/packages/cli/src/drivers/token/hermes-token-driver.ts
@@ -19,16 +19,22 @@ import type { DbTokenDriver, DbTokenResult, SyncContext } from "../types.js";
 export interface HermesSqliteTokenDriverOpts {
   /** Path to the Hermes SQLite database */
   dbPath: string;
+  /**
+   * Key identifying this DB instance for cursor storage.
+   * E.g. "default" for ~/.hermes/state.db, "profiles/tomato" for profile DBs.
+   */
+  dbKey: string;
   /** Factory for opening the DB (DI for testability — native SQLite not always available) */
   openHermesDb: (dbPath: string) => { querySessions: QuerySessionsFn; close: () => void } | null;
 }
 
 export function createHermesSqliteTokenDriver(
   opts: HermesSqliteTokenDriverOpts,
-): DbTokenDriver<HermesSqliteCursor> {
+): DbTokenDriver<HermesSqliteCursor> & { dbKey: string } {
   return {
     kind: "db",
     source: "hermes",
+    dbKey: opts.dbKey,
 
     async run(
       prevCursor: HermesSqliteCursor | undefined,

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -1,5 +1,54 @@
 import { homedir } from "node:os";
+import { readdirSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+/**
+ * Discover Hermes profile databases at ~/.hermes/profiles/<name>/state.db.
+ *
+ * Returns an array of { dbPath, dbKey } objects:
+ *   - dbPath: absolute path to the state.db file
+ *   - dbKey: profile identifier (e.g. "profiles/tomato")
+ *
+ * Only returns profiles that have an existing state.db file.
+ */
+function discoverHermesProfileDbs(hermesHome: string): Array<{ dbPath: string; dbKey: string }> {
+  const profilesDir = join(hermesHome, "profiles");
+  if (!existsSync(profilesDir)) {
+    return [];
+  }
+
+  try {
+    const st = statSync(profilesDir);
+    if (!st.isDirectory()) {
+      return [];
+    }
+  } catch {
+    return [];
+  }
+
+  const results: Array<{ dbPath: string; dbKey: string }> = [];
+  try {
+    const entries = readdirSync(profilesDir);
+    for (const name of entries) {
+      const profileDir = join(profilesDir, name);
+      try {
+        const profileStat = statSync(profileDir);
+        if (!profileStat.isDirectory()) continue;
+
+        const dbPath = join(profileDir, "state.db");
+        if (existsSync(dbPath)) {
+          results.push({ dbPath, dbKey: `profiles/${name}` });
+        }
+      } catch {
+        // Skip inaccessible profile directories
+      }
+    }
+  } catch {
+    // profiles dir unreadable
+  }
+
+  return results;
+}
 
 /**
  * Resolve the platform-specific Kosmos data directories.
@@ -116,6 +165,8 @@ export function resolveDefaultPaths(home = homedir()) {
     copilotCliLogsDir: join(home, ".copilot", "logs"),
     /** Hermes Agent database: ~/.hermes/state.db (or $HERMES_HOME/state.db) */
     hermesDbPath: join(hermesHome, "state.db"),
+    /** Hermes Agent profile databases: ~/.hermes/profiles/<name>/state.db */
+    hermesProfileDbPaths: discoverHermesProfileDbs(hermesHome),
     /** Kosmos data directories (kosmos-app + pm-studio-app, platform-aware) */
     kosmosDataDirs: resolveKosmosDataDirs(home),
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -207,8 +207,18 @@ export interface CursorState {
    * rescan needed for the upgrade path since the DB cursor itself is valid.
    */
   knownDbSources?: Record<string, true>;
-  /** Hermes Agent SQLite database cursor (separate from per-file cursors) */
-  hermesSqlite?: HermesSqliteCursor;
+  /**
+   * Hermes Agent SQLite database cursors, keyed by DB path identifier.
+   *
+   * Keys are path identifiers:
+   *   - "default" for ~/.hermes/state.db (or $HERMES_HOME/state.db)
+   *   - "profiles/<name>" for ~/.hermes/profiles/<name>/state.db
+   *
+   * Migration: Old cursors.json files (pre-multi-profile) have hermesSqlite
+   * as a flat HermesSqliteCursor object. sync.ts detects this and migrates
+   * to { "default": oldCursor } on first access.
+   */
+  hermesSqlite?: Record<string, HermesSqliteCursor>;
   /** ISO 8601 timestamp of last cursor update */
   updatedAt: string | null;
 }


### PR DESCRIPTION
## Problem

pew CLI only reads the default Hermes `state.db` at `~/.hermes/state.db` (or `$HERMES_HOME/state.db`), but Hermes Agent supports profiles where each profile has its own independent database at `~/.hermes/profiles/<name>/state.db`.

On this machine: the main instance has 113 sessions, but the "tomato" profile's 9 sessions were completely invisible to pew — token data silently lost.

## Solution

Scan `~/.hermes/profiles/*/state.db` and create one token driver per discovered profile DB, each with an independent cursor.

### Changes

**Commit 1: Discovery + driver layer**
- `packages/cli/src/utils/paths.ts` — Add `resolveHermesProfileDbPaths()` to scan the profiles directory
- `packages/core/src/types.ts` — Change `CursorState.hermesSqlite` from `HermesSqliteCursor` to `Record<string, HermesSqliteCursor>`, keyed by DB identifier (`"default"`, `"profiles/tomato"`, etc.)
- `packages/cli/src/drivers/token/hermes-token-driver.ts` — Add `dbKey` property for per-DB cursor mapping
- `packages/cli/src/drivers/registry.ts` — Accept `hermesProfileDbPaths` array, create one driver per DB

**Commit 2: Sync integration**
- `packages/cli/src/commands/sync.ts` — Iterate all hermes DBs for pre-check, per-profile cursor keys (`hermesSqlite:default`, `hermesSqlite:profiles/x`), auto-migrate old flat cursor to Record format
- `packages/cli/src/cli.ts` — Pass `hermesProfileDbPaths` from path resolution

### Backward compatibility
- Old `cursors.json` files with flat `hermesSqlite` cursor are auto-migrated to `{ "default": oldCursor }` on first sync
- `hermesDbPath` (single path) still works — profiles are additive
- Source remains `"hermes"` regardless of profile — all data goes to the same source bucket

All 2926 tests pass ✅