### PR TITLE
feat(cli): add logout command

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -32,10 +32,11 @@ describe("CLI main command", () => {
     expect(names).toContain("uninstall");
     expect(names).toContain("reset");
     expect(names).toContain("update");
+    expect(names).toContain("logout");
   });
 
-  it("should have exactly 8 subcommands", () => {
+  it("should have exactly 9 subcommands", () => {
     const names = Object.keys(main.subCommands!);
-    expect(names).toHaveLength(8);
+    expect(names).toHaveLength(9);
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import { executeSync } from "./commands/sync.js";
 import { executeSessionSync } from "./commands/session-sync.js";
 import { executeStatus } from "./commands/status.js";
 import { executeLogin, resolveHost } from "./commands/login.js";
+import { executeLogout } from "./commands/logout.js";
 import { executeUpload } from "./commands/upload.js";
 import { executeSessionUpload } from "./commands/session-upload.js";
 import { executeNotify } from "./commands/notify.js";
@@ -482,6 +483,41 @@ const loginCommand = defineCommand({
   },
 });
 
+const logoutCommand = defineCommand({
+  meta: {
+    name: "logout",
+    description: "Disconnect your CLI from the pew dashboard",
+  },
+  args: {
+    dev: {
+      type: "boolean",
+      description: "Use the dev host (pew.dev.hexly.ai)",
+      default: false,
+    },
+  },
+  async run() {
+    const paths = resolveDefaultPaths();
+    const dev = isDevMode();
+
+    const result = await executeLogout({
+      configDir: paths.stateDir,
+      dev,
+    });
+
+    if (result.alreadyLoggedOut) {
+      log.info("Not logged in.");
+      return;
+    }
+
+    if (result.success) {
+      log.success("Logged out successfully.");
+    } else {
+      log.error(`Logout failed: ${result.error}`);
+      process.exitCode = 1;
+    }
+  },
+});
+
 const notifyCommand = defineCommand({
   meta: {
     name: "notify",
@@ -825,6 +861,7 @@ export const main = defineCommand({
     sync: syncCommand,
     status: statusCommand,
     login: loginCommand,
+    logout: logoutCommand,
     notify: notifyCommand,
     init: initCommand,
     uninstall: uninstallCommand,

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -1,0 +1,53 @@
+/**
+ * CLI logout command — clears stored authentication token.
+ *
+ * Removes the API token from the pew config file, effectively
+ * logging the user out. After logout, `pew login` must be run
+ * again to re-authenticate.
+ */
+
+import { ConfigManager } from "../config/manager.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LogoutOptions {
+  /** Directory for config file */
+  configDir: string;
+  /** Whether dev mode is active (uses config.dev.json) */
+  dev?: boolean;
+}
+
+export interface LogoutResult {
+  success: boolean;
+  alreadyLoggedOut?: boolean;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export async function executeLogout(options: LogoutOptions): Promise<LogoutResult> {
+  const { configDir, dev = false } = options;
+
+  try {
+    const configManager = new ConfigManager(configDir, dev);
+    const config = await configManager.load();
+
+    if (!config.token) {
+      return { success: true, alreadyLoggedOut: true };
+    }
+
+    // Clear the token
+    configManager.write({ ...config, token: undefined });
+
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Failed to clear credentials",
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Add `pew logout` command to clear stored API token, allowing users to switch accounts or disconnect their CLI.

## Changes

- **New**: `packages/cli/src/commands/logout.ts` — implements `executeLogout()` that clears the token from config
- **Modified**: `packages/cli/src/cli.ts` — registers the `logout` subcommand with proper dev mode support

## Behavior

- `pew logout` → clears token, prints success
- `pew logout` (when already logged out) → prints "Not logged in."
- Error handling for file system failures

Closes #73