### PR TITLE
fix(web): apply tzOffset to day-granularity queries for correct local date bucketing

### DIFF
--- a/packages/web/src/app/api/usage/by-device/route.ts
+++ b/packages/web/src/app/api/usage/by-device/route.ts
@@ -70,11 +70,20 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const fromParam = url.searchParams.get("from");
   const toParam = url.searchParams.get("to");
+  const tzOffsetParam = url.searchParams.get("tzOffset");
+  const tzOffset = tzOffsetParam !== null ? parseInt(tzOffsetParam, 10) : 0;
 
   const dateRange = parseDateRange(fromParam, toParam);
   if (!dateRange) {
     return NextResponse.json(
       { error: "Invalid date format" },
+      { status: 400 }
+    );
+  }
+
+  if (!Number.isFinite(tzOffset) || Math.abs(tzOffset) > 840) {
+    return NextResponse.json(
+      { error: "Invalid tzOffset value" },
       { status: 400 }
     );
   }
@@ -91,7 +100,7 @@ export async function GET(request: Request) {
     const costRows = await db.getDeviceCostDetails(userId, fromDate, toDate);
 
     // Timeline query — daily totals per device
-    const timelineRows = await db.getDeviceTimeline(userId, fromDate, toDate);
+    const timelineRows = await db.getDeviceTimeline(userId, fromDate, toDate, { tzOffset });
 
     // 4. Build pricing map (merge static defaults + DB overrides)
     let pricingMap;

--- a/packages/web/src/app/api/usage/route.ts
+++ b/packages/web/src/app/api/usage/route.ts
@@ -56,6 +56,8 @@ export async function GET(request: Request) {
   const granularity = url.searchParams.get("granularity") ?? "half-hour";
   const fromParam = url.searchParams.get("from");
   const toParam = url.searchParams.get("to");
+  const tzOffsetParam = url.searchParams.get("tzOffset");
+  const tzOffset = tzOffsetParam !== null ? parseInt(tzOffsetParam, 10) : 0;
 
   // Validate source filter
   if (sourceFilter && !VALID_SOURCES.has(sourceFilter)) {
@@ -69,6 +71,14 @@ export async function GET(request: Request) {
   if (!VALID_GRANULARITIES.has(granularity)) {
     return NextResponse.json(
       { error: `Invalid granularity: "${granularity}"` },
+      { status: 400 }
+    );
+  }
+
+  // Validate tzOffset
+  if (!Number.isFinite(tzOffset) || Math.abs(tzOffset) > 840) {
+    return NextResponse.json(
+      { error: "Invalid tzOffset value" },
       { status: 400 }
     );
   }
@@ -117,6 +127,7 @@ export async function GET(request: Request) {
       ...(sourceFilter && { source: sourceFilter }),
       ...(deviceIdFilter && { deviceId: deviceIdFilter }),
       granularity: granularity as "half-hour" | "day",
+      tzOffset,
     });
 
     // Compute summary

--- a/packages/web/src/hooks/use-device-data.ts
+++ b/packages/web/src/hooks/use-device-data.ts
@@ -41,6 +41,7 @@ export function useDeviceData(
       const params = new URLSearchParams();
       if (fromDate) params.set("from", fromDate);
       if (toDate) params.set("to", toDate);
+      params.set("tzOffset", String(new Date().getTimezoneOffset()));
 
       const qs = params.toString();
       const url = `/api/usage/by-device${qs ? `?${qs}` : ""}`;

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -226,6 +226,9 @@ export function useUsageData(
       if (toDate) params.set("to", toDate);
       if (source) params.set("source", source);
       if (deviceId) params.set("deviceId", deviceId);
+      if (granularity === "day") {
+        params.set("tzOffset", String(new Date().getTimezoneOffset()));
+      }
 
       const res = await fetch(`/api/usage?${params.toString()}`);
       if (!res.ok) {

--- a/packages/web/src/lib/db-worker.ts
+++ b/packages/web/src/lib/db-worker.ts
@@ -819,6 +819,7 @@ export function createWorkerDbRead(): DbRead {
         source?: string;
         deviceId?: string;
         granularity?: "half-hour" | "day";
+        tzOffset?: number;
       },
     ): Promise<UsageRecordRow[]> {
       return rpc<UsageRecordRow[]>({
@@ -829,6 +830,7 @@ export function createWorkerDbRead(): DbRead {
         source: options?.source,
         deviceId: options?.deviceId,
         granularity: options?.granularity,
+        tzOffset: options?.tzOffset,
       });
     },
 
@@ -862,12 +864,14 @@ export function createWorkerDbRead(): DbRead {
       userId: string,
       fromDate: string,
       toDate: string,
+      options?: { tzOffset?: number },
     ): Promise<UsageDeviceTimelineRow[]> {
       return rpc<UsageDeviceTimelineRow[]>({
         method: "usage.getDeviceTimeline",
         userId,
         fromDate,
         toDate,
+        tzOffset: options?.tzOffset,
       });
     },
 

--- a/packages/web/src/lib/db.ts
+++ b/packages/web/src/lib/db.ts
@@ -466,6 +466,7 @@ export interface DbRead {
       source?: string;
       deviceId?: string;
       granularity?: "half-hour" | "day";
+      tzOffset?: number;
     },
   ): Promise<UsageRecordRow[]>;
 
@@ -488,6 +489,7 @@ export interface DbRead {
     userId: string,
     fromDate: string,
     toDate: string,
+    options?: { tzOffset?: number },
   ): Promise<UsageDeviceTimelineRow[]>;
 
   // ---------------------------------------------------------------------------

--- a/packages/worker-read/src/rpc/usage.ts
+++ b/packages/worker-read/src/rpc/usage.ts
@@ -73,6 +73,7 @@ export interface GetUsageRequest {
   source?: string;
   deviceId?: string;
   granularity?: "half-hour" | "day";
+  tzOffset?: number;
 }
 
 export interface GetDeviceSummaryRequest {
@@ -94,6 +95,7 @@ export interface GetDeviceTimelineRequest {
   userId: string;
   fromDate: string;
   toDate: string;
+  tzOffset?: number;
 }
 
 export interface GetModelPricingRequest {
@@ -123,12 +125,30 @@ async function handleGetUsage(
   }
 
   const granularity = req.granularity ?? "half-hour";
-  const timeColumn =
-    granularity === "day" ? "date(hour_start) AS hour_start" : "hour_start";
-  const groupBy =
-    granularity === "day"
-      ? "date(hour_start), source, model"
-      : "hour_start, source, model";
+  const rawTz = req.tzOffset ?? 0;
+  const tzOffset =
+    Number.isFinite(rawTz) && Math.abs(rawTz) <= 840 ? rawTz : 0;
+
+  let timeColumn: string;
+  let groupBy: string;
+  const prependParams: unknown[] = [];
+
+  if (granularity === "day") {
+    if (tzOffset !== 0) {
+      const offsetStr = String(-tzOffset);
+      timeColumn =
+        "date(datetime(hour_start, ? || ' minutes')) AS hour_start";
+      groupBy =
+        "date(datetime(hour_start, ? || ' minutes')), source, model";
+      prependParams.push(offsetStr, offsetStr);
+    } else {
+      timeColumn = "date(hour_start) AS hour_start";
+      groupBy = "date(hour_start), source, model";
+    }
+  } else {
+    timeColumn = "hour_start";
+    groupBy = "hour_start, source, model";
+  }
 
   const conditions = ["user_id = ?", "hour_start >= ?", "hour_start < ?"];
   const params: unknown[] = [req.userId, req.fromDate, req.toDate];
@@ -160,7 +180,9 @@ async function handleGetUsage(
   `;
 
   const stmt = db.prepare(sql);
-  const results = await stmt.bind(...params).all<UsageRow>();
+  const results = await stmt
+    .bind(...prependParams, ...params)
+    .all<UsageRow>();
 
   return Response.json({ result: results.results });
 }
@@ -248,10 +270,25 @@ async function handleGetDeviceTimeline(
     );
   }
 
+  const rawTz = req.tzOffset ?? 0;
+  const tzOffset =
+    Number.isFinite(rawTz) && Math.abs(rawTz) <= 840 ? rawTz : 0;
+
+  let dateExpr: string;
+  const tzParams: unknown[] = [];
+
+  if (tzOffset !== 0) {
+    const offsetStr = String(-tzOffset);
+    dateExpr = "date(datetime(ur.hour_start, ? || ' minutes'))";
+    tzParams.push(offsetStr, offsetStr);
+  } else {
+    dateExpr = "date(ur.hour_start)";
+  }
+
   const results = await db
     .prepare(
       `SELECT
-        date(ur.hour_start) AS date,
+        ${dateExpr} AS date,
         ur.device_id,
         SUM(ur.total_tokens) AS total_tokens,
         SUM(ur.input_tokens) AS input_tokens,
@@ -261,10 +298,10 @@ async function handleGetDeviceTimeline(
       WHERE ur.user_id = ?
         AND ur.hour_start >= ?
         AND ur.hour_start < ?
-      GROUP BY date(ur.hour_start), ur.device_id
+      GROUP BY ${dateExpr}, ur.device_id
       ORDER BY date ASC`
     )
-    .bind(req.userId, req.fromDate, req.toDate)
+    .bind(...tzParams, req.userId, req.fromDate, req.toDate)
     .all<TimelineRow>();
 
   return Response.json({ result: results.results });


### PR DESCRIPTION
## Summary

  - Day-granularity SQL used `date(hour_start)` which buckets by UTC date. For non-UTC users (e.g. UTC+8 at local 00:16),
  today's token activity was attributed to the previous day — dashboard showed "today" as 0.
  - Pass `tzOffset` (from `new Date().getTimezoneOffset()`) through the full stack: frontend hooks → API routes →
  worker-read RPC → SQL query.
  - Worker-read SQL now uses `date(datetime(hour_start, ? || ' minutes'))` with parameterized offset to group by the user's
   local date.

  ## Test plan

  - [ ] `bun run build` passes
  - [ ] `bun run test` passes
  - [ ] Deploy worker-read, open dashboard in non-UTC timezone, verify "today" shows correct token count