### PR TITLE
perf(leaderboard): memoize derived data in session and usage hooks

### DIFF
--- a/packages/web/src/components/leaderboard/season-countdown.tsx
+++ b/packages/web/src/components/leaderboard/season-countdown.tsx
@@ -51,12 +51,46 @@ export function SeasonCountdown({
 }: SeasonCountdownProps) {
   const [now, setNow] = useState(() => Date.now());
 
-  // Tick every second for active/upcoming seasons
+  // Tick every second for active/upcoming seasons, pause when tab is hidden
   useEffect(() => {
     if (status === "ended") return;
 
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
+    let id: ReturnType<typeof setInterval> | null = null;
+
+    const start = () => {
+      if (id === null) {
+        // Sync immediately on resume so the display isn't stale
+        setNow(Date.now());
+        id = setInterval(() => setNow(Date.now()), 1000);
+      }
+    };
+
+    const stop = () => {
+      if (id !== null) {
+        clearInterval(id);
+        id = null;
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        start();
+      } else {
+        stop();
+      }
+    };
+
+    // Only start if currently visible
+    if (document.visibilityState === "visible") {
+      start();
+    }
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
   }, [status]);
 
   const fullRange = `${formatSeasonDate(startDate)} — ${formatSeasonDate(endDate)}`;

--- a/packages/web/src/hooks/use-derived-usage-data.ts
+++ b/packages/web/src/hooks/use-derived-usage-data.ts
@@ -1,0 +1,47 @@
+import { useMemo } from "react";
+import type { UsageRow, DailyPoint, SourceAggregate, ModelAggregate } from "@/hooks/use-usage-data";
+import {
+  toDailyPoints,
+  toSourceAggregates,
+  toModelAggregates,
+  sourceLabel,
+} from "@/hooks/use-usage-data";
+
+interface UseDerivedUsageDataResult {
+  daily: DailyPoint[];
+  sources: SourceAggregate[];
+  models: ModelAggregate[];
+}
+
+/**
+ * Shared hook that memoizes daily, source, and model aggregations from usage
+ * records. Used by both `useUsageData` and `useUserProfile` to avoid
+ * duplicating the same derived-data logic.
+ */
+export function useDerivedUsageData(
+  records: UsageRow[] | null,
+  tzOffset: number,
+): UseDerivedUsageDataResult {
+  const daily = useMemo(
+    () => (records ? toDailyPoints(records, tzOffset) : []),
+    [records, tzOffset],
+  );
+
+  const sources = useMemo(
+    () =>
+      records
+        ? toSourceAggregates(records).map((s) => ({
+            ...s,
+            label: sourceLabel(s.label),
+          }))
+        : [],
+    [records],
+  );
+
+  const models = useMemo(
+    () => (records ? toModelAggregates(records) : []),
+    [records],
+  );
+
+  return { daily, sources, models };
+}

--- a/packages/web/src/hooks/use-leaderboard.ts
+++ b/packages/web/src/hooks/use-leaderboard.ts
@@ -201,7 +201,8 @@ export function useLeaderboard(
   // Fetch when filters change or on initial mount (when enabled)
   useEffect(() => {
     if (!enabled) {
-      // Not enabled yet - stay in loading state, don't fetch
+      // Reset so re-enabling with the same filter key will refetch
+      lastFilterKeyRef.current = null;
       return;
     }
 

--- a/packages/web/src/hooks/use-season-leaderboard.ts
+++ b/packages/web/src/hooks/use-season-leaderboard.ts
@@ -81,6 +81,9 @@ export function useSeasonLeaderboard(
   // Track which teams have already been fetched to avoid duplicate requests
   const fetchedTeamsRef = useRef<Set<string>>(new Set());
 
+  // Track team IDs currently being loaded (ref for stable closure)
+  const loadingTeamIdsRef = useRef<Set<string>>(new Set());
+
   // Initial fetch without expand=members for faster load
   const fetchData = useCallback(async (signal?: AbortSignal) => {
     if (!seasonIdOrSlug) return;
@@ -130,11 +133,12 @@ export function useSeasonLeaderboard(
   const loadTeamMembers = useCallback(
     async (teamId: string) => {
       if (!seasonIdOrSlug || !data) return;
-      // Skip if already fetched or currently loading
-      if (fetchedTeamsRef.current.has(teamId) || loadingTeamIds.has(teamId)) {
+      // Skip if already fetched or currently loading (use ref for stable identity)
+      if (fetchedTeamsRef.current.has(teamId) || loadingTeamIdsRef.current.has(teamId)) {
         return;
       }
 
+      loadingTeamIdsRef.current.add(teamId);
       setLoadingTeamIds((prev) => new Set(prev).add(teamId));
 
       try {
@@ -170,6 +174,7 @@ export function useSeasonLeaderboard(
       } catch {
         // Silently fail — user can retry by collapsing/expanding again
       } finally {
+        loadingTeamIdsRef.current.delete(teamId);
         setLoadingTeamIds((prev) => {
           const next = new Set(prev);
           next.delete(teamId);
@@ -177,7 +182,7 @@ export function useSeasonLeaderboard(
         });
       }
     },
-    [seasonIdOrSlug, data, loadingTeamIds],
+    [seasonIdOrSlug, data],
   );
 
   useEffect(() => {

--- a/packages/web/src/hooks/use-session-data.ts
+++ b/packages/web/src/hooks/use-session-data.ts
@@ -114,11 +114,11 @@ export function useSessionData(
     }
   }, [enabled]);
 
-  const overview = toSessionOverview(records);
   const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
-  const hoursGrid = toWorkingHoursGrid(records, tzOffset);
-  const dailyMessages = toMessageDailyStats(records, tzOffset);
-  const projectBreakdown = toProjectBreakdown(records);
+  const overview = useMemo(() => toSessionOverview(records), [records]);
+  const hoursGrid = useMemo(() => toWorkingHoursGrid(records, tzOffset), [records, tzOffset]);
+  const dailyMessages = useMemo(() => toMessageDailyStats(records, tzOffset), [records, tzOffset]);
+  const projectBreakdown = useMemo(() => toProjectBreakdown(records), [records]);
 
   return {
     records,

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { useDerivedUsageData } from "@/hooks/use-derived-usage-data";
 
 import { toLocalDateStr } from "@/lib/usage-helpers";
 
@@ -271,24 +272,7 @@ export function useUsageData(
 
   // Memoize derived data to avoid recalculation on every render
   const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
-  const daily = useMemo(
-    () => (data ? toDailyPoints(data.records, tzOffset) : []),
-    [data, tzOffset],
-  );
-  const sources = useMemo(
-    () =>
-      data
-        ? toSourceAggregates(data.records).map((s) => ({
-            ...s,
-            label: sourceLabel(s.label),
-          }))
-        : [],
-    [data],
-  );
-  const models = useMemo(
-    () => (data ? toModelAggregates(data.records) : []),
-    [data],
-  );
+  const { daily, sources, models } = useDerivedUsageData(data?.records ?? null, tzOffset);
 
   return { data, daily, sources, models, loading, error, refetch: () => fetchData() };
 }

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -205,6 +205,9 @@ export function useUsageData(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Frozen per mount — acceptable; page refresh handles DST changes
+  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
+
   const fetchData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     setError(null);
@@ -228,7 +231,7 @@ export function useUsageData(
       if (source) params.set("source", source);
       if (deviceId) params.set("deviceId", deviceId);
       if (granularity === "day") {
-        params.set("tzOffset", String(new Date().getTimezoneOffset()));
+        params.set("tzOffset", String(tzOffset));
       }
 
       const res = await fetch(`/api/usage?${params.toString()}`, signal ? { signal } : undefined);
@@ -255,7 +258,7 @@ export function useUsageData(
         setLoading(false);
       }
     }
-  }, [days, fromDate, toDate, source, deviceId, granularity]);
+  }, [days, fromDate, toDate, source, deviceId, granularity, tzOffset]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -271,7 +274,6 @@ export function useUsageData(
   }, [fetchData]);
 
   // Memoize derived data to avoid recalculation on every render
-  const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const { daily, sources, models } = useDerivedUsageData(data?.records ?? null, tzOffset);
 
   return { data, daily, sources, models, loading, error, refetch: () => fetchData() };

--- a/packages/web/src/hooks/use-user-profile.ts
+++ b/packages/web/src/hooks/use-user-profile.ts
@@ -9,13 +9,8 @@ import type {
   ModelAggregate,
   HeatmapPoint,
 } from "@/hooks/use-usage-data";
-import {
-  toDailyPoints,
-  toSourceAggregates,
-  toModelAggregates,
-  toHeatmapData,
-  sourceLabel,
-} from "@/hooks/use-usage-data";
+import { toHeatmapData } from "@/hooks/use-usage-data";
+import { useDerivedUsageData } from "@/hooks/use-derived-usage-data";
 import type { BadgeIconType } from "@pew/core";
 
 // ---------------------------------------------------------------------------
@@ -154,24 +149,7 @@ export function useUserProfile(
 
   // Memoize derived data to avoid recalculation on every render
   const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
-  const daily = useMemo(
-    () => (data ? toDailyPoints(data.records, tzOffset) : []),
-    [data, tzOffset],
-  );
-  const sources = useMemo(
-    () =>
-      data
-        ? toSourceAggregates(data.records).map((s) => ({
-            ...s,
-            label: sourceLabel(s.label),
-          }))
-        : [],
-    [data],
-  );
-  const models = useMemo(
-    () => (data ? toModelAggregates(data.records) : []),
-    [data],
-  );
+  const { daily, sources, models } = useDerivedUsageData(data?.records ?? null, tzOffset);
   const heatmap = useMemo(() => toHeatmapData(daily), [daily]);
 
   return {


### PR DESCRIPTION
Performance and correctness fixes:
- Memoize 4 unmemoized derivations in 
- Extract shared  hook
- Fix  stale closure via ref
- Fix  skip on re-enable
- Pause countdown interval when tab is hidden

Closes #78