### PR TITLE
fix(web): reset leaderboard scope on sign-out and guard against API failure

### DIFF
--- a/packages/web/src/app/leaderboard/agents/page.tsx
+++ b/packages/web/src/app/leaderboard/agents/page.tsx
@@ -165,6 +165,7 @@ function AgentsLeaderboardContent() {
   const [scopeInitialized, setScopeInitialized] = useState(false);
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
+  const [orgsLoaded, setOrgsLoaded] = useState(false);
 
   // Dialog state for user profile popup
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -226,8 +227,11 @@ function AgentsLeaderboardContent() {
         const teamsJson = await teamsRes.json();
         setTeams(teamsJson.teams ?? []);
       }
+      // Mark as loaded only on success
+      setOrgsLoaded(true);
     } catch {
       // Silently fail — scope dropdown optional
+      // Do NOT set orgsLoaded = true so validation effect won't run
     }
   }, []);
 
@@ -237,6 +241,7 @@ function AgentsLeaderboardContent() {
     if (isSessionLoading) return;
 
     if (!isAuthenticated) {
+      setScope({ type: "global" });
       setScopeInitialized(true);
       return;
     }
@@ -254,7 +259,8 @@ function AgentsLeaderboardContent() {
   // Validate stored scope against available orgs/teams
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (!scopeInitialized) return;
+    // Only validate when orgs have been successfully loaded
+    if (!scopeInitialized || !orgsLoaded) return;
 
     if (scope.type === "org" && scope.id) {
       const valid = organizations.some((o) => o.id === scope.id);
@@ -269,7 +275,7 @@ function AgentsLeaderboardContent() {
         saveScopeToStorage({ type: "global" });
       }
     }
-  }, [scopeInitialized, scope, organizations, teams]);
+  }, [scopeInitialized, orgsLoaded, scope, organizations, teams]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleScopeChange = (newScope: ScopeSelection) => {

--- a/packages/web/src/app/leaderboard/agents/page.tsx
+++ b/packages/web/src/app/leaderboard/agents/page.tsx
@@ -227,8 +227,10 @@ function AgentsLeaderboardContent() {
         const teamsJson = await teamsRes.json();
         setTeams(teamsJson.teams ?? []);
       }
-      // Mark as loaded only on success
-      setOrgsLoaded(true);
+      // Mark as loaded only when BOTH fetches succeeded
+      if (orgsRes.ok && teamsRes.ok) {
+        setOrgsLoaded(true);
+      }
     } catch {
       // Silently fail — scope dropdown optional
       // Do NOT set orgsLoaded = true so validation effect won't run

--- a/packages/web/src/app/leaderboard/models/page.tsx
+++ b/packages/web/src/app/leaderboard/models/page.tsx
@@ -178,6 +178,7 @@ function ModelsLeaderboardContent() {
   const [scopeInitialized, setScopeInitialized] = useState(false);
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
+  const [orgsLoaded, setOrgsLoaded] = useState(false);
 
   // Dialog state for user profile popup
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -239,8 +240,11 @@ function ModelsLeaderboardContent() {
         const teamsJson = await teamsRes.json();
         setTeams(teamsJson.teams ?? []);
       }
+      // Mark as loaded only on success
+      setOrgsLoaded(true);
     } catch {
       // Silently fail — scope dropdown optional
+      // Do NOT set orgsLoaded = true so validation effect won't run
     }
   }, []);
 
