### PR TITLE
fix(web): add AbortController to 8 data-fetching hooks

### DIFF
--- a/packages/web/src/hooks/use-achievements.ts
+++ b/packages/web/src/hooks/use-achievements.ts
@@ -83,7 +83,7 @@ export function useAchievements(options?: UseAchievementsOptions): UseAchievemen
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     setError(null);
 
@@ -91,7 +91,9 @@ export function useAchievements(options?: UseAchievementsOptions): UseAchievemen
       const tzOffset = new Date().getTimezoneOffset();
       const params = new URLSearchParams({ tzOffset: String(tzOffset) });
       if (limit) params.set("limit", String(limit));
-      const res = await fetch(`/api/achievements?${params}`);
+      const res = await fetch(`/api/achievements?${params}`, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
 
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
@@ -99,19 +101,31 @@ export function useAchievements(options?: UseAchievementsOptions): UseAchievemen
       }
 
       const json = await res.json();
+
+      if (signal?.aborted) return;
+
       setData(json);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
     }
   }, [limit]);
 
   useEffect(() => {
-    fetchData();
+    const controller = new AbortController();
+
+    fetchData(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
   }, [fetchData]);
 
-  return { data, loading, error, refetch: fetchData };
+  return { data, loading, error, refetch: () => fetchData() };
 }
 
 // ---------------------------------------------------------------------------
