### PR TITLE
fix(cli): fix Hermes profile discovery and Multica Codex status classification

### DIFF
--- a/packages/cli/src/__tests__/paths.test.ts
+++ b/packages/cli/src/__tests__/paths.test.ts
@@ -92,6 +92,28 @@ describe("resolveDefaultPaths", () => {
     expect(paths.hermesDbPath).toBe(join("/fakehome", ".hermes", "state.db"));
   });
 
+  it("should ignore HERMES_HOME env var for hermesDbPath", () => {
+    process.env.HERMES_HOME = "/custom/hermes/profiles/tomato";
+    const paths = resolveDefaultPaths("/fakehome");
+    // Should always use home-based path, not HERMES_HOME
+    expect(paths.hermesDbPath).toBe(join("/fakehome", ".hermes", "state.db"));
+  });
+
+  it("should discover hermes profiles from home dir even when HERMES_HOME is set", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "pew-paths-test-"));
+    const hermesDir = join(tempDir, ".hermes");
+    const profilesDir = join(hermesDir, "profiles");
+    const tomatoDir = join(profilesDir, "tomato");
+    mkdirSync(tomatoDir, { recursive: true });
+    writeFileSync(join(tomatoDir, "state.db"), "fake-db");
+    // Point HERMES_HOME to a profile-specific dir (simulating Hermes agent)
+    process.env.HERMES_HOME = join(profilesDir, "tomato");
+    const paths = resolveDefaultPaths(tempDir);
+    // Should still discover profiles from ~/.hermes/profiles/
+    expect(paths.hermesProfileDbPaths).toHaveLength(1);
+    expect(paths.hermesProfileDbPaths[0].dbKey).toBe("profiles/tomato");
+  });
+
   it("should return exactly 17 path properties", () => {
     const keys = [
       "stateDir",

--- a/packages/cli/src/__tests__/status.test.ts
+++ b/packages/cli/src/__tests__/status.test.ts
@@ -23,6 +23,7 @@ const defaultDirs: SourceDirs = {
   piSessionsDir: "/home/.pi/agent/sessions",
   vscodeCopilotDirs: ["/home/.config/Code/User"],
   copilotCliLogsDir: "/home/.copilot/logs",
+  multicaCodexDirs: [],
 };
 
 describe("executeStatus", () => {
@@ -245,6 +246,42 @@ describe("executeStatus", () => {
     });
     expect(result.trackedFiles).toBe(1);
     expect(result.sources["vscode-copilot"]).toBe(1);
+    expect(result.sources["unknown"]).toBeUndefined();
+  });
+
+  it("should classify Multica Codex files as codex", async () => {
+    const multicaDirs = ["/home/multica_workspaces/ws-1/task-a/codex-home/sessions"];
+    const cursorStore = new CursorStore(stateDir);
+    await cursorStore.save({
+      files: {
+        "/home/multica_workspaces/ws-1/task-a/codex-home/sessions/2026/04/10/rollout-abc.jsonl": {
+          type: "codex",
+          offset: 100,
+          inode: 50,
+          size: 100,
+          mtimeMs: 9000,
+          lastTotals: null,
+          lastModel: null,
+        },
+        "/home/.codex/sessions/2026/04/10/rollout-xyz.jsonl": {
+          type: "codex",
+          offset: 200,
+          inode: 51,
+          size: 200,
+          mtimeMs: 9001,
+          lastTotals: null,
+          lastModel: null,
+        },
+      },
+      updatedAt: "2026-04-10T10:00:00.000Z",
+    });
+
+    const result = await executeStatus({
+      stateDir,
+      sourceDirs: { ...defaultDirs, multicaCodexDirs: multicaDirs },
+    });
+    expect(result.trackedFiles).toBe(2);
+    expect(result.sources["codex"]).toBe(2);
     expect(result.sources["unknown"]).toBeUndefined();
   });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -373,6 +373,7 @@ const statusCommand = defineCommand({
         piSessionsDir: paths.piSessionsDir,
         vscodeCopilotDirs: paths.vscodeCopilotDirs,
         copilotCliLogsDir: paths.copilotCliLogsDir,
+        multicaCodexDirs: paths.multicaCodexDirs,
       },
       notifierStatuses,
       onCorruptLine: handleCorruptLine,

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -15,6 +15,7 @@ export interface SourceDirs {
   piSessionsDir: string;
   vscodeCopilotDirs: string[];
   copilotCliLogsDir: string;
+  multicaCodexDirs: string[];
 }
 
 /** Status summary for display */
@@ -40,6 +41,10 @@ export interface StatusResult {
 function classifySource(filePath: string, dirs: SourceDirs): string {
   if (filePath.startsWith(dirs.claudeDir)) return "claude-code";
   if (filePath.startsWith(dirs.codexSessionsDir)) return "codex";
+  // Multica Codex extra dirs
+  for (const dir of dirs.multicaCodexDirs) {
+    if (filePath.startsWith(dir)) return "codex";
+  }
   if (filePath.startsWith(dirs.geminiDir)) return "gemini-cli";
   if (filePath.startsWith(dirs.kosmosDataDir)) return "kosmos";
   if (filePath.startsWith(dirs.pmstudioDataDir)) return "pmstudio";

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -158,7 +158,9 @@ function resolveVscodeCopilotDirs(home: string): string[] {
  */
 export function resolveDefaultPaths(home = homedir()) {
   const codexHome = process.env.CODEX_HOME || join(home, ".codex");
-  const hermesHome = process.env.HERMES_HOME || join(home, ".hermes");
+  // Always use ~/.hermes as the Hermes root - ignore HERMES_HOME which points to
+  // a profile-specific directory (e.g. ~/.hermes/profiles/tomato), not the root.
+  const hermesHome = join(home, ".hermes");
   return {
     /** pew state directory: ~/.config/pew/ */
     stateDir: join(home, ".config", "pew"),
@@ -191,7 +193,7 @@ export function resolveDefaultPaths(home = homedir()) {
     vscodeCopilotDirs: resolveVscodeCopilotDirs(home),
     /** GitHub Copilot CLI logs: ~/.copilot/logs */
     copilotCliLogsDir: join(home, ".copilot", "logs"),
-    /** Hermes Agent database: ~/.hermes/state.db (or $HERMES_HOME/state.db) */
+    /** Hermes Agent database: ~/.hermes/state.db */
     hermesDbPath: join(hermesHome, "state.db"),
     /** Hermes Agent profile databases: ~/.hermes/profiles/<name>/state.db */
     hermesProfileDbPaths: discoverHermesProfileDbs(hermesHome),


### PR DESCRIPTION
## Summary

Two bug fixes for `pew sync` and `pew status`:

### Bug 1: `HERMES_HOME` env var breaks Hermes profile discovery

When `HERMES_HOME` is set (e.g. by Hermes Agent profile system to `~/.hermes/profiles/tomato`), `resolveDefaultPaths()` used it as the Hermes root. This caused:
- `hermesDbPath` to point to only the active profile DB
- `discoverHermesProfileDbs()` to search `$HERMES_HOME/profiles/` (does not exist) instead of `~/.hermes/profiles/`

Result: only 1 of 4 Hermes DBs synced when running from a Hermes session. The launchd cron was unaffected (no `HERMES_HOME` set).

**Fix**: Always use `~/.hermes` as the Hermes root, ignore `HERMES_HOME` env var — pew needs the root directory, not a profile-specific one.

### Bug 2: `pew status` classifies Multica Codex files as "unknown"

22 Multica Codex session files from `~/multica_workspaces/<ws>/<task>/codex-home/sessions/` were displayed as "unknown" source in `pew status`, even though `pew sync` correctly processed them as codex.

**Fix**: Add `multicaCodexDirs` to `SourceDirs` interface and `classifySource()` function in status command.

## Changes

- `packages/cli/src/utils/paths.ts` — Remove `HERMES_HOME` env var override, always use `~/.hermes`
- `packages/cli/src/commands/status.ts` — Add `multicaCodexDirs` to `SourceDirs` and `classifySource()`  
- `packages/cli/src/cli.ts` — Pass `multicaCodexDirs` to status command
- `packages/cli/src/__tests__/paths.test.ts` — Add 2 tests for HERMES_HOME isolation
- `packages/cli/src/__tests__/status.test.ts` — Add test for Multica Codex classification

## Test Results

All 3212 tests pass (186 test files).