### PR TITLE
fix(cli): add missing db source counts and clean up sync output

### DIFF
--- a/packages/cli/src/__tests__/session-sync.test.ts
+++ b/packages/cli/src/__tests__/session-sync.test.ts
@@ -747,7 +747,7 @@ describe("executeSessionSync", () => {
 
     expect(result.totalSnapshots).toBe(1);
     expect(result.sources.opencode).toBe(1);
-    expect(result.filesScanned.opencode).toBe(1);
+    expect(result.dbsScanned.opencode).toBe(1);
 
     const records = await readSessionQueue(stateDir);
     expect(records).toHaveLength(1);
@@ -839,8 +839,9 @@ describe("executeSessionSync", () => {
     // Should have sessions from both JSON and SQLite
     expect(result.sources.opencode).toBe(2);
     expect(result.totalSnapshots).toBe(2);
-    // 1 JSON dir + 1 SQLite DB = 2
-    expect(result.filesScanned.opencode).toBe(2);
+    // 1 JSON dir + 1 SQLite DB
+    expect(result.filesScanned.opencode).toBe(1);
+    expect(result.dbsScanned.opencode).toBe(1);
 
     const records = await readSessionQueue(stateDir);
     const keys = records.map((r) => r.session_key).sort();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -139,6 +139,58 @@ function logSessionSyncProgress(event: {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Scanned summary formatter — builds a compact "Scanned: ..." line
+// showing both file-based and DB-based source counts.
+// ---------------------------------------------------------------------------
+
+/** Display name mapping for source keys */
+const SOURCE_LABELS: Record<string, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  gemini: "Gemini",
+  kosmos: "Kosmos",
+  opencode: "OpenCode",
+  openclaw: "OpenClaw",
+  pi: "Pi",
+  vscodeCopilot: "VSCode Copilot",
+  copilotCli: "Copilot CLI",
+  hermes: "Hermes",
+};
+
+/**
+ * Format a unified "Scanned:" line combining file counts and DB counts.
+ * File-based sources show just the number, DB-based sources show "N db(s)".
+ * Sources with 0 files AND 0 dbs are omitted.
+ */
+function formatScannedLine(
+  filesScanned: Record<string, number>,
+  dbsScanned?: Record<string, number>,
+): string {
+  const parts: string[] = [];
+
+  // Collect all unique source keys (union of files + dbs)
+  const allKeys = new Set([
+    ...Object.keys(filesScanned),
+    ...Object.keys(dbsScanned ?? {}),
+  ]);
+
+  for (const key of allKeys) {
+    const fileCount = filesScanned[key] ?? 0;
+    const dbCount = dbsScanned?.[key] ?? 0;
+    if (fileCount === 0 && dbCount === 0) continue;
+
+    const label = SOURCE_LABELS[key] ?? key;
+    const segments: string[] = [];
+    if (fileCount > 0) segments.push(String(fileCount));
+    if (dbCount > 0) segments.push(`${dbCount} db${dbCount > 1 ? "s" : ""}`);
+    parts.push(`${label}: ${segments.join(" + ")}`);
+  }
+
+  if (parts.length === 0) return pc.dim("Scanned: (none)");
+  return `Scanned: ${pc.dim(parts.join("  "))}`;
+}
+
 const syncCommand = defineCommand({
   meta: {
     name: "sync",
@@ -158,7 +210,7 @@ const syncCommand = defineCommand({
   },
   async run({ args }) {
     const paths = resolveDefaultPaths();
-    log.start("Syncing token usage from AI coding tools...");
+    log.start("Syncing token usage...");
     log.blank();
 
     // Dynamic import: opencode-sqlite-db.ts uses platform SQLite bindings
@@ -227,30 +279,16 @@ const syncCommand = defineCommand({
       if (result.sources.copilotCli > 0) deltaParts.push(`Copilot CLI: ${result.sources.copilotCli}`);
       if (result.sources.hermes > 0) deltaParts.push(`Hermes: ${result.sources.hermes}`);
       if (deltaParts.length > 0) {
-        log.text(pc.dim(deltaParts.join("  |  ")));
+        log.text(pc.dim(deltaParts.join("  ")));
       }
     }
 
-    // Always show files scanned
-    const fs = result.filesScanned;
-    const scanParts: string[] = [];
-    if (fs.claude > 0) scanParts.push(`Claude: ${fs.claude}`);
-    if (fs.codex > 0) scanParts.push(`Codex: ${fs.codex}`);
-    if (fs.gemini > 0) scanParts.push(`Gemini: ${fs.gemini}`);
-    if (fs.kosmos > 0) scanParts.push(`Kosmos: ${fs.kosmos}`);
-    if (fs.opencode > 0) scanParts.push(`OpenCode: ${fs.opencode}`);
-    if (fs.openclaw > 0) scanParts.push(`OpenClaw: ${fs.openclaw}`);
-    if (fs.pi > 0) scanParts.push(`Pi: ${fs.pi}`);
-    if (fs.vscodeCopilot > 0) scanParts.push(`VSCode Copilot: ${fs.vscodeCopilot}`);
-    if (fs.copilotCli > 0) scanParts.push(`Copilot CLI: ${fs.copilotCli}`);
-    if (fs.hermes > 0) scanParts.push(`Hermes: ${fs.hermes}`);
-    if (scanParts.length > 0) {
-      log.text(`Files scanned: ${pc.dim(scanParts.join("  |  "))}`);
-    }
+    // Always show scanned summary (files + dbs on one line)
+    log.text(formatScannedLine(result.filesScanned, result.dbsScanned));
 
     // ---------- Session sync ----------
     log.blank();
-    log.start("Syncing session statistics...");
+    log.start("Syncing sessions...");
     log.blank();
 
     const sessionResult = await executeSessionSync({
@@ -287,23 +325,12 @@ const syncCommand = defineCommand({
       if (sessionResult.sources.openclaw > 0) sessParts.push(`OpenClaw: ${sessionResult.sources.openclaw}`);
       if (sessionResult.sources.pi > 0) sessParts.push(`Pi: ${sessionResult.sources.pi}`);
       if (sessParts.length > 0) {
-        log.text(pc.dim(sessParts.join("  |  ")));
+        log.text(pc.dim(sessParts.join("  ")));
       }
     }
 
-    // Always show session files scanned
-    const sfs = sessionResult.filesScanned;
-    const sessScanParts: string[] = [];
-    if (sfs.claude > 0) sessScanParts.push(`Claude: ${sfs.claude}`);
-    if (sfs.codex > 0) sessScanParts.push(`Codex: ${sfs.codex}`);
-    if (sfs.gemini > 0) sessScanParts.push(`Gemini: ${sfs.gemini}`);
-    if (sfs.kosmos > 0) sessScanParts.push(`Kosmos: ${sfs.kosmos}`);
-    if (sfs.opencode > 0) sessScanParts.push(`OpenCode: ${sfs.opencode}`);
-    if (sfs.openclaw > 0) sessScanParts.push(`OpenClaw: ${sfs.openclaw}`);
-    if (sfs.pi > 0) sessScanParts.push(`Pi: ${sfs.pi}`);
-    if (sessScanParts.length > 0) {
-      log.text(`Files scanned: ${pc.dim(sessScanParts.join("  |  "))}`);
-    }
+    // Always show scanned summary (files + dbs on one line)
+    log.text(formatScannedLine(sessionResult.filesScanned, sessionResult.dbsScanned));
 
     // Auto-upload if logged in
     if (args.upload) {
@@ -637,7 +664,7 @@ const uninstallCommand = defineCommand({
 
 async function runUpload(stateDir: string, apiUrl: string, dev: boolean): Promise<void> {
   log.blank();
-  log.start("Uploading tokens to dashboard...");
+  log.start("Uploading tokens...");
 
   const uploadResult = await executeUpload({
     stateDir,
@@ -679,7 +706,7 @@ async function runUpload(stateDir: string, apiUrl: string, dev: boolean): Promis
 
 async function runSessionUpload(stateDir: string, apiUrl: string, dev: boolean): Promise<void> {
   log.blank();
-  log.start("Uploading sessions to dashboard...");
+  log.start("Uploading sessions...");
 
   const uploadResult = await executeSessionUpload({
     stateDir,

--- a/packages/cli/src/commands/notify.ts
+++ b/packages/cli/src/commands/notify.ts
@@ -54,6 +54,7 @@ export async function executeNotify(
           totalDeltas: tokenResult.totalDeltas,
           totalRecords: tokenResult.totalRecords,
           filesScanned: tokenResult.filesScanned,
+          dbsScanned: tokenResult.dbsScanned,
           sources: tokenResult.sources,
         };
       } catch (err) {
@@ -78,6 +79,7 @@ export async function executeNotify(
           totalSnapshots: sessionResult.totalSnapshots,
           totalRecords: sessionResult.totalRecords,
           filesScanned: sessionResult.filesScanned,
+          dbsScanned: sessionResult.dbsScanned,
           sources: sessionResult.sources,
         };
       } catch (err) {

--- a/packages/cli/src/commands/session-sync.ts
+++ b/packages/cli/src/commands/session-sync.ts
@@ -98,6 +98,10 @@ export interface SessionSyncResult {
     openclaw: number;
     pi: number;
   };
+  /** Total SQLite databases scanned per source */
+  dbsScanned: {
+    opencode: number;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -175,6 +179,7 @@ export async function executeSessionSync(
   const allSnapshots: SessionSnapshot[] = [];
   const sourceCounts = { claude: 0, codex: 0, gemini: 0, kosmos: 0, opencode: 0, openclaw: 0, pi: 0 };
   const filesScanned = { claude: 0, codex: 0, gemini: 0, kosmos: 0, opencode: 0, openclaw: 0, pi: 0 };
+  const dbsScanned = { opencode: 0 };
 
   // Build driver sets from options
   const { fileDrivers, dbDrivers } = createSessionDrivers(opts);
@@ -317,8 +322,8 @@ export async function executeSessionSync(
       message: "Checking OpenCode SQLite database for sessions...",
     });
 
-    // Count DB as 1 file scanned for the source
-    filesScanned[key] += 1;
+    // Count DB as 1 database scanned for the source
+    dbsScanned.opencode += 1;
 
     const prevCursor = cursors.openCodeSqlite as OpenCodeSqliteSessionCursor | undefined;
     const result = await driver.run(prevCursor, {});
@@ -379,5 +384,6 @@ export async function executeSessionSync(
     totalRecords: deduped.length,
     sources: sourceCounts,
     filesScanned,
+    dbsScanned,
   };
 }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -94,6 +94,11 @@ export interface SyncResult {
     copilotCli: number;
     hermes: number;
   };
+  /** Total SQLite databases scanned per source */
+  dbsScanned: {
+    opencode: number;
+    hermes: number;
+  };
 }
 
 /** Internal bucket for aggregating deltas */
@@ -210,6 +215,7 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
   const allDeltas: ParsedDelta[] = [];
   const sourceCounts = { claude: 0, codex: 0, copilotCli: 0, gemini: 0, hermes: 0, kosmos: 0, opencode: 0, openclaw: 0, pi: 0, vscodeCopilot: 0 };
   const filesScanned = { claude: 0, codex: 0, copilotCli: 0, gemini: 0, hermes: 0, kosmos: 0, opencode: 0, openclaw: 0, pi: 0, vscodeCopilot: 0 };
+  const dbsScanned = { opencode: 0, hermes: 0 };
 
   // Collect all discovered file paths (across all drivers) for knownFilePaths
   const discoveredFiles = new Set<string>();
@@ -545,6 +551,9 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
 
     allDeltas.push(...result.deltas);
     sourceCounts[key] += result.deltas.length;
+    if (key === "opencode" || key === "hermes") {
+      dbsScanned[key] += 1;
+    }
 
     const dedupSkipped = result.rowCount - (result.deltas.length > 0 ? result.deltas.length : 0);
     onProgress?.({
@@ -680,5 +689,6 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
     totalRecords: records.length,
     sources: sourceCounts,
     filesScanned,
+    dbsScanned,
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -425,6 +425,7 @@ export interface SyncCycleResult {
     totalDeltas: number;
     totalRecords: number;
     filesScanned: Record<string, number>;
+    dbsScanned?: Record<string, number>;
     sources: Record<string, number>;
   };
   /** Error from token sync phase, if it failed */
@@ -435,6 +436,7 @@ export interface SyncCycleResult {
     totalSnapshots: number;
     totalRecords: number;
     filesScanned: Record<string, number>;
+    dbsScanned?: Record<string, number>;
     sources: Record<string, number>;
   };
   /** Error from session sync phase, if it failed */


### PR DESCRIPTION
## Problem

The `pew sync` CLI output had two issues:

1. **Missing DB source counts** — OpenCode (SQLite) and Hermes (SQLite) databases were scanned but never shown in the "Files scanned" line, making it seem like only file-based sources (Claude, Codex) were being processed.

2. **Cluttered output** — verbose phase labels, pipe separators, and inconsistent formatting made the output hard to scan.

## Changes

- Add `dbsScanned` field to `SyncResult` and `SessionSyncResult` to track SQLite database sources separately from file-based sources
- Introduce `formatScannedLine()` helper that merges file and DB counts into a unified `Scanned:` line (e.g. `Claude: 59  Hermes: 2 dbs`)
- Shorten phase labels (`Syncing token usage...`, `Uploading tokens...`)
- Remove pipe separators for cleaner alignment
- Update `SyncCycleResult` in `@pew/core` to include optional `dbsScanned`

## Before
```
◐ Syncing token usage from AI coding tools...
✔ Synced 1 new events → 1 queue records
  Hermes: 1
  Files scanned: Claude: 59  |  Codex: 16     ← missing OpenCode & Hermes
```

## After
```
◐ Syncing token usage...
✔ Synced 10 new events → 1 queue records
  Hermes: 10
  Scanned: Claude: 59  Codex: 16  Hermes: 2 dbs  OpenCode: 1 db
```

All 3077 tests pass.