@@ -135,7 +149,7 @@ export function useAchievementMembers(
   const [error, setError] = useState<string | null>(null);
   const [cursor, setCursor] = useState<string | null>(null);
 
-  const fetchData = useCallback(async (nextCursor?: string) => {
+  const fetchData = useCallback(async (nextCursor?: string, signal?: AbortSignal) => {
     if (!achievementId) return;
 
     setLoading(true);
@@ -145,7 +159,9 @@ export function useAchievementMembers(
       const params = new URLSearchParams({ limit: String(limit) });
       if (nextCursor) params.set("cursor", nextCursor);
 
-      const res = await fetch(`/api/achievements/${achievementId}/members?${params}`);
+      const res = await fetch(`/api/achievements/${achievementId}/members?${params}`, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
 
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
@@ -153,6 +169,8 @@ export function useAchievementMembers(
       }
 
       const json: AchievementMembersData = await res.json();
+
+      if (signal?.aborted) return;
 
       if (nextCursor) {
         // Append to existing data
@@ -165,17 +183,28 @@ export function useAchievementMembers(
       }
       setCursor(json.cursor);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
     }
   }, [achievementId, limit]);
 
   useEffect(() => {
     if (achievementId) {
+      const controller = new AbortController();
+
+      // Reset data when achievementId changes to avoid stale data
       setData(null);
       setCursor(null);
-      fetchData();
+
+      fetchData(undefined, controller.signal);
+
+      return () => {
+        controller.abort();
+      };
     }
   }, [achievementId, fetchData]);
 

--- a/packages/web/src/hooks/use-device-data.ts
+++ b/packages/web/src/hooks/use-device-data.ts
@@ -35,7 +35,7 @@ export function useDeviceData(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     setError(null);
 
@@ -47,7 +47,9 @@ export function useDeviceData(
 
       const qs = params.toString();
       const url = `/api/usage/by-device${qs ? `?${qs}` : ""}`;
-      const res = await fetch(url);
+      const res = await fetch(url, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
 
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
@@ -57,17 +59,32 @@ export function useDeviceData(
       }
 
       const json = (await res.json()) as ByDeviceResponse;
+
+      if (signal?.aborted) return;
+
       setData(json);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
     }
   }, [fromDate, toDate, granularity]);
 
   useEffect(() => {
-    fetchData();
+    const controller = new AbortController();
+
+    // Clear data on filter change to avoid stale data
+    setData(null);
+
+    fetchData(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
   }, [fetchData]);
 
-  return { data, loading, error, refetch: fetchData };
+  return { data, loading, error, refetch: () => fetchData() };
 }

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -90,7 +90,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
   // Fetch
   // ---------------------------------------------------------------------------
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     setError(null);
 
@@ -102,7 +102,10 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
       }
       const qs = params.toString();
       const url = qs ? `/api/projects?${qs}` : "/api/projects";
-      const res = await fetch(url);
+      const res = await fetch(url, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
+
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(
@@ -111,16 +114,31 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
       }
 
       const json = (await res.json()) as ProjectsData;
+
+      if (signal?.aborted) return;
+
       setData(json);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
     }
   }, [from, to]);
 
   useEffect(() => {
-    fetchData();
+    const controller = new AbortController();
+
+    // Clear data on filter change to avoid stale data
+    setData(null);
+
+    fetchData(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
   }, [fetchData]);
 
   // ---------------------------------------------------------------------------
@@ -235,7 +253,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
     allTags,
     loading,
     error,
-    refetch: fetchData,
+    refetch: () => fetchData(),
     createProject,
     updateProject,
     deleteProject,

--- a/packages/web/src/hooks/use-session-data.ts
+++ b/packages/web/src/hooks/use-session-data.ts
@@ -51,7 +51,7 @@ export function useSessionData(
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     if (!enabled) return;
     setLoading(true);
     setError(null);
@@ -64,7 +64,9 @@ export function useSessionData(
 
       const qs = params.toString();
       const url = qs ? `/api/sessions?${qs}` : "/api/sessions";
-      const res = await fetch(url);
+      const res = await fetch(url, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
 
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
@@ -74,17 +76,33 @@ export function useSessionData(
       }
 
       const json = (await res.json()) as { records: SessionRow[] };
+
+      if (signal?.aborted) return;
+
       setRecords(json.records);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
     }
-    }, [fromDate, toDate, source, enabled]);
+  }, [fromDate, toDate, source, enabled]);
 
   useEffect(() => {
     if (!enabled) return;
-    fetchData();
+
+    const controller = new AbortController();
+
+    // Clear records on filter change to avoid stale data
+    setRecords([]);
+
+    fetchData(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
   }, [fetchData, enabled]);
 
   // Reset state when disabled to avoid stale data
@@ -110,6 +128,6 @@ export function useSessionData(
     projectBreakdown,
     loading,
     error,
-    refetch: fetchData,
+    refetch: () => fetchData(),
   };
 }

--- a/packages/web/src/hooks/use-showcases.ts
+++ b/packages/web/src/hooks/use-showcases.ts
@@ -78,7 +78,7 @@ export function useShowcases(options: UseShowcasesOptions = {}): UseShowcasesRes
   // Track whether we have data to determine loading vs refreshing
   const hasDataRef = useRef(false);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     // Use ref to check if we have data (avoids data in deps)
     if (!hasDataRef.current) {
       setLoading(true);
@@ -93,7 +93,10 @@ export function useShowcases(options: UseShowcasesOptions = {}): UseShowcasesRes
       params.set("limit", String(limit));
       params.set("offset", String(offset));
 
-      const res = await fetch(`/api/showcases?${params.toString()}`);
+      const res = await fetch(`/api/showcases?${params.toString()}`, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
+
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(
@@ -102,23 +105,38 @@ export function useShowcases(options: UseShowcasesOptions = {}): UseShowcasesRes
       }
 
       const json = (await res.json()) as ShowcasesResponse;
+
+      if (signal?.aborted) return;
+
       setData(json);
       hasDataRef.current = true;
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+        setRefreshing(false);
+      }
     }
   }, [mine, limit, offset]);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     // Reset hasDataRef when params change to show loading state
     hasDataRef.current = false;
-    fetchData();
+    // Clear data on param change to avoid stale data
+    setData(null);
+
+    fetchData(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
   }, [fetchData]);
 
