### PR TITLE
refactor(web): extract shared leaderboard page shell and scope hook

### DIFF
--- a/packages/web/src/app/leaderboard/agents/page.tsx
+++ b/packages/web/src/app/leaderboard/agents/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Suspense, useState, useEffect, useCallback, useRef } from "react";
-import { useSession } from "next-auth/react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -10,23 +9,13 @@ import { sourceLabel } from "@/hooks/use-usage-data";
 import {
   useLeaderboard,
   type LeaderboardPeriod,
-  type LeaderboardEntry,
 } from "@/hooks/use-leaderboard";
+import { useLeaderboardScope } from "@/hooks/use-leaderboard-scope";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
 import { PageHeader } from "@/components/leaderboard/page-header";
-import { TableHeader } from "@/components/leaderboard/table-header";
-import { LeaderboardSkeleton } from "@/components/leaderboard/leaderboard-skeleton";
-import { LeaderboardRow } from "@/components/leaderboard/leaderboard-row";
-import { PeriodTabs, PERIOD_TO_TAB } from "@/components/leaderboard/period-tabs";
-import {
-  ScopeDropdown,
-  loadScopeFromStorage,
-  saveScopeToStorage,
-  type ScopeSelection,
-  type Organization,
-  type Team,
-} from "@/components/leaderboard/scope-dropdown";
-import { UserProfileDialog } from "@/components/user-profile-dialog";
+import { PeriodTabs } from "@/components/leaderboard/period-tabs";
+import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
+import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
 
 // ---------------------------------------------------------------------------
 // Agent list (matches VALID_SOURCES in API route)