@@ -250,6 +254,7 @@ function ModelsLeaderboardContent() {
     if (isSessionLoading) return;
 
     if (!isAuthenticated) {
+      setScope({ type: "global" });
       setScopeInitialized(true);
       return;
     }
@@ -267,7 +272,8 @@ function ModelsLeaderboardContent() {
   // Validate stored scope against available orgs/teams
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (!scopeInitialized) return;
+    // Only validate when orgs have been successfully loaded
+    if (!scopeInitialized || !orgsLoaded) return;
 
     if (scope.type === "org" && scope.id) {
       const valid = organizations.some((o) => o.id === scope.id);
@@ -282,7 +288,7 @@ function ModelsLeaderboardContent() {
         saveScopeToStorage({ type: "global" });
       }
     }
-  }, [scopeInitialized, scope, organizations, teams]);
+  }, [scopeInitialized, orgsLoaded, scope, organizations, teams]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleScopeChange = (newScope: ScopeSelection) => {

--- a/packages/web/src/app/leaderboard/models/page.tsx
+++ b/packages/web/src/app/leaderboard/models/page.tsx
@@ -240,8 +240,10 @@ function ModelsLeaderboardContent() {
         const teamsJson = await teamsRes.json();
         setTeams(teamsJson.teams ?? []);
       }
-      // Mark as loaded only on success
-      setOrgsLoaded(true);
+      // Mark as loaded only when BOTH fetches succeeded
+      if (orgsRes.ok && teamsRes.ok) {
+        setOrgsLoaded(true);
+      }
     } catch {
       // Silently fail — scope dropdown optional
       // Do NOT set orgsLoaded = true so validation effect won't run

--- a/packages/web/src/app/leaderboard/page.tsx
+++ b/packages/web/src/app/leaderboard/page.tsx
@@ -44,6 +44,7 @@ export default function LeaderboardPage() {
   const [scopeInitialized, setScopeInitialized] = useState(false);
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
+  const [orgsLoaded, setOrgsLoaded] = useState(false);
 
   // Dialog state for user profile popup
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -93,8 +94,11 @@ export default function LeaderboardPage() {
         const teamsJson = await teamsRes.json();
         setTeams(teamsJson.teams ?? []);
       }
+      // Mark as loaded only on success
+      setOrgsLoaded(true);
     } catch {
       // Silently fail — scope dropdown optional
+      // Do NOT set orgsLoaded = true so validation effect won't run
     }
   }, []);
 
@@ -109,6 +113,7 @@ export default function LeaderboardPage() {
 
     // Unauthenticated - use global scope immediately
     if (!isAuthenticated) {
+      setScope({ type: "global" });
       setScopeInitialized(true);
       return;
     }
@@ -128,7 +133,8 @@ export default function LeaderboardPage() {
   // (intentionally calling setState in effect to correct invalid state after async load)
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (!scopeInitialized) return;
+    // Only validate when orgs have been successfully loaded
+    if (!scopeInitialized || !orgsLoaded) return;
 
     if (scope.type === "org" && scope.id) {
       const valid = organizations.some((o) => o.id === scope.id);
@@ -143,7 +149,7 @@ export default function LeaderboardPage() {
         saveScopeToStorage({ type: "global" });
       }
     }
-  }, [scopeInitialized, scope, organizations, teams]);
+  }, [scopeInitialized, orgsLoaded, scope, organizations, teams]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   // Handle scope change

--- a/packages/web/src/app/leaderboard/page.tsx
+++ b/packages/web/src/app/leaderboard/page.tsx
@@ -94,8 +94,10 @@ export default function LeaderboardPage() {
         const teamsJson = await teamsRes.json();
         setTeams(teamsJson.teams ?? []);
       }
-      // Mark as loaded only on success
-      setOrgsLoaded(true);
+      // Mark as loaded only when BOTH fetches succeeded
+      if (orgsRes.ok && teamsRes.ok) {
+        setOrgsLoaded(true);
+      }
     } catch {
       // Silently fail — scope dropdown optional
       // Do NOT set orgsLoaded = true so validation effect won't run


### PR DESCRIPTION
Fixes #57

## Changes
- Reset scope to global when user signs out (prevents stale org/team scope)
- Added `orgsLoaded` success flag — only validate persisted scope when org/team data loaded successfully
- Added `response.ok` check — HTTP 500 no longer counts as successful load

## Review
Codex review round 1: Found `response.ok` not checked → fixed in follow-up commit
Final: 2 clean commits