### PR TITLE
fix(cli): improve pew login UX for SSH/headless sessions

### DIFF
--- a/packages/cli/src/__tests__/login.test.ts
+++ b/packages/cli/src/__tests__/login.test.ts
@@ -561,4 +561,59 @@ describe("executeLogin", () => {
       expect(result.error).toContain("No API key");
     });
   });
+
+  // ---- Custom log callback ----
+
+  describe("custom log callback", () => {
+    it("should use custom log function instead of console.log", async () => {
+      const logMessages: string[] = [];
+
+      // Use a short timeout so the test doesn't hang waiting for browser callback
+      const loginPromise = executeLogin({
+        configDir: tempDir,
+        apiUrl: "http://localhost:7020",
+        timeoutMs: 300,
+        generateNonce: () => FIXED_NONCE,
+        log: (msg) => logMessages.push(msg),
+        openBrowser: async (_url) => {
+          // Simulate browser failure to trigger the log callback
+          throw new Error("Browser not available");
+        },
+      });
+
+      // Wait for timeout or result
+      const result = await loginPromise;
+
+      // The log function should have been called with the "Could not open browser" message
+      const browserMsg = logMessages.find((m) => m.includes("Could not open browser"));
+      expect(browserMsg).toBeDefined();
+      expect(result.success).toBe(false);
+    }, 2000);
+
+    it("should not call log function for code-based login (browser flow is skipped)", async () => {
+      const logMessages: string[] = [];
+
+      const mockFetch = async () => {
+        return new Response(JSON.stringify({
+          api_key: "pk_log_test",
+          email: "log@example.com",
+        }), { status: 200 });
+      };
+
+      const result = await executeLogin({
+        configDir: tempDir,
+        apiUrl: "http://localhost:7020",
+        code: "ABCD-9999",
+        fetch: mockFetch as typeof globalThis.fetch,
+        log: (msg) => logMessages.push(msg),
+        openBrowser: async () => {
+          throw new Error("Should not open browser");
+        },
+      });
+
+      // log callback should NOT be called for code-based login (no browser flow)
+      expect(logMessages).toHaveLength(0);
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/packages/cli/src/__tests__/ssh.test.ts
+++ b/packages/cli/src/__tests__/ssh.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { isSSHSession } from "../utils/ssh.js";
+
+describe("isSSHSession", () => {
+  it("returns false when no SSH env vars are set", () => {
+    expect(isSSHSession({})).toBe(false);
+  });
+
+  it("returns true when SSH_CLIENT is set", () => {
+    expect(isSSHSession({ SSH_CLIENT: "192.168.1.1 12345 22" })).toBe(true);
+  });
+
+  it("returns true when SSH_TTY is set", () => {
+    expect(isSSHSession({ SSH_TTY: "/dev/pts/0" })).toBe(true);
+  });
+
+  it("returns true when SSH_CONNECTION is set", () => {
+    expect(isSSHSession({ SSH_CONNECTION: "192.168.1.1 12345 10.0.0.1 22" })).toBe(true);
+  });
+
+  it("returns true when multiple SSH env vars are set", () => {
+    expect(
+      isSSHSession({
+        SSH_CLIENT: "192.168.1.1 12345 22",
+        SSH_TTY: "/dev/pts/0",
+        SSH_CONNECTION: "192.168.1.1 12345 10.0.0.1 22",
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when env vars are empty strings", () => {
+    expect(isSSHSession({ SSH_CLIENT: "", SSH_TTY: "", SSH_CONNECTION: "" })).toBe(false);
+  });
+
+  it("ignores unrelated env vars", () => {
+    expect(isSSHSession({ HOME: "/home/user", PATH: "/usr/bin" })).toBe(false);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,7 @@ import { executeNotify } from "./commands/notify.js";
 import { executeInit } from "./commands/init.js";
 import { executeUninstall } from "./commands/uninstall.js";
 import { executeReset } from "./commands/reset.js";
+import { isSSHSession } from "./utils/ssh.js";
 import { executeUpdate } from "./commands/update.js";
 import { resolveNotifierPaths } from "./notifier/paths.js";
 import { statusAll } from "./notifier/registry.js";
@@ -417,6 +418,75 @@ const statusCommand = defineCommand({
   },
 });
 
+// ---------------------------------------------------------------------------
+// SSH/headless detection helpers for login
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a headless-aware openBrowser wrapper.
+ *
+ * - SSH session: skip the browser attempt entirely, print the login URL and
+ *   `--code` instructions, then throw so cli-base still waits for the timeout
+ *   (port-forwarding power users can still use the URL).
+ * - Non-SSH browser failure: add a `--code` hint beneath the URL that
+ *   cli-base already printed.
+ */
+function buildOpenBrowserFn(
+  host: string,
+  env: NodeJS.ProcessEnv = process.env,
+): (url: string) => Promise<void> {
+  const ssh = isSSHSession(env);
+
+  return async (url: string) => {
+    if (ssh) {
+      // Print the URL (in lieu of opening a browser)
+      log.text(`  ${pc.dim(url)}`);
+      log.blank();
+      // Print actionable SSH guidance
+      log.text(pc.bold("SSH session detected — browser login is unavailable."));
+      log.blank();
+      log.text(pc.bold("Recommended: use the one-time code flow"));
+      log.text(`  1. Open ${pc.cyan(host + "/manage-devices")} in your local browser`);
+      log.text(`  2. Click ${pc.bold("CLI Login Code")} to generate a code`);
+      log.text(`  3. Run: ${pc.cyan("pew login --code XXXX-XXXX")}`);
+      log.blank();
+      log.text(pc.dim("Alternative — SSH port forwarding:"));
+      // Extract port from the callback URL so we can show the exact command
+      try {
+        const cb = new URL(new URL(url).searchParams.get("callback") ?? "");
+        const port = cb.port;
+        log.text(pc.dim(`  ssh -L ${port}:localhost:${port} user@host`));
+        log.text(pc.dim("  Then open the URL above in your local browser."));
+      } catch {
+        log.text(pc.dim("  Forward the callback port with: ssh -L PORT:localhost:PORT user@host"));
+      }
+      log.blank();
+      // Throw so cli-base does NOT additionally try to open a browser and shows
+      // "Could not open browser" — we already displayed everything useful.
+      throw new Error("SSH session — browser unavailable");
+    }
+
+    // Non-SSH: attempt real browser open
+    try {
+      await openBrowser(url);
+    } catch (err) {
+      // cli-base will print "Could not open browser. Open this URL manually: ..."
+      // We append the --code hint after it resolves
+      // Note: cli-base's log callback runs synchronously before the timeout, so
+      // printing here may appear before cli-base's message. We add a small guard.
+      setTimeout(() => {
+        log.blank();
+        log.text(pc.bold("Tip: On a headless server? Use the code flow instead:"));
+        log.text(`  1. Open ${pc.cyan(host + "/manage-devices")} in your browser`);
+        log.text(`  2. Click ${pc.bold("CLI Login Code")} to generate a code`);
+        log.text(`  3. Run: ${pc.cyan("pew login --code XXXX-XXXX")}`);
+        log.blank();
+      }, 50);
+      throw err;
+    }
+  };
+}
+
 const loginCommand = defineCommand({
   meta: {
     name: "login",
@@ -446,17 +516,26 @@ const loginCommand = defineCommand({
 
     if (args.code) {
       log.start("Verifying authentication code...");
+    } else if (isSSHSession()) {
+      log.start("SSH session detected — preparing headless login...");
     } else {
       log.start("Opening browser for authentication...");
     }
+
+    // In SSH mode, suppress cli-base's "Could not open browser" fallback message
+    // since buildOpenBrowserFn already printed more helpful SSH guidance.
+    const loginLog = isSSHSession()
+      ? (msg: string) => { if (!msg.startsWith("Could not open browser")) console.log(msg); }
+      : undefined;
 
     const result = await executeLogin({
       configDir: paths.stateDir,
       apiUrl: host,
       dev,
       force: args.force,
-      openBrowser,
+      openBrowser: buildOpenBrowserFn(host),
       code: args.code,
+      log: loginLog,
     });
 
     if (result.alreadyLoggedIn) {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -48,6 +48,8 @@ export interface LoginOptions {
   code?: string;
   /** Injected fetch function (for testing) */
   fetch?: typeof globalThis.fetch;
+  /** Log function for browser flow messages (default: console.log) */
+  log?: (msg: string) => void;
 }
 
 export interface LoginResult {
@@ -73,6 +75,7 @@ export async function executeLogin(options: LoginOptions): Promise<LoginResult> 
     code,
     fetch: fetchFn = globalThis.fetch,
   } = options;
+  // log is accessed via options.log below (not destructured to avoid shadowing)
 
   const configManager = new ConfigManager(configDir, dev);
 
@@ -90,6 +93,7 @@ export async function executeLogin(options: LoginOptions): Promise<LoginResult> 
   }
 
   // 3. Browser-based OAuth login flow
+  const logFn = options.log ?? ((msg: string) => console.log(msg));
   const result = await performLogin({
     openBrowser: openBrowserFn,
     onSaveToken: (token) => {
@@ -99,7 +103,7 @@ export async function executeLogin(options: LoginOptions): Promise<LoginResult> 
     timeoutMs,
     generateNonce,
     accentColor: PEW_ACCENT_COLOR,
-    log: (msg: string) => console.log(msg),
+    log: logFn,
   });
 
   return {

--- a/packages/cli/src/utils/ssh.ts
+++ b/packages/cli/src/utils/ssh.ts
@@ -1,0 +1,15 @@
+/**
+ * SSH/headless session detection.
+ *
+ * Standard environment variables set by sshd when a client connects:
+ * - SSH_CLIENT  — set on login sessions
+ * - SSH_TTY     — set when a pseudo-terminal is allocated
+ * - SSH_CONNECTION — set on all SSH connections (login + non-interactive)
+ */
+
+/**
+ * Returns true when the process is running inside an SSH session.
+ */
+export function isSSHSession(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.SSH_CLIENT || env.SSH_TTY || env.SSH_CONNECTION);
+}


### PR DESCRIPTION
## Summary

- Detect SSH sessions via `SSH_CLIENT`, `SSH_TTY`, `SSH_CONNECTION` env vars
- In SSH mode, skip browser-open attempt and print clear step-by-step guidance for the `--code` flow
- Also show SSH port-forwarding alternative for power users
- Suppress the generic \"Could not open browser\" noise in SSH mode (replaced by better messaging)

## Problem

When running `pew login` on a remote machine via SSH, the CLI tries to open a browser for OAuth, but:
1. There is no browser on the headless server
2. Even if the user manually opens the URL, the OAuth callback goes to `localhost` on the SSH server — unreachable from the user's local browser

## Solution

The `--code` flow already existed. The fix adds SSH detection so users get clear guidance automatically:

```
SSH session detected — preparing headless login...

Recommended: use the one-time code flow
  1. Open https://pew.md/manage-devices in your local browser
  2. Click "CLI Login Code" to generate a code
  3. Run: pew login --code XXXX-XXXX

Alternative — SSH port forwarding:
  ssh -L 43077:localhost:43077 user@host
  Then open the URL above in your local browser.
```

## New files

- `packages/cli/src/utils/ssh.ts` — `isSSHSession()` helper
- `packages/cli/src/__tests__/ssh.test.ts` — 7 unit tests

## Test plan

- [ ] Run `pew login` on an SSH session — should show headless guidance
- [ ] Run `pew login` normally — should behave as before
- [ ] Run `pew login --code XXXX-XXXX` on SSH — should work as before
- [ ] All unit tests pass: `bun run test`