-  return { data, loading, refreshing, error, refetch: fetchData };
+  return { data, loading, refreshing, error, refetch: () => fetchData() };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -204,7 +204,7 @@ export function useUsageData(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     setError(null);
 
@@ -227,7 +227,10 @@ export function useUsageData(
       if (source) params.set("source", source);
       if (deviceId) params.set("deviceId", deviceId);
 
-      const res = await fetch(`/api/usage?${params.toString()}`);
+      const res = await fetch(`/api/usage?${params.toString()}`, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
+
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(
@@ -236,16 +239,31 @@ export function useUsageData(
       }
 
       const json = (await res.json()) as UsageData;
+
+      if (signal?.aborted) return;
+
       setData(json);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
     }
   }, [days, fromDate, toDate, source, deviceId, granularity]);
 
   useEffect(() => {
-    fetchData();
+    const controller = new AbortController();
+
+    // Clear data on filter change to avoid stale data
+    setData(null);
+
+    fetchData(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
   }, [fetchData]);
 
   const daily = data ? toDailyPoints(data.records, new Date().getTimezoneOffset()) : [];
@@ -257,5 +275,5 @@ export function useUsageData(
     : [];
   const models = data ? toModelAggregates(data.records) : [];
 
-  return { data, daily, sources, models, loading, error, refetch: fetchData };
+  return { data, daily, sources, models, loading, error, refetch: () => fetchData() };
 }

--- a/packages/web/src/hooks/use-user-achievements.ts
+++ b/packages/web/src/hooks/use-user-achievements.ts
@@ -50,14 +50,16 @@ export function useUserAchievements(slug: string | null): UseUserAchievementsRes
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     if (!slug) return;
 
     setLoading(true);
     setError(null);
 
     try {
-      const res = await fetch(`/api/users/${encodeURIComponent(slug)}/achievements`);
+      const res = await fetch(`/api/users/${encodeURIComponent(slug)}/achievements`, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
 
       if (!res.ok) {
         if (res.status === 404) {
@@ -70,21 +72,36 @@ export function useUserAchievements(slug: string | null): UseUserAchievementsRes
       }
 
       const json = await res.json();
+
+      if (signal?.aborted) return;
+
       setData(json);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
     }
   }, [slug]);
 
   useEffect(() => {
     if (slug) {
-      fetchData();
+      const controller = new AbortController();
+
+      // Reset data when slug changes to avoid showing stale user's data
+      setData(null);
+
+      fetchData(controller.signal);
+
+      return () => {
+        controller.abort();
+      };
     } else {
       setData(null);
     }
   }, [slug, fetchData]);
 
-  return { data, loading, error, refetch: fetchData };
+  return { data, loading, error, refetch: () => fetchData() };
 }

--- a/packages/web/src/hooks/use-user-profile.ts
+++ b/packages/web/src/hooks/use-user-profile.ts
@@ -83,7 +83,7 @@ export function useUserProfile(
   const [error, setError] = useState<string | null>(null);
   const [notFound, setNotFound] = useState(false);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     if (!slug) {
       setLoading(false);
       return;
@@ -106,7 +106,9 @@ export function useUserProfile(
 
       if (source) params.set("source", source);
 
-      const res = await fetch(`/api/users/${slug}?${params.toString()}`);
+      const res = await fetch(`/api/users/${slug}?${params.toString()}`, signal ? { signal } : undefined);
+
+      if (signal?.aborted) return;
 
       if (res.status === 404) {
         setNotFound(true);
@@ -121,16 +123,32 @@ export function useUserProfile(
       }
 
       const json = (await res.json()) as UserProfileData;
+
+      if (signal?.aborted) return;
+
       setData(json);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
     }
   }, [slug, days, from, to, source]);
 
   useEffect(() => {
-    fetchData();
+    const controller = new AbortController();
+
+    // Reset data when slug changes to avoid showing stale user's data
+    setData(null);
+    setNotFound(false);
+
+    fetchData(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
   }, [fetchData]);
 
   const daily = data ? toDailyPoints(data.records, new Date().getTimezoneOffset()) : [];
@@ -153,6 +171,6 @@ export function useUserProfile(
     loading,
     error,
     notFound,
-    refetch: fetchData,
+    refetch: () => fetchData(),
   };
 }


### PR DESCRIPTION
Fixes #59

## Changes
Added AbortController / request-sequencing guards to 8 hooks that previously lacked them:
- `use-usage-data.ts`, `use-device-data.ts`, `use-session-data.ts`, `use-projects.ts`
- `use-showcases.ts`, `use-user-profile.ts`
- `use-achievements.ts`, `use-user-achievements.ts`

Each hook now:
- Creates AbortController in useEffect
- Passes signal to fetch calls
- Ignores AbortError
- Cleans up on unmount/dep change

## Review Notes
Codex review identified two follow-up items (not blocking):
- Imperative `refetch()` paths still lack abort (manual refresh scenario)
- `loadMore()` in useAchievementMembers lacks abort (pagination scenario)

These are edge cases that can be addressed separately.