### PR TITLE
fix(openclaw-parser): count cacheRead+cacheWrite in inputTokens

### DIFF
--- a/packages/cli/src/__tests__/openclaw-parser.test.ts
+++ b/packages/cli/src/__tests__/openclaw-parser.test.ts
@@ -42,8 +42,8 @@ describe("parseOpenClawFile", () => {
     expect(result.deltas).toHaveLength(1);
     expect(result.deltas[0].source).toBe("openclaw");
     expect(result.deltas[0].model).toBe("claude-sonnet-4");
-    expect(result.deltas[0].tokens.inputTokens).toBe(5000);
-    expect(result.deltas[0].tokens.cachedInputTokens).toBe(1200); // cacheRead + cacheWrite
+    expect(result.deltas[0].tokens.inputTokens).toBe(6200); // input + cacheRead + cacheWrite
+    expect(result.deltas[0].tokens.cachedInputTokens).toBe(1000); // cacheRead only
     expect(result.deltas[0].tokens.outputTokens).toBe(800);
     expect(result.deltas[0].tokens.reasoningOutputTokens).toBe(0);
     expect(result.endOffset).toBeGreaterThan(0);

--- a/packages/cli/src/parsers/openclaw.ts
+++ b/packages/cli/src/parsers/openclaw.ts
@@ -18,10 +18,14 @@ export interface OpenClawFileResult {
  * lines with `message.usage` containing absolute token counts (no diffing needed).
  *
  * OpenClaw normalization:
- *   input                        → inputTokens
- *   cacheRead + cacheWrite       → cachedInputTokens
- *   output                       → outputTokens
- *   (hardcoded 0)                → reasoningOutputTokens
+ *   input + cacheRead + cacheWrite → inputTokens  (full input cost incl. cache)
+ *   cacheRead                      → cachedInputTokens
+ *   output                         → outputTokens
+ *   (hardcoded 0)                  → reasoningOutputTokens
+ *
+ * NOTE: `usage.input` is only the uncached token delta (typically 1–3 per turn).
+ * The bulk of input cost lives in cacheRead (cache hits) and cacheWrite (cache fills).
+ * All three must be summed to produce the true inputTokens count.
  */
 export async function parseOpenClawFile(opts: {
   filePath: string;
@@ -71,8 +75,11 @@ export async function parseOpenClawFile(opts: {
         typeof msg.model === "string" ? msg.model.trim() : "unknown";
 
       const tokens: TokenDelta = {
-        inputTokens: toNonNegInt(usage.input),
-        cachedInputTokens: toNonNegInt(usage.cacheRead) + toNonNegInt(usage.cacheWrite),
+        inputTokens:
+          toNonNegInt(usage.input) +
+          toNonNegInt(usage.cacheRead) +
+          toNonNegInt(usage.cacheWrite),
+        cachedInputTokens: toNonNegInt(usage.cacheRead),
         outputTokens: toNonNegInt(usage.output),
         reasoningOutputTokens: 0,
       };


### PR DESCRIPTION
## Problem

OpenClaw's `usage.input` only contains the **uncached token delta** (typically 1–3 per turn). The bulk of input cost lives in:

- `cacheRead`: tokens served from the prompt cache (cache hit cost)
- `cacheWrite`: tokens written into the prompt cache (cache fill cost)

Previously the parser mapped:
```
inputTokens      = usage.input                           // only 1-3 per turn!
cachedInputTokens = usage.cacheRead + usage.cacheWrite   // everything else
```

This caused a ~57,000x undercount of `inputTokens` in real sessions.

## Fix

```
inputTokens      = usage.input + usage.cacheRead + usage.cacheWrite  // full input cost
cachedInputTokens = usage.cacheRead                                  // true cache-hit quantity
```

## Verification

Real OpenClaw session (36 turns, claude-sonnet-4.6 with prompt caching):

| Metric | Before | After |
|--------|--------|-------|
| inputTokens | 46 | 2,615,134 |
| cachedInputTokens | 2,615,088 | 2,420,531 |

## Tests

All 12 existing `openclaw-parser` tests pass with updated expected values. No other test files changed.