@@ -135,7 +124,6 @@ function AgentSelector({
 // ---------------------------------------------------------------------------
 
 const PAGE_SIZE = 20;
-const MAX_ENTRIES = 100;
 
 // ---------------------------------------------------------------------------
 // Page
@@ -150,9 +138,6 @@ export default function AgentsLeaderboardPage() {
 }
 
 function AgentsLeaderboardContent() {
-  const { status } = useSession();
-  const isAuthenticated = status === "authenticated";
-  const isSessionLoading = status === "loading";
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -161,20 +146,18 @@ function AgentsLeaderboardContent() {
   const selectedAgent = urlSource && AGENT_SET.has(urlSource) ? urlSource : DEFAULT_AGENT;
 
   const [period, setPeriod] = useState<LeaderboardPeriod>("week");
-  const [scope, setScope] = useState<ScopeSelection>({ type: "global" });
-  const [scopeInitialized, setScopeInitialized] = useState(false);
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [orgsLoaded, setOrgsLoaded] = useState(false);
 
-  // Dialog state for user profile popup
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [dialogEntry, setDialogEntry] = useState<LeaderboardEntry | null>(null);
-
-  const handleRowSelect = useCallback((entry: LeaderboardEntry) => {
-    setDialogEntry(entry);
-    setDialogOpen(true);
-  }, []);
+  const {
+    scope,
+    setScope,
+    organizations,
+    teams,
+    scopeInitialized,
+    isSessionLoading,
+    isAuthenticated,
+    teamId,
+    orgId,
+  } = useLeaderboardScope();
 
   // Update URL when agent changes (URL is source of truth, not local state)
   const handleAgentChange = useCallback(
@@ -190,9 +173,6 @@ function AgentsLeaderboardContent() {
     },
     [searchParams, router],
   );
-
-  const teamId = scope.type === "team" ? scope.id ?? null : null;
-  const orgId = scope.type === "org" ? scope.id ?? null : null;
 
   const {
     entries,
@@ -210,80 +190,6 @@ function AgentsLeaderboardContent() {
     limit: PAGE_SIZE,
     enabled: scopeInitialized && !isSessionLoading,
   });
-
-  // Fetch user's organizations and teams
-  const fetchOrgsAndTeams = useCallback(async () => {
-    try {
-      const [orgsRes, teamsRes] = await Promise.all([
-        fetch("/api/organizations/mine"),
-        fetch("/api/teams"),
-      ]);
-
-      if (orgsRes.ok) {
-        const orgsJson = await orgsRes.json();
-        setOrganizations(orgsJson.organizations ?? []);
-      }
-      if (teamsRes.ok) {
-        const teamsJson = await teamsRes.json();
-        setTeams(teamsJson.teams ?? []);
-      }
-      // Mark as loaded only when BOTH fetches succeeded
-      if (orgsRes.ok && teamsRes.ok) {
-        setOrgsLoaded(true);
-      }
-    } catch {
-      // Silently fail — scope dropdown optional
-      // Do NOT set orgsLoaded = true so validation effect won't run
-    }
-  }, []);
-
-  // Initialize scope from localStorage and fetch orgs/teams
-  /* eslint-disable react-hooks/set-state-in-effect -- async fetch and localStorage read */
-  useEffect(() => {
-    if (isSessionLoading) return;
-
-    if (!isAuthenticated) {
-      setScope({ type: "global" });
-      setScopeInitialized(true);
-      return;
-    }
-
-    fetchOrgsAndTeams().then(() => {
-      const stored = loadScopeFromStorage();
-      if (stored) {
-        setScope(stored);
-      }
-      setScopeInitialized(true);
-    });
-  }, [isSessionLoading, isAuthenticated, fetchOrgsAndTeams]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
-  // Validate stored scope against available orgs/teams
-  /* eslint-disable react-hooks/set-state-in-effect */
-  useEffect(() => {
-    // Only validate when orgs have been successfully loaded
-    if (!scopeInitialized || !orgsLoaded) return;
-
-    if (scope.type === "org" && scope.id) {
-      const valid = organizations.some((o) => o.id === scope.id);
-      if (!valid) {
-        setScope({ type: "global" });
-        saveScopeToStorage({ type: "global" });
-      }
-    } else if (scope.type === "team" && scope.id) {
-      const valid = teams.some((t) => t.id === scope.id);
-      if (!valid) {
-        setScope({ type: "global" });
-        saveScopeToStorage({ type: "global" });
-      }
-    }
-  }, [scopeInitialized, orgsLoaded, scope, organizations, teams]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
-  const handleScopeChange = (newScope: ScopeSelection) => {
-    setScope(newScope);
-    saveScopeToStorage(newScope);
-  };
 
   return (
     <>
@@ -321,7 +227,7 @@ function AgentsLeaderboardContent() {
             <div className="hidden sm:block">
               <ScopeDropdown
                 value={scope}
-                onChange={handleScopeChange}
+                onChange={setScope}
                 organizations={organizations}
                 teams={teams}
               />
@@ -329,61 +235,19 @@ function AgentsLeaderboardContent() {
           )}
         </div>
 
-        {/* Error */}
-        {error && (
-          <div className="rounded-[var(--radius-card)] bg-destructive/10 p-4 text-sm text-destructive">
-            Failed to load leaderboard: {error}
-          </div>
-        )}
-
-        {/* Table header row */}
-        <TableHeader />
-
-        {/* Loading — skeleton on initial load */}
-        {loading && <LeaderboardSkeleton />}
-
-        {/* Content */}
-        {entries.length > 0 && (
-          <div className="space-y-2">
-            {entries.map((entry, i) => (
-              <LeaderboardRow
-                key={entry.user.id}
-                entry={entry}
-                index={i}
-                animationStartIndex={animationStartIndex}
-                onSelect={handleRowSelect}
-              />
-            ))}
-            {hasMore && entries.length < MAX_ENTRIES && (
-              <button
-                onClick={loadMore}
-                disabled={loadingMore}
-                className="w-full rounded-[var(--radius-card)] bg-secondary py-3 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
-              >
-                {loadingMore ? "Loading..." : "Show more"}
-              </button>
-            )}
-          </div>
-        )}
-
-        {/* Empty state */}
-        {!loading && entries.length === 0 && !error && (
-          <div className="rounded-[var(--radius-card)] bg-secondary p-8 text-center text-sm text-muted-foreground">
-            No usage data for {sourceLabel(selectedAgent)} in this period.
-          </div>
-        )}
+        {/* Shared page shell: error, table, loading, empty, dialog */}
+        <LeaderboardPageShell
+          entries={entries}
+          loading={loading}
+          loadingMore={loadingMore}
+          error={error}
+          hasMore={hasMore}
+          loadMore={loadMore}
+          animationStartIndex={animationStartIndex}
+          period={period}
+          emptyMessage={`No usage data for ${sourceLabel(selectedAgent)} in this period.`}
+        />
       </main>
-
-      {/* User profile dialog */}
-      <UserProfileDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        slug={dialogEntry?.user.slug ?? dialogEntry?.user.id ?? null}
-        name={dialogEntry?.user.name ?? null}
-        image={dialogEntry?.user.image ?? null}
-        badges={dialogEntry?.badges ?? []}
-        defaultTab={PERIOD_TO_TAB[period]}
-      />
     </>
   );
 }

--- a/packages/web/src/app/leaderboard/models/page.tsx
+++ b/packages/web/src/app/leaderboard/models/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Suspense, useState, useEffect, useCallback, useRef } from "react";
-import { useSession } from "next-auth/react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -10,23 +9,13 @@ import { shortModel } from "@/lib/model-helpers";
 import {
   useLeaderboard,
   type LeaderboardPeriod,
-  type LeaderboardEntry,
 } from "@/hooks/use-leaderboard";
+import { useLeaderboardScope } from "@/hooks/use-leaderboard-scope";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
 import { PageHeader } from "@/components/leaderboard/page-header";
-import { TableHeader } from "@/components/leaderboard/table-header";
-import { LeaderboardSkeleton } from "@/components/leaderboard/leaderboard-skeleton";
-import { LeaderboardRow } from "@/components/leaderboard/leaderboard-row";
-import { PeriodTabs, PERIOD_TO_TAB } from "@/components/leaderboard/period-tabs";
-import {
-  ScopeDropdown,
-  loadScopeFromStorage,
-  saveScopeToStorage,
-  type ScopeSelection,
-  type Organization,
-  type Team,
-} from "@/components/leaderboard/scope-dropdown";
-import { UserProfileDialog } from "@/components/user-profile-dialog";
+import { PeriodTabs } from "@/components/leaderboard/period-tabs";
+import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
+import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
 
 // ---------------------------------------------------------------------------
 // Model list — Top 20 by token usage from D1 (2026-04-10 snapshot)
@@ -146,7 +135,6 @@ function ModelSelector({
 // ---------------------------------------------------------------------------
 
 const PAGE_SIZE = 20;
-const MAX_ENTRIES = 100;
 
 // ---------------------------------------------------------------------------
 // Page
@@ -161,9 +149,6 @@ export default function ModelsLeaderboardPage() {
 }
 
 function ModelsLeaderboardContent() {
-  const { status } = useSession();
-  const isAuthenticated = status === "authenticated";
-  const isSessionLoading = status === "loading";
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -174,20 +159,18 @@ function ModelsLeaderboardContent() {
   const selectedModel = urlModel && urlModel.trim() ? urlModel : DEFAULT_MODEL;
 
   const [period, setPeriod] = useState<LeaderboardPeriod>("week");
-  const [scope, setScope] = useState<ScopeSelection>({ type: "global" });
-  const [scopeInitialized, setScopeInitialized] = useState(false);
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [orgsLoaded, setOrgsLoaded] = useState(false);
 
-  // Dialog state for user profile popup
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [dialogEntry, setDialogEntry] = useState<LeaderboardEntry | null>(null);
-
-  const handleRowSelect = useCallback((entry: LeaderboardEntry) => {
-    setDialogEntry(entry);
-    setDialogOpen(true);
-  }, []);
+  const {
+    scope,
+    setScope,
+    organizations,
+    teams,
+    scopeInitialized,
+    isSessionLoading,
+    isAuthenticated,
+    teamId,
+    orgId,
+  } = useLeaderboardScope();
 
   // Update URL when model changes (URL is source of truth, not local state)
   const handleModelChange = useCallback(
@@ -203,9 +186,6 @@ function ModelsLeaderboardContent() {
     },
     [searchParams, router],
   );
-
-  const teamId = scope.type === "team" ? scope.id ?? null : null;
-  const orgId = scope.type === "org" ? scope.id ?? null : null;
 
   const {
     entries,
@@ -223,80 +203,6 @@ function ModelsLeaderboardContent() {
     limit: PAGE_SIZE,
     enabled: scopeInitialized && !isSessionLoading,
   });
-
-  // Fetch user's organizations and teams
-  const fetchOrgsAndTeams = useCallback(async () => {
-    try {
-      const [orgsRes, teamsRes] = await Promise.all([
-        fetch("/api/organizations/mine"),
-        fetch("/api/teams"),
-      ]);
-
-      if (orgsRes.ok) {
-        const orgsJson = await orgsRes.json();
-        setOrganizations(orgsJson.organizations ?? []);
-      }
-      if (teamsRes.ok) {
-        const teamsJson = await teamsRes.json();
-        setTeams(teamsJson.teams ?? []);
-      }
-      // Mark as loaded only when BOTH fetches succeeded
-      if (orgsRes.ok && teamsRes.ok) {
-        setOrgsLoaded(true);
-      }
-    } catch {
-      // Silently fail — scope dropdown optional
-      // Do NOT set orgsLoaded = true so validation effect won't run
-    }
-  }, []);
-
-  // Initialize scope from localStorage and fetch orgs/teams
-  /* eslint-disable react-hooks/set-state-in-effect -- async fetch and localStorage read */
-  useEffect(() => {
-    if (isSessionLoading) return;
-
-    if (!isAuthenticated) {
-      setScope({ type: "global" });
-      setScopeInitialized(true);
-      return;
-    }
-
-    fetchOrgsAndTeams().then(() => {
-      const stored = loadScopeFromStorage();
-      if (stored) {
-        setScope(stored);
-      }
-      setScopeInitialized(true);
-    });
-  }, [isSessionLoading, isAuthenticated, fetchOrgsAndTeams]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
-  // Validate stored scope against available orgs/teams
-  /* eslint-disable react-hooks/set-state-in-effect */
-  useEffect(() => {
-    // Only validate when orgs have been successfully loaded
-    if (!scopeInitialized || !orgsLoaded) return;
-
-    if (scope.type === "org" && scope.id) {
-      const valid = organizations.some((o) => o.id === scope.id);
-      if (!valid) {
-        setScope({ type: "global" });
-        saveScopeToStorage({ type: "global" });
-      }
-    } else if (scope.type === "team" && scope.id) {
-      const valid = teams.some((t) => t.id === scope.id);
-      if (!valid) {
-        setScope({ type: "global" });
-        saveScopeToStorage({ type: "global" });
-      }
-    }
-  }, [scopeInitialized, orgsLoaded, scope, organizations, teams]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
-  const handleScopeChange = (newScope: ScopeSelection) => {
-    setScope(newScope);
-    saveScopeToStorage(newScope);
-  };
 
   return (
     <>
@@ -334,7 +240,7 @@ function ModelsLeaderboardContent() {
             <div className="hidden sm:block">
               <ScopeDropdown
                 value={scope}
-                onChange={handleScopeChange}
+                onChange={setScope}
                 organizations={organizations}
                 teams={teams}
               />
@@ -342,61 +248,19 @@ function ModelsLeaderboardContent() {
           )}
         </div>
 
-        {/* Error */}
-        {error && (
-          <div className="rounded-[var(--radius-card)] bg-destructive/10 p-4 text-sm text-destructive">
-            Failed to load leaderboard: {error}
-          </div>
-        )}
-
-        {/* Table header row */}
-        <TableHeader />
-
-        {/* Loading — skeleton on initial load */}
-        {loading && <LeaderboardSkeleton />}
-
-        {/* Content */}
-        {entries.length > 0 && (
-          <div className="space-y-2">
-            {entries.map((entry, i) => (
-              <LeaderboardRow
-                key={entry.user.id}
-                entry={entry}
-                index={i}
-                animationStartIndex={animationStartIndex}
-                onSelect={handleRowSelect}
-              />
-            ))}
-            {hasMore && entries.length < MAX_ENTRIES && (
-              <button
-                onClick={loadMore}
-                disabled={loadingMore}
-                className="w-full rounded-[var(--radius-card)] bg-secondary py-3 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
-              >
-                {loadingMore ? "Loading..." : "Show more"}
-              </button>
-            )}
-          </div>
-        )}
-
-        {/* Empty state */}
-        {!loading && entries.length === 0 && !error && (
-          <div className="rounded-[var(--radius-card)] bg-secondary p-8 text-center text-sm text-muted-foreground">
-            No usage data for {shortModel(selectedModel)} in this period.
-          </div>
-        )}
+        {/* Shared page shell: error, table, loading, empty, dialog */}
+        <LeaderboardPageShell
+          entries={entries}
+          loading={loading}
+          loadingMore={loadingMore}
+          error={error}
+          hasMore={hasMore}
+          loadMore={loadMore}
+          animationStartIndex={animationStartIndex}
+          period={period}
+          emptyMessage={`No usage data for ${shortModel(selectedModel)} in this period.`}
+        />
       </main>
-
-      {/* User profile dialog */}
-      <UserProfileDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        slug={dialogEntry?.user.slug ?? dialogEntry?.user.id ?? null}
-        name={dialogEntry?.user.name ?? null}
-        image={dialogEntry?.user.image ?? null}
-        badges={dialogEntry?.badges ?? []}
-        defaultTab={PERIOD_TO_TAB[period]}
-      />
     </>
   );
 }

--- a/packages/web/src/app/leaderboard/page.tsx
+++ b/packages/web/src/app/leaderboard/page.tsx
@@ -1,67 +1,42 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { useSession } from "next-auth/react";
+import { useState } from "react";
 import {
   useLeaderboard,
   type LeaderboardPeriod,
-  type LeaderboardEntry,
 } from "@/hooks/use-leaderboard";
+import { useLeaderboardScope } from "@/hooks/use-leaderboard-scope";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
 import { PageHeader } from "@/components/leaderboard/page-header";
-import { TableHeader } from "@/components/leaderboard/table-header";
-import { LeaderboardSkeleton } from "@/components/leaderboard/leaderboard-skeleton";
-import { LeaderboardRow } from "@/components/leaderboard/leaderboard-row";
-import { PeriodTabs, PERIOD_TO_TAB } from "@/components/leaderboard/period-tabs";
-import {
-  ScopeDropdown,
-  loadScopeFromStorage,
-  saveScopeToStorage,
-  type ScopeSelection,
-  type Organization,
-  type Team,
-} from "@/components/leaderboard/scope-dropdown";
-import { UserProfileDialog } from "@/components/user-profile-dialog";
+import { PeriodTabs } from "@/components/leaderboard/period-tabs";
+import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
+import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const PAGE_SIZE = 20;
-const MAX_ENTRIES = 100;
 
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 export default function LeaderboardPage() {
-  const { status } = useSession();
-  const isAuthenticated = status === "authenticated";
-  const isSessionLoading = status === "loading";
-
   const [period, setPeriod] = useState<LeaderboardPeriod>("week");
-  const [scope, setScope] = useState<ScopeSelection>({ type: "global" });
-  const [scopeInitialized, setScopeInitialized] = useState(false);
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [orgsLoaded, setOrgsLoaded] = useState(false);
 
-  // Dialog state for user profile popup
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [dialogEntry, setDialogEntry] = useState<LeaderboardEntry | null>(null);
+  const {
+    scope,
+    setScope,
+    organizations,
+    teams,
+    scopeInitialized,
+    isSessionLoading,
+    isAuthenticated,
+    teamId,
+    orgId,
+  } = useLeaderboardScope();
 
-  const handleRowSelect = useCallback((entry: LeaderboardEntry) => {
-    setDialogEntry(entry);
-    setDialogOpen(true);
-  }, []);
-
-  const teamId = scope.type === "team" ? scope.id ?? null : null;
-  const orgId = scope.type === "org" ? scope.id ?? null : null;
-
-  // Delay fetch until scope is initialized:
-  // - Session loading: wait (don't know if user is authenticated yet)
-  // - Authenticated: wait for orgs/teams + localStorage scope restore
-  // - Unauthenticated: fetch immediately with global scope
   const {
     entries,
     loading,
@@ -77,88 +52,6 @@ export default function LeaderboardPage() {
     limit: PAGE_SIZE,
     enabled: scopeInitialized && !isSessionLoading,
   });
-
-  // Fetch user's organizations and teams
-  const fetchOrgsAndTeams = useCallback(async () => {
-    try {
-      const [orgsRes, teamsRes] = await Promise.all([
-        fetch("/api/organizations/mine"),
-        fetch("/api/teams"),
-      ]);
-
-      if (orgsRes.ok) {
-        const orgsJson = await orgsRes.json();
-        setOrganizations(orgsJson.organizations ?? []);
-      }
-      if (teamsRes.ok) {
-        const teamsJson = await teamsRes.json();
-        setTeams(teamsJson.teams ?? []);
-      }
-      // Mark as loaded only when BOTH fetches succeeded
-      if (orgsRes.ok && teamsRes.ok) {
-        setOrgsLoaded(true);
-      }
-    } catch {
-      // Silently fail — scope dropdown optional
-      // Do NOT set orgsLoaded = true so validation effect won't run
-    }
-  }, []);
-
-  // Initialize scope from localStorage and fetch orgs/teams
-  // Wait for session to resolve before deciding auth state
-  /* eslint-disable react-hooks/set-state-in-effect -- async fetch and localStorage read */
-  useEffect(() => {
-    // Still loading session - wait
-    if (isSessionLoading) {
-      return;
-    }
-
-    // Unauthenticated - use global scope immediately
-    if (!isAuthenticated) {
-      setScope({ type: "global" });
-      setScopeInitialized(true);
-      return;
-    }
-
-    // Authenticated - fetch orgs/teams and restore scope
-    fetchOrgsAndTeams().then(() => {
-      const stored = loadScopeFromStorage();
-      if (stored) {
-        setScope(stored);
-      }
-      setScopeInitialized(true);
-    });
-  }, [isSessionLoading, isAuthenticated, fetchOrgsAndTeams]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
-  // Validate stored scope against available orgs/teams
-  // (intentionally calling setState in effect to correct invalid state after async load)
-  /* eslint-disable react-hooks/set-state-in-effect */
-  useEffect(() => {
-    // Only validate when orgs have been successfully loaded
-    if (!scopeInitialized || !orgsLoaded) return;
-
-    if (scope.type === "org" && scope.id) {
-      const valid = organizations.some((o) => o.id === scope.id);
-      if (!valid) {
-        setScope({ type: "global" });
-        saveScopeToStorage({ type: "global" });
-      }
-    } else if (scope.type === "team" && scope.id) {
-      const valid = teams.some((t) => t.id === scope.id);
-      if (!valid) {
-        setScope({ type: "global" });
-        saveScopeToStorage({ type: "global" });
-      }
-    }
-  }, [scopeInitialized, orgsLoaded, scope, organizations, teams]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
-  // Handle scope change
-  const handleScopeChange = (newScope: ScopeSelection) => {
-    setScope(newScope);
-    saveScopeToStorage(newScope);
-  };
 
   return (
     <>
@@ -193,7 +86,7 @@ export default function LeaderboardPage() {
             <div className="hidden sm:block">
               <ScopeDropdown
                 value={scope}
-                onChange={handleScopeChange}
+                onChange={setScope}
                 organizations={organizations}
                 teams={teams}
               />
@@ -201,62 +94,18 @@ export default function LeaderboardPage() {
           )}
         </div>
 
-        {/* Error */}
-        {error && (
-          <div className="rounded-[var(--radius-card)] bg-destructive/10 p-4 text-sm text-destructive">
-            Failed to load leaderboard: {error}
-          </div>
-        )}
-
-        {/* Table header row */}
-        <TableHeader />
-
-        {/* Loading — skeleton on initial load */}
-        {loading && <LeaderboardSkeleton />}
-
-        {/* Content — no opacity change during pagination */}
-        {entries.length > 0 && (
-          <div className="space-y-2">
-            {entries.map((entry, i) => (
-              <LeaderboardRow
-                key={entry.user.id}
-                entry={entry}
-                index={i}
-                animationStartIndex={animationStartIndex}
-                onSelect={handleRowSelect}
-              />
-            ))}
-            {/* Load more button — hide when reached max or no more data */}
-            {hasMore && entries.length < MAX_ENTRIES && (
-              <button
-                onClick={loadMore}
-                disabled={loadingMore}
-                className="w-full rounded-[var(--radius-card)] bg-secondary py-3 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
-              >
-                {loadingMore ? "Loading..." : "Show more"}
-              </button>
-            )}
-          </div>
-        )}
-
-        {/* Empty state — only show after loading completes with no results */}
-        {!loading && entries.length === 0 && !error && (
-          <div className="rounded-[var(--radius-card)] bg-secondary p-8 text-center text-sm text-muted-foreground">
-            No usage data for this period yet.
-          </div>
-        )}
+        {/* Shared page shell: error, table, loading, empty, dialog */}
+        <LeaderboardPageShell
+          entries={entries}
+          loading={loading}
+          loadingMore={loadingMore}
+          error={error}
+          hasMore={hasMore}
+          loadMore={loadMore}
+          animationStartIndex={animationStartIndex}
+          period={period}
+        />
       </main>
-
-      {/* User profile dialog — stays in-page, preserves scroll & pagination */}
-      <UserProfileDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        slug={dialogEntry?.user.slug ?? dialogEntry?.user.id ?? null}
-        name={dialogEntry?.user.name ?? null}
-        image={dialogEntry?.user.image ?? null}
-        badges={dialogEntry?.badges ?? []}
-        defaultTab={PERIOD_TO_TAB[period]}
-      />
     </>
   );
 }

--- a/packages/web/src/components/leaderboard/leaderboard-page-shell.tsx
+++ b/packages/web/src/components/leaderboard/leaderboard-page-shell.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { LeaderboardEntry, LeaderboardPeriod } from "@/hooks/use-leaderboard";
+import { TableHeader } from "@/components/leaderboard/table-header";
+import { LeaderboardSkeleton } from "@/components/leaderboard/leaderboard-skeleton";
+import { LeaderboardRow } from "@/components/leaderboard/leaderboard-row";
+import { UserProfileDialog } from "@/components/user-profile-dialog";
+import { PERIOD_TO_TAB } from "@/components/leaderboard/period-tabs";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_ENTRIES = 100;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LeaderboardPageShellProps {
+  /** Leaderboard entries to display */
+  entries: LeaderboardEntry[];
+  /** Whether initial data is loading */
+  loading: boolean;
+  /** Whether more data is being loaded */
+  loadingMore: boolean;
+  /** Error message if fetch failed */
+  error: string | null;
+  /** Whether more entries can be loaded */
+  hasMore: boolean;
+  /** Load more entries callback */
+  loadMore: () => void;
+  /** Index where animation should start (for staggered entry) */
+  animationStartIndex: number;
+  /** Current period for profile dialog default tab */
+  period: LeaderboardPeriod;
+  /** Custom empty state message */
+  emptyMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared page shell for leaderboard pages.
+ * Handles:
+ * - Loading skeleton
+ * - Error state
+ * - Empty state
+ * - Load-more button
+ * - Profile dialog wiring
+ */
+export function LeaderboardPageShell({
+  entries,
+  loading,
+  loadingMore,
+  error,
+  hasMore,
+  loadMore,
+  animationStartIndex,
+  period,
+  emptyMessage = "No usage data for this period yet.",
+}: LeaderboardPageShellProps) {
+  // Dialog state for user profile popup
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogEntry, setDialogEntry] = useState<LeaderboardEntry | null>(null);
+
+  const handleRowSelect = useCallback((entry: LeaderboardEntry) => {
+    setDialogEntry(entry);
+    setDialogOpen(true);
+  }, []);
+
+  return (
+    <>
+      {/* Error */}
+      {error && (
+        <div className="rounded-[var(--radius-card)] bg-destructive/10 p-4 text-sm text-destructive">
+          Failed to load leaderboard: {error}
+        </div>
+      )}
+
+      {/* Table header row */}
+      <TableHeader />
+
+      {/* Loading — skeleton on initial load */}
+      {loading && <LeaderboardSkeleton />}
+
+      {/* Content — no opacity change during pagination */}
+      {entries.length > 0 && (
+        <div className="space-y-2">
+          {entries.map((entry, i) => (
+            <LeaderboardRow
+              key={entry.user.id}
+              entry={entry}
+              index={i}
+              animationStartIndex={animationStartIndex}
+              onSelect={handleRowSelect}
+            />
+          ))}
+          {/* Load more button — hide when reached max or no more data */}
+          {hasMore && entries.length < MAX_ENTRIES && (
+            <button
+              onClick={loadMore}
+              disabled={loadingMore}
+              className="w-full rounded-[var(--radius-card)] bg-secondary py-3 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+            >
+              {loadingMore ? "Loading..." : "Show more"}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Empty state — only show after loading completes with no results */}
+      {!loading && entries.length === 0 && !error && (
+        <div className="rounded-[var(--radius-card)] bg-secondary p-8 text-center text-sm text-muted-foreground">
+          {emptyMessage}
+        </div>
+      )}
+
+      {/* User profile dialog — stays in-page, preserves scroll & pagination */}
+      <UserProfileDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        slug={dialogEntry?.user.slug ?? dialogEntry?.user.id ?? null}
+        name={dialogEntry?.user.name ?? null}
+        image={dialogEntry?.user.image ?? null}
+        badges={dialogEntry?.badges ?? []}
+        defaultTab={PERIOD_TO_TAB[period]}
+      />
+    </>
+  );
+}

--- a/packages/web/src/hooks/use-leaderboard-scope.ts
+++ b/packages/web/src/hooks/use-leaderboard-scope.ts
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import {
+  loadScopeFromStorage,
+  saveScopeToStorage,
+  type ScopeSelection,
+  type Organization,
+  type Team,
+} from "@/components/leaderboard/scope-dropdown";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseLeaderboardScopeReturn {
+  /** Current scope selection */
+  scope: ScopeSelection;
+  /** Update scope and persist to localStorage */
+  setScope: (scope: ScopeSelection) => void;
+  /** User's organizations */
+  organizations: Organization[];
+  /** User's teams */
+  teams: Team[];
+  /** Whether scope initialization is complete (ready to fetch leaderboard) */
+  scopeInitialized: boolean;
+  /** Whether orgs/teams have been loaded */
+  orgsLoaded: boolean;
+  /** Whether session is still loading */
+  isSessionLoading: boolean;
+  /** Whether user is authenticated */
+  isAuthenticated: boolean;
+  /** Computed teamId for useLeaderboard */
+  teamId: string | null;
+  /** Computed orgId for useLeaderboard */
+  orgId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared hook for leaderboard scope management.
+ * Handles:
+ * - Auth-gated scope initialization
+ * - Organization/team fetching with orgsLoaded guard
+ * - Scope validation (reset invalid stored scope)
+ * - localStorage persistence
+ */
+export function useLeaderboardScope(): UseLeaderboardScopeReturn {
+  const { status } = useSession();
+  const isAuthenticated = status === "authenticated";
+  const isSessionLoading = status === "loading";
+
+  const [scope, setScopeState] = useState<ScopeSelection>({ type: "global" });
+  const [scopeInitialized, setScopeInitialized] = useState(false);
+  const [orgsLoaded, setOrgsLoaded] = useState(false);
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [teams, setTeams] = useState<Team[]>([]);
+
+  // Fetch user's organizations and teams
+  const fetchOrgsAndTeams = useCallback(async () => {
+    try {
+      const [orgsRes, teamsRes] = await Promise.all([
+        fetch("/api/organizations/mine"),
+        fetch("/api/teams"),
+      ]);
+
+      if (orgsRes.ok) {
+        const orgsJson = await orgsRes.json();
+        setOrganizations(orgsJson.organizations ?? []);
+      }
+      if (teamsRes.ok) {
+        const teamsJson = await teamsRes.json();
+        setTeams(teamsJson.teams ?? []);
+      }
+    } catch {
+      // Silently fail — scope dropdown optional
+    } finally {
+      setOrgsLoaded(true);
+    }
+  }, []);
+
+  // Initialize scope from localStorage and fetch orgs/teams
+  // Wait for session to resolve before deciding auth state
+  useEffect(() => {
+    // Still loading session - wait
+    if (isSessionLoading) {
+      return;
+    }
+
+    // Unauthenticated - use global scope immediately
+    if (!isAuthenticated) {
+      setScopeInitialized(true);
+      setOrgsLoaded(true);
+      return;
+    }
+
+    // Authenticated - fetch orgs/teams and restore scope
+    fetchOrgsAndTeams().then(() => {
+      const stored = loadScopeFromStorage();
+      if (stored) {
+        setScopeState(stored);
+      }
+      setScopeInitialized(true);
+    });
+  }, [isSessionLoading, isAuthenticated, fetchOrgsAndTeams]);
+
+  // Validate stored scope against available orgs/teams
+  // (intentionally calling setState in effect to correct invalid state after async load)
+  useEffect(() => {
+    if (!scopeInitialized) return;
+
+    if (scope.type === "org" && scope.id) {
+      const valid = organizations.some((o) => o.id === scope.id);
+      if (!valid) {
+        setScopeState({ type: "global" });
+        saveScopeToStorage({ type: "global" });
+      }
+    } else if (scope.type === "team" && scope.id) {
+      const valid = teams.some((t) => t.id === scope.id);
+      if (!valid) {
+        setScopeState({ type: "global" });
+        saveScopeToStorage({ type: "global" });
+      }
+    }
+  }, [scopeInitialized, scope, organizations, teams]);
+
+  // Handle scope change with persistence
+  const setScope = useCallback((newScope: ScopeSelection) => {
+    setScopeState(newScope);
+    saveScopeToStorage(newScope);
+  }, []);
+
+  // Computed IDs for useLeaderboard
+  const teamId = scope.type === "team" ? scope.id ?? null : null;
+  const orgId = scope.type === "org" ? scope.id ?? null : null;
+
+  return {
+    scope,
+    setScope,
+    organizations,
+    teams,
+    scopeInitialized,
+    orgsLoaded,
+    isSessionLoading,
+    isAuthenticated,
+    teamId,
+    orgId,
+  };
+}


### PR DESCRIPTION
Fixes #61

## Changes
- Created `use-leaderboard-scope.ts` hook extracting duplicated scope bootstrapping logic
- Created `leaderboard-page-shell.tsx` component for shared loading/error/empty/pagination shell
- Simplified `page.tsx`, `agents/page.tsx`, `models/page.tsx` — each now only contains its specific selector + useLeaderboard call
- Net reduction: -483 lines duplicated code, +371 lines shared abstractions

## Review
✅ Codex review: APPROVED — clean extraction, no behavior change, TypeScript and ESLint pass