### PR TITLE
fix(leaderboard): data correctness bugs — tzOffset, setDate, error/skeleton overlap

### DIFF
--- a/packages/web/src/app/(dashboard)/daily-usage/page.tsx
+++ b/packages/web/src/app/(dashboard)/daily-usage/page.tsx
@@ -280,7 +280,7 @@ export default function DailyUsagePage() {
 
   const { pricingMap } = usePricingMap();
 
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
 
   // Daily points for the main chart (padded to full month)
   const daily = useMemo(() => {

--- a/packages/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/web/src/app/(dashboard)/dashboard/page.tsx
@@ -93,7 +93,7 @@ export default function DashboardPage() {
   const { pricingMap } = usePricingMap();
 
   // Timezone offset for UTC→local date conversion (used by multiple helpers)
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const today = useMemo(() => getLocalToday(tzOffset), [tzOffset]);
 
   // Fill date gaps + extend to today so charts always show up to the current day

--- a/packages/web/src/app/(dashboard)/devices/page.tsx
+++ b/packages/web/src/app/(dashboard)/devices/page.tsx
@@ -174,7 +174,7 @@ export default function ByDevicePage() {
 
   const devices = useMemo(() => data?.devices ?? [], [data]);
 
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const today = useMemo(() => getLocalToday(tzOffset), [tzOffset]);
 
   // Fill date gaps in device timeline so charts extend to today

--- a/packages/web/src/app/(dashboard)/hourly-usage/page.tsx
+++ b/packages/web/src/app/(dashboard)/hourly-usage/page.tsx
@@ -365,7 +365,7 @@ export default function RecentPage() {
   const loading = usageLoading || deviceLoading;
 
   // For hourly pattern charts, fetch last 30 days of half-hour data
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const { patternFrom, patternTo } = useMemo(() => {
     const today = getLocalToday(tzOffset);
     const fromDate = new Date(today + "T00:00:00Z");

--- a/packages/web/src/app/(dashboard)/models/page.tsx
+++ b/packages/web/src/app/(dashboard)/models/page.tsx
@@ -88,7 +88,7 @@ export default function ModelsPage() {
 
   const { pricingMap } = usePricingMap();
 
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const today = useMemo(() => getLocalToday(tzOffset), [tzOffset]);
 
   const modelGroups = useMemo(

--- a/packages/web/src/app/(dashboard)/projects/page.tsx
+++ b/packages/web/src/app/(dashboard)/projects/page.tsx
@@ -476,7 +476,7 @@ function SummaryTable({
 export default function ProjectsPage() {
   const [period, setPeriod] = useState<Period>("all");
   const [tagFilter, setTagFilter] = useState("");
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const today = useMemo(() => getLocalToday(tzOffset), [tzOffset]);
   const { from, to } = periodToDateRange(
     period,

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -118,7 +118,7 @@ export default function SessionsPage() {
     [usageData],
   );
 
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const today = useMemo(() => getLocalToday(tzOffset), [tzOffset]);
 
   const peakSlots = useMemo(

--- a/packages/web/src/components/leaderboard/leaderboard-page-shell.tsx
+++ b/packages/web/src/components/leaderboard/leaderboard-page-shell.tsx
@@ -81,11 +81,11 @@ export function LeaderboardPageShell({
         </div>
       )}
 
-      {/* Table header row — hide when error */}
-      {!error && <TableHeader />}
+      {/* Table header row — show when there are entries or during initial load */}
+      {(entries.length > 0 || loading) && <TableHeader />}
 
-      {/* Loading — skeleton on initial load, hide when error */}
-      {loading && !error && <LeaderboardSkeleton />}
+      {/* Loading — skeleton on initial load only (no entries yet, no error) */}
+      {loading && !error && entries.length === 0 && <LeaderboardSkeleton />}
 
       {/* Content — no opacity change during pagination */}
       {entries.length > 0 && (

--- a/packages/web/src/components/leaderboard/leaderboard-page-shell.tsx
+++ b/packages/web/src/components/leaderboard/leaderboard-page-shell.tsx
@@ -81,11 +81,11 @@ export function LeaderboardPageShell({
         </div>
       )}
 
-      {/* Table header row */}
-      <TableHeader />
+      {/* Table header row — hide when error */}
+      {!error && <TableHeader />}
 
-      {/* Loading — skeleton on initial load */}
-      {loading && <LeaderboardSkeleton />}
+      {/* Loading — skeleton on initial load, hide when error */}
+      {loading && !error && <LeaderboardSkeleton />}
 
       {/* Content — no opacity change during pagination */}
       {entries.length > 0 && (

--- a/packages/web/src/hooks/use-session-data.ts
+++ b/packages/web/src/hooks/use-session-data.ts
@@ -115,7 +115,7 @@ export function useSessionData(
   }, [enabled]);
 
   const overview = toSessionOverview(records);
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const hoursGrid = toWorkingHoursGrid(records, tzOffset);
   const dailyMessages = toMessageDailyStats(records, tzOffset);
   const projectBreakdown = toProjectBreakdown(records);

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -215,7 +215,7 @@ export function useUsageData(
         fromStr = fromDate;
       } else {
         const d = new Date();
-        d.setDate(d.getDate() - days);
+        d.setUTCDate(d.getUTCDate() - days);
         fromStr = d.toISOString().slice(0, 10);
       }
 

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -270,7 +270,7 @@ export function useUsageData(
   }, [fetchData]);
 
   // Memoize derived data to avoid recalculation on every render
-  const tzOffset = new Date().getTimezoneOffset();
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
   const daily = useMemo(
     () => (data ? toDailyPoints(data.records, tzOffset) : []),
     [data, tzOffset],

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -270,7 +270,7 @@ export function useUsageData(
   }, [fetchData]);
 
   // Memoize derived data to avoid recalculation on every render
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const daily = useMemo(
     () => (data ? toDailyPoints(data.records, tzOffset) : []),
     [data, tzOffset],

--- a/packages/web/src/hooks/use-user-profile.ts
+++ b/packages/web/src/hooks/use-user-profile.ts
@@ -153,7 +153,7 @@ export function useUserProfile(
   }, [fetchData]);
 
   // Memoize derived data to avoid recalculation on every render
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const daily = useMemo(
     () => (data ? toDailyPoints(data.records, tzOffset) : []),
     [data, tzOffset],

--- a/packages/web/src/hooks/use-user-profile.ts
+++ b/packages/web/src/hooks/use-user-profile.ts
@@ -153,7 +153,7 @@ export function useUserProfile(
   }, [fetchData]);
 
   // Memoize derived data to avoid recalculation on every render
-  const tzOffset = new Date().getTimezoneOffset();
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
   const daily = useMemo(
     () => (data ? toDailyPoints(data.records, tzOffset) : []),
     [data, tzOffset],


### PR DESCRIPTION
Fix three data-correctness bugs:
- Memoize  in  and 
- Fix  →  for API date filter
- Make error and skeleton mutually exclusive (preserving header when rows exist)

Closes #79