### PR TITLE
fix(web): unify season time boundary across countdown, status badge, and API

### DIFF
--- a/packages/web/src/__tests__/season-status.test.ts
+++ b/packages/web/src/__tests__/season-status.test.ts
@@ -38,8 +38,17 @@ describe("deriveSeasonStatus", () => {
     ).toBe("active");
   });
 
-  it("should return 'ended' one second after endDate", () => {
-    const now = new Date("2026-04-15T23:59:01Z");
+  it("should return 'active' at exactly endDate + 59 seconds (within the final minute)", () => {
+    // end_date is inclusive at minute precision, so end_date + 59s is still active
+    const now = new Date("2026-04-15T23:59:59Z");
+    expect(
+      deriveSeasonStatus("2026-03-15T00:00:00Z", "2026-04-15T23:59:00Z", now)
+    ).toBe("active");
+  });
+
+  it("should return 'ended' at exactly endDate + 60 seconds (exclusive boundary)", () => {
+    // Season ends at endDate + 60s (exclusive), so endDate + 60s is the first "ended" moment
+    const now = new Date("2026-04-16T00:00:00Z");
     expect(
       deriveSeasonStatus("2026-03-15T00:00:00Z", "2026-04-15T23:59:00Z", now)
     ).toBe("ended");

--- a/packages/web/src/app/leaderboard/seasons/[slug]/page.tsx
+++ b/packages/web/src/app/leaderboard/seasons/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { cn, formatTokensFull } from "@/lib/utils";
 import { formatDuration } from "@/lib/date-helpers";
+import { getSeasonEndExclusiveISO } from "@/lib/season-helpers";
 import { teamColor, withAlpha } from "@/lib/palette";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -286,7 +287,7 @@ export default function SeasonLeaderboardPage() {
 
   // Compute exclusive end date for the dialog (end_date is inclusive at minute precision)
   const seasonEndExclusive = data?.season.end_date
-    ? new Date(new Date(data.season.end_date).getTime() + 60_000).toISOString()
+    ? getSeasonEndExclusiveISO(data.season.end_date)
     : undefined;
 
   return (

--- a/packages/web/src/components/leaderboard/season-countdown.tsx
+++ b/packages/web/src/components/leaderboard/season-countdown.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Calendar, Clock } from "lucide-react";
 import { formatSeasonDate } from "@/lib/seasons";
+import { getSeasonEndExclusive } from "@/lib/season-helpers";
 import type { SeasonStatus } from "@pew/core";
 import {
   Tooltip,
@@ -72,9 +73,11 @@ export function SeasonCountdown({
   }
 
   // Active or upcoming — show countdown with tooltip for full range
+  // Use exclusive end boundary (end_date + 60s) for active seasons
+  // to align with when data actually stops changing
   const targetMs =
     status === "active"
-      ? new Date(endDate).getTime()
+      ? getSeasonEndExclusive(endDate)
       : new Date(startDate).getTime();
   const remaining = Math.max(0, targetMs - now);
   const label = status === "active" ? "Ends in" : "Starts in";

--- a/packages/web/src/lib/season-helpers.ts
+++ b/packages/web/src/lib/season-helpers.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared season time boundary helpers.
+ *
+ * The core insight: end_date is inclusive at minute precision, meaning
+ * usage recorded at end_date:00 through end_date:59 should be counted.
+ * This requires adding 60_000ms (1 minute) to get the exclusive boundary
+ * for comparisons.
+ *
+ * These helpers centralize this logic to ensure consistency across:
+ * - API queries (leaderboard data aggregation)
+ * - Countdown timer display
+ * - Season status badge ("Active" vs "Ended")
+ */
+
+import type { SeasonStatus } from "@pew/core";
+
+/**
+ * Convert an ISO end_date to an exclusive upper bound timestamp (ms).
+ *
+ * end_date is inclusive at minute precision, so we add 60_000ms (1 minute)
+ * to get the exclusive boundary for `<` comparisons.
+ *
+ * @example
+ * // If end_date is "2026-03-31T23:59:00Z"
+ * // Returns timestamp for "2026-04-01T00:00:00Z"
+ */
+export function getSeasonEndExclusive(endDate: string): number {
+  return new Date(endDate).getTime() + 60_000;
+}
+
+/**
+ * Convert an ISO end_date to an exclusive upper bound ISO string.
+ *
+ * Same logic as getSeasonEndExclusive() but returns an ISO string
+ * for use in SQL queries.
+ */
+export function getSeasonEndExclusiveISO(endDate: string): string {
+  return new Date(getSeasonEndExclusive(endDate)).toISOString();
+}
+
+/**
+ * Check if a season is currently active (now is within the valid range).
+ *
+ * @param startDate - Season start date (ISO string)
+ * @param endDate - Season end date (ISO string, inclusive at minute precision)
+ * @param now - Optional current timestamp for testing
+ */
+export function isSeasonActive(
+  startDate: string,
+  endDate: string,
+  now?: Date
+): boolean {
+  const nowMs = (now ?? new Date()).getTime();
+  const startMs = new Date(startDate).getTime();
+  const endExclusiveMs = getSeasonEndExclusive(endDate);
+  return nowMs >= startMs && nowMs < endExclusiveMs;
+}
+
+/**
+ * Check if a season has ended (now is past the exclusive end boundary).
+ *
+ * @param endDate - Season end date (ISO string, inclusive at minute precision)
+ * @param now - Optional current timestamp for testing
+ */
+export function isSeasonEnded(endDate: string, now?: Date): boolean {
+  const nowMs = (now ?? new Date()).getTime();
+  return nowMs >= getSeasonEndExclusive(endDate);
+}
+
+/**
+ * Derive season status from start/end ISO datetime strings compared to now.
+ *
+ * Uses the exclusive end boundary (end_date + 60_000ms) to ensure
+ * consistency with API queries. This means:
+ * - "active" status persists for the full final minute
+ * - Countdown and status badge align with when data stops changing
+ *
+ * @param startDate - Season start date (ISO string)
+ * @param endDate - Season end date (ISO string, inclusive at minute precision)
+ * @param now - Optional current timestamp for testing
+ */
+export function deriveSeasonStatusExclusive(
+  startDate: string,
+  endDate: string,
+  now?: Date
+): SeasonStatus {
+  const nowMs = (now ?? new Date()).getTime();
+  const startMs = new Date(startDate).getTime();
+
+  if (nowMs < startMs) return "upcoming";
+  if (isSeasonEnded(endDate, now)) return "ended";
+  return "active";
+}

--- a/packages/web/src/lib/seasons.ts
+++ b/packages/web/src/lib/seasons.ts
@@ -6,13 +6,18 @@
  */
 
 import type { SeasonStatus } from "@pew/core";
+import { isSeasonEnded } from "@/lib/season-helpers";
 
 /**
  * Derive season status from start/end ISO datetime strings compared to now.
  *
  * - now < start_date  → "upcoming"
- * - start_date <= now <= end_date  → "active"
- * - now > end_date  → "ended"
+ * - start_date <= now < end_date + 60s → "active"
+ * - now >= end_date + 60s  → "ended"
+ *
+ * Uses exclusive end boundary (end_date + 60_000ms) to ensure consistency
+ * with API queries. end_date is inclusive at minute precision, so we add
+ * 60 seconds to get the actual boundary when data stops changing.
  *
  * Uses epoch ms comparison to avoid ISO format mismatches
  * (toISOString() includes .000Z but stored dates may omit ms).
@@ -24,7 +29,7 @@ export function deriveSeasonStatus(
 ): SeasonStatus {
   const nowMs = (now ?? new Date()).getTime();
   if (nowMs < new Date(startDate).getTime()) return "upcoming";
-  if (nowMs > new Date(endDate).getTime()) return "ended";
+  if (isSeasonEnded(endDate, now)) return "ended";
   return "active";
 }
 


### PR DESCRIPTION
Fixes #56

## Changes
- Created `packages/web/src/lib/season-helpers.ts` with shared `getSeasonEndExclusive()` helper
- Updated countdown component to use `end_date + 60s` consistent with API aggregation
- Updated season detail page to derive status from the same exclusive-end rule
- Updated `deriveSeasonStatus()` in `seasons.ts` to use consistent boundary

## Review
✅ Codex review: APPROVED — all existing tests pass, type checks clean