### PR TITLE
fix(web): mobile responsive improvements for leaderboard pages

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -335,3 +335,12 @@
     opacity: 1 !important;
   }
 }
+
+/* Hide scrollbar utility */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/packages/web/src/app/leaderboard/agents/page.tsx
+++ b/packages/web/src/app/leaderboard/agents/page.tsx
@@ -310,12 +310,14 @@ function AgentsLeaderboardContent() {
 
           {/* Scope dropdown */}
           {isAuthenticated && (
-            <ScopeDropdown
-              value={scope}
-              onChange={handleScopeChange}
-              organizations={organizations}
-              teams={teams}
-            />
+            <div className="hidden sm:block">
+              <ScopeDropdown
+                value={scope}
+                onChange={handleScopeChange}
+                organizations={organizations}
+                teams={teams}
+              />
+            </div>
           )}
         </div>
 

--- a/packages/web/src/app/leaderboard/models/page.tsx
+++ b/packages/web/src/app/leaderboard/models/page.tsx
@@ -323,12 +323,14 @@ function ModelsLeaderboardContent() {
 
           {/* Scope dropdown */}
           {isAuthenticated && (
-            <ScopeDropdown
-              value={scope}
-              onChange={handleScopeChange}
-              organizations={organizations}
-              teams={teams}
-            />
+            <div className="hidden sm:block">
+              <ScopeDropdown
+                value={scope}
+                onChange={handleScopeChange}
+                organizations={organizations}
+                teams={teams}
+              />
+            </div>
           )}
         </div>
 

--- a/packages/web/src/app/leaderboard/page.tsx
+++ b/packages/web/src/app/leaderboard/page.tsx
@@ -182,12 +182,14 @@ export default function LeaderboardPage() {
 
           {/* Scope dropdown (org/team filter) — only show for authenticated users */}
           {isAuthenticated && (
-            <ScopeDropdown
-              value={scope}
-              onChange={handleScopeChange}
-              organizations={organizations}
-              teams={teams}
-            />
+            <div className="hidden sm:block">
+              <ScopeDropdown
+                value={scope}
+                onChange={handleScopeChange}
+                organizations={organizations}
+                teams={teams}
+              />
+            </div>
           )}
         </div>
 

--- a/packages/web/src/components/leaderboard/leaderboard-nav.tsx
+++ b/packages/web/src/components/leaderboard/leaderboard-nav.tsx
@@ -33,7 +33,7 @@ export function LeaderboardNav() {
 
   return (
     <nav
-      className="relative flex gap-6 border-b border-border animate-fade-up"
+      className="relative flex gap-6 border-b border-border animate-fade-up overflow-x-auto scrollbar-hide"
       style={{ animationDelay: "120ms" }}
       aria-label="Leaderboard navigation"
     >
@@ -47,7 +47,7 @@ export function LeaderboardNav() {
             key={tab.href}
             href={tab.href}
             className={cn(
-              "relative pb-2.5 text-sm font-semibold uppercase tracking-wider transition-colors",
+              "relative shrink-0 whitespace-nowrap pb-2.5 text-sm font-semibold uppercase tracking-wider transition-colors",
               isActive
                 ? "text-foreground"
                 : "text-muted-foreground hover:text-foreground",

--- a/packages/web/src/components/leaderboard/leaderboard-row.tsx
+++ b/packages/web/src/components/leaderboard/leaderboard-row.tsx
@@ -67,7 +67,7 @@ export function LeaderboardRow({
             <TokenTierBadge totalTokens={total_tokens} />
           </div>
           {teams.length > 0 && (
-            <div className="flex gap-1 flex-wrap">
+            <div className="hidden sm:flex gap-1 flex-wrap">
               {teams.map((team) => (
                 <span
                   key={team.id}
@@ -97,8 +97,8 @@ export function LeaderboardRow({
       </div>
 
       {/* Total — check-style handwriting font, full number */}
-      <div className="relative z-10 w-[160px] sm:w-[280px] shrink-0 text-right flex items-center justify-end">
-        <span className="font-handwriting text-[32px] sm:text-[39px] leading-none tracking-tight text-foreground whitespace-nowrap">
+      <div className="relative z-10 w-[120px] sm:w-[280px] shrink-0 text-right flex items-center justify-end">
+        <span className="font-handwriting text-[28px] sm:text-[39px] leading-none tracking-tight text-foreground whitespace-nowrap">
           {formatTokensFull(total_tokens)}
         </span>
       </div>

--- a/packages/web/src/components/leaderboard/period-tabs.tsx
+++ b/packages/web/src/components/leaderboard/period-tabs.tsx
@@ -8,10 +8,10 @@ import type { ProfileDialogTab } from "@/components/user-profile-dialog";
 // Constants (re-exported for consumers)
 // ---------------------------------------------------------------------------
 
-export const PERIODS: { value: LeaderboardPeriod; label: string }[] = [
-  { value: "week", label: "Last 7 Days" },
-  { value: "month", label: "Last 30 Days" },
-  { value: "all", label: "All Time" },
+export const PERIODS: { value: LeaderboardPeriod; label: string; shortLabel: string }[] = [
+  { value: "week", label: "Last 7 Days", shortLabel: "7D" },
+  { value: "month", label: "Last 30 Days", shortLabel: "30D" },
+  { value: "all", label: "All Time", shortLabel: "All" },
 ];
 
 /** Map leaderboard period to profile dialog tab */
@@ -39,13 +39,14 @@ export function PeriodTabs({
           key={p.value}
           onClick={() => onChange(p.value)}
           className={cn(
-            "flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+            "flex-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
             value === p.value
               ? "bg-card text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground",
           )}
         >
-          {p.label}
+          <span className="sm:hidden">{p.shortLabel}</span>
+          <span className="hidden sm:inline">{p.label}</span>
         </button>
       ))}
     </div>

--- a/packages/web/src/components/leaderboard/table-header.tsx
+++ b/packages/web/src/components/leaderboard/table-header.tsx
@@ -27,7 +27,7 @@ export function TableHeader() {
         {/* Duration — matches row's duration column */}
         <span className="hidden sm:block w-24 shrink-0 text-right">Duration</span>
         {/* Tokens — matches row's total column */}
-        <span className="w-[160px] sm:w-[280px] shrink-0 text-right">Tokens</span>
+        <span className="w-[120px] sm:w-[280px] shrink-0 text-right">Tokens</span>
       </div>
       {/* Thin divider — Armory's Divider--thin--silver */}
       <div className="h-px bg-border/50" />

--- a/packages/web/src/components/showcase/showcase-card.tsx
+++ b/packages/web/src/components/showcase/showcase-card.tsx
@@ -29,13 +29,13 @@ export function ShowcaseCard({ showcase, isLoggedIn, onLoginRequired, onUpvoteCh
   const githubOwner = showcase.repo_key.split("/")[0];
 
   return (
-    <article className="group relative flex gap-4 rounded-[var(--radius-card)] bg-secondary p-4 transition-all hover:bg-secondary/80">
+    <article className="group relative flex flex-col sm:flex-row gap-4 rounded-[var(--radius-card)] bg-secondary p-4 transition-all hover:bg-secondary/80">
       {/* OG Image */}
       <Link
         href={showcase.github_url}
         target="_blank"
         rel="noopener noreferrer"
-        className="relative shrink-0 w-[180px] aspect-[1.91/1] rounded-lg overflow-hidden bg-accent/50"
+        className="relative shrink-0 w-full sm:w-[180px] aspect-[1.91/1] rounded-lg overflow-hidden bg-accent/50"
       >
         <ShowcaseImage
           url={showcase.og_image_url}
@@ -144,7 +144,7 @@ export function ShowcaseCard({ showcase, isLoggedIn, onLoginRequired, onUpvoteCh
       </div>
 
       {/* Upvote Button */}
-      <div className="shrink-0 self-center">
+      <div className="shrink-0 self-start sm:self-center">
         <UpvoteButton
           showcaseId={showcase.id}
           initialCount={showcase.upvote_count}


### PR DESCRIPTION
## Summary

Five mobile responsive fixes for the leaderboard section:

### 1. Nav tabs horizontal scroll
- Added `overflow-x-auto` + `scrollbar-hide` to nav element
- Tab links get `shrink-0 whitespace-nowrap` to prevent compression
- New `scrollbar-hide` CSS utility in `globals.css`

### 2. Leaderboard row progressive column hiding
- Teams badges: `hidden sm:flex` (hide on mobile, show on sm+)
- Total tokens column: reduced from `w-[160px]` to `w-[120px]` on mobile
- Font size: `text-[28px]` mobile → `text-[39px]` desktop
- Table header mirrors the same width change

### 3. Period tabs short labels
- Added `shortLabel` field: "7D" / "30D" / "All"
- Renders short labels on mobile (`sm:hidden`) and full labels on desktop (`hidden sm:inline`)
- Added `whitespace-nowrap` to prevent wrapping

### 4. Showcase card vertical layout
- Card: `flex flex-col sm:flex-row` (vertical on mobile, horizontal on desktop)
- OG image: `w-full sm:w-[180px]` (full width on mobile)
- Upvote button: `self-start sm:self-center`

### 5. Scope dropdown hidden on mobile
- Wrapped `<ScopeDropdown>` in `<div className="hidden sm:block">` on Individual, Agents, and Models pages

## Files Changed (9)
- `globals.css` — scrollbar-hide utility
- `leaderboard-nav.tsx` — horizontal scroll
- `leaderboard-row.tsx` + `table-header.tsx` — column widths
- `period-tabs.tsx` — short labels
- `showcase-card.tsx` — vertical stack
- `page.tsx` + `agents/page.tsx` + `models/page.tsx` — hide scope dropdown

## Verification
- `bun run --filter "@pew/web" build` ✅ passes