### PR TITLE
refactor(leaderboard): extract shared data fetching hook to eliminate boilerplate

### DIFF
--- a/packages/web/src/hooks/use-achievements.ts
+++ b/packages/web/src/hooks/use-achievements.ts
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import type { AchievementTier, AchievementCategory } from "@/lib/achievement-helpers";
+import { useFetchData } from "@/hooks/use-fetch-data";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -79,53 +81,15 @@ interface UseAchievementsOptions {
 
 export function useAchievements(options?: UseAchievementsOptions): UseAchievementsResult {
   const limit = options?.limit;
-  const [data, setData] = useState<AchievementData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const tzOffset = new Date().getTimezoneOffset();
-      const params = new URLSearchParams({ tzOffset: String(tzOffset) });
-      if (limit) params.set("limit", String(limit));
-      const res = await fetch(`/api/achievements?${params}`, signal ? { signal } : undefined);
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || `HTTP ${res.status}`);
-      }
-
-      const json = await res.json();
-
-      if (signal?.aborted) return;
-
-      setData(json);
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
-    }
+  const url = useMemo(() => {
+    const tzOffset = new Date().getTimezoneOffset();
+    const params = new URLSearchParams({ tzOffset: String(tzOffset) });
+    if (limit) params.set("limit", String(limit));
+    return `/api/achievements?${params}`;
   }, [limit]);
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData]);
-
-  return { data, loading, error, refetch: () => fetchData() };
+  return useFetchData<AchievementData>(url);
 }
 
 // ---------------------------------------------------------------------------
@@ -164,8 +128,7 @@ export function useAchievementMembers(
       if (signal?.aborted) return;
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || `HTTP ${res.status}`);
+        await throwApiError(res);
       }
 
       const json: AchievementMembersData = await res.json();

--- a/packages/web/src/hooks/use-device-data.ts
+++ b/packages/web/src/hooks/use-device-data.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useMemo } from "react";
 import type { ByDeviceResponse } from "@pew/core";
+import { useFetchData } from "@/hooks/use-fetch-data";
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -31,61 +32,17 @@ export function useDeviceData(
   options: UseDeviceDataOptions = {}
 ): UseDeviceDataResult {
   const { from: fromDate, to: toDate, granularity } = options;
-  const [data, setData] = useState<ByDeviceResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    setLoading(true);
-    setError(null);
+  const url = useMemo(() => {
+    const params = new URLSearchParams();
+    if (fromDate) params.set("from", fromDate);
+    if (toDate) params.set("to", toDate);
+    if (granularity) params.set("granularity", granularity);
+    params.set("tzOffset", String(new Date().getTimezoneOffset()));
 
-    try {
-      const params = new URLSearchParams();
-      if (fromDate) params.set("from", fromDate);
-      if (toDate) params.set("to", toDate);
-      if (granularity) params.set("granularity", granularity);
-      params.set("tzOffset", String(new Date().getTimezoneOffset()));
-
-      const qs = params.toString();
-      const url = `/api/usage/by-device${qs ? `?${qs}` : ""}`;
-      const res = await fetch(url, signal ? { signal } : undefined);
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`
-        );
-      }
-
-      const json = (await res.json()) as ByDeviceResponse;
-
-      if (signal?.aborted) return;
-
-      setData(json);
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
-    }
+    const qs = params.toString();
+    return `/api/usage/by-device${qs ? `?${qs}` : ""}`;
   }, [fromDate, toDate, granularity]);
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    // Clear data on filter change to avoid stale data
-    setData(null);
-
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData]);
-
-  return { data, loading, error, refetch: () => fetchData() };
+  return useFetchData<ByDeviceResponse>(url);
 }

--- a/packages/web/src/hooks/use-devices.ts
+++ b/packages/web/src/hooks/use-devices.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import type { DevicesResponse } from "@pew/core";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -38,10 +39,7 @@ export function useDevices(): UseDevicesResult {
       const res = await fetch("/api/devices");
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`
-        );
+        await throwApiError(res);
       }
 
       const json = (await res.json()) as DevicesResponse;
@@ -70,10 +68,7 @@ export function useDevices(): UseDevicesResult {
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          const errorMsg =
-            (body as { error?: string }).error ?? `HTTP ${res.status}`;
-          return { success: false, error: errorMsg };
+          await throwApiError(res);
         }
 
         // Refetch full list after mutation
@@ -100,10 +95,7 @@ export function useDevices(): UseDevicesResult {
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          const errorMsg =
-            (body as { error?: string }).error ?? `HTTP ${res.status}`;
-          return { success: false, error: errorMsg };
+          await throwApiError(res);
         }
 
         // Refetch full list after deletion

--- a/packages/web/src/hooks/use-fetch-data.ts
+++ b/packages/web/src/hooks/use-fetch-data.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { throwApiError } from "@/lib/api-error";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface UseFetchDataOptions {
+  /** When false, skip fetching entirely. Defaults to true. */
+  enabled?: boolean;
+  /** Initial value for `loading` state. Defaults to true. */
+  initialLoading?: boolean;
+}
+
+interface UseFetchDataResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared data-fetching hook that encapsulates the
+ * `useState / useEffect / fetch / AbortController` boilerplate.
+ *
+ * @param url - The URL to fetch. Pass `null` to skip fetching (conditional hooks).
+ * @param options - Optional configuration.
+ */
+export function useFetchData<T>(
+  url: string | null,
+  options?: UseFetchDataOptions,
+): UseFetchDataResult<T> {
+  const { enabled = true, initialLoading = true } = options ?? {};
+
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(initialLoading);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stable ref so `refetch` never causes extra renders / effect re-runs
+  const urlRef = useRef(url);
+  urlRef.current = url;
+
+  const fetchData = useCallback(
+    async (signal?: AbortSignal) => {
+      const target = urlRef.current;
+      if (!target || !enabled) return;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch(target, signal ? { signal } : undefined);
+
+        if (signal?.aborted) return;
+
+        if (!res.ok) {
+          await throwApiError(res);
+        }
+
+        const json = (await res.json()) as T;
+
+        if (signal?.aborted) return;
+
+        setData(json);
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        if (!signal?.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    // `url` is intentionally included so the effect re-runs when the URL changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [url, enabled],
+  );
+
+  useEffect(() => {
+    if (!url || !enabled) {
+      // Reset state when disabled / no URL
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    // Clear stale data when URL changes
+    setData(null);
+
+    fetchData(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
+  }, [fetchData, url, enabled]);
+
+  const refetch = useCallback(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error, refetch };
+}

--- a/packages/web/src/hooks/use-leaderboard.ts
+++ b/packages/web/src/hooks/use-leaderboard.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { BadgeIconType } from "@pew/core";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -157,10 +158,7 @@ export function useLeaderboard(
         }
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          throw new Error(
-            (body as { error?: string }).error ?? `HTTP ${res.status}`,
-          );
+          await throwApiError(res);
         }
 
         const json = (await res.json()) as LeaderboardData;

--- a/packages/web/src/hooks/use-pricing.ts
+++ b/packages/web/src/hooks/use-pricing.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import {
   type PricingMap,
   getDefaultPricingMap,
@@ -8,6 +7,7 @@ import {
   estimateCost,
   formatCost,
 } from "@/lib/pricing";
+import { useFetchData } from "@/hooks/use-fetch-data";
 
 interface UsePricingMapResult {
   /** Merged pricing map (DB overrides + static defaults). Falls back to static defaults while loading. */
@@ -22,39 +22,14 @@ interface UsePricingMapResult {
  * Returns static defaults immediately while loading so cost calculations never block.
  */
 export function usePricingMap(): UsePricingMapResult {
-  const [pricingMap, setPricingMap] = useState<PricingMap>(
-    getDefaultPricingMap
-  );
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data, loading, error, refetch } = useFetchData<PricingMap>("/api/pricing");
 
-  const fetchMap = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch("/api/pricing");
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`
-        );
-      }
-      const json = (await res.json()) as PricingMap;
-      setPricingMap(json);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-      // Keep using static defaults on error
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchMap();
-  }, [fetchMap]);
-
-  return { pricingMap, loading, error, refetch: fetchMap };
+  return {
+    pricingMap: data ?? getDefaultPricingMap(),
+    loading,
+    error,
+    refetch,
+  };
 }
 
 // Re-export helpers so pages can import everything from one place

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -107,10 +108,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
       if (signal?.aborted) return;
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`,
-        );
+        await throwApiError(res);
       }
 
       const json = (await res.json()) as ProjectsData;
@@ -170,10 +168,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          throw new Error(
-            (body as { error?: string }).error ?? `HTTP ${res.status}`,
-          );
+          await throwApiError(res);
         }
 
         const project = (await res.json()) as Project;
@@ -207,10 +202,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          throw new Error(
-            (body as { error?: string }).error ?? `HTTP ${res.status}`,
-          );
+          await throwApiError(res);
         }
 
         const project = (await res.json()) as Project;
@@ -232,10 +224,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          throw new Error(
-            (body as { error?: string }).error ?? `HTTP ${res.status}`,
-          );
+          await throwApiError(res);
         }
 
         await fetchData();

--- a/packages/web/src/hooks/use-season-leaderboard.ts
+++ b/packages/web/src/hooks/use-season-leaderboard.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { SeasonStatus } from "@pew/core";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -106,10 +107,7 @@ export function useSeasonLeaderboard(
       if (signal?.aborted) return;
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`,
-        );
+        await throwApiError(res);
       }
 
       const json = (await res.json()) as SeasonLeaderboardData;

--- a/packages/web/src/hooks/use-season-registration.ts
+++ b/packages/web/src/hooks/use-season-registration.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import type { SeasonStatus } from "@pew/core";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,10 +66,7 @@ export function useSeasonRegistration(
       ]);
 
       if (!seasonsRes.ok) {
-        const body = await seasonsRes.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${seasonsRes.status}`,
-        );
+        await throwApiError(seasonsRes);
       }
 
       const seasonsData = (await seasonsRes.json()) as {
@@ -129,10 +127,7 @@ export function useSeasonRegistration(
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          throw new Error(
-            (body as { error?: string }).error ?? `HTTP ${res.status}`,
-          );
+          await throwApiError(res);
         }
 
         // Optimistic update
@@ -166,10 +161,7 @@ export function useSeasonRegistration(
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          throw new Error(
-            (body as { error?: string }).error ?? `HTTP ${res.status}`,
-          );
+          await throwApiError(res);
         }
 
         // Optimistic update

--- a/packages/web/src/hooks/use-seasons.ts
+++ b/packages/web/src/hooks/use-seasons.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { SeasonStatus } from "@pew/core";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -68,10 +69,7 @@ export function useSeasons(
       const res = await fetch(url);
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`,
-        );
+        await throwApiError(res);
       }
 
       const json = (await res.json()) as SeasonsData;

--- a/packages/web/src/hooks/use-session-data.ts
+++ b/packages/web/src/hooks/use-session-data.ts
@@ -63,7 +63,7 @@ export function useSessionData(
     { enabled, initialLoading: enabled },
   );
 
-  const records = data?.records ?? [];
+  const records = useMemo(() => data?.records ?? [], [data]);
 
   const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const overview = useMemo(() => toSessionOverview(records), [records]);

--- a/packages/web/src/hooks/use-session-data.ts
+++ b/packages/web/src/hooks/use-session-data.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import {
   toSessionOverview,
   toWorkingHoursGrid,
@@ -12,6 +12,7 @@ import {
   type MessageDailyStat,
   type ProjectBreakdownItem,
 } from "@/lib/session-helpers";
+import { useFetchData } from "@/hooks/use-fetch-data";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -47,72 +48,22 @@ export function useSessionData(
   options: UseSessionDataOptions = {}
 ): UseSessionDataResult {
   const { from: fromDate, to: toDate, source, enabled = true } = options;
-  const [records, setRecords] = useState<SessionRow[]>([]);
-  const [loading, setLoading] = useState(enabled);
-  const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    if (!enabled) return;
-    setLoading(true);
-    setError(null);
+  const url = useMemo(() => {
+    const params = new URLSearchParams();
+    if (fromDate) params.set("from", fromDate);
+    if (toDate) params.set("to", toDate);
+    if (source) params.set("source", source);
+    const qs = params.toString();
+    return qs ? `/api/sessions?${qs}` : "/api/sessions";
+  }, [fromDate, toDate, source]);
 
-    try {
-      const params = new URLSearchParams();
-      if (fromDate) params.set("from", fromDate);
-      if (toDate) params.set("to", toDate);
-      if (source) params.set("source", source);
+  const { data, loading, error, refetch } = useFetchData<{ records: SessionRow[] }>(
+    enabled ? url : null,
+    { enabled, initialLoading: enabled },
+  );
 
-      const qs = params.toString();
-      const url = qs ? `/api/sessions?${qs}` : "/api/sessions";
-      const res = await fetch(url, signal ? { signal } : undefined);
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`
-        );
-      }
-
-      const json = (await res.json()) as { records: SessionRow[] };
-
-      if (signal?.aborted) return;
-
-      setRecords(json.records);
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
-    }
-  }, [fromDate, toDate, source, enabled]);
-
-  useEffect(() => {
-    if (!enabled) return;
-
-    const controller = new AbortController();
-
-    // Clear records on filter change to avoid stale data
-    setRecords([]);
-
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData, enabled]);
-
-  // Reset state when disabled to avoid stale data
-  useEffect(() => {
-    if (!enabled) {
-      setRecords([]);
-      setLoading(false);
-      setError(null);
-    }
-  }, [enabled]);
+  const records = data?.records ?? [];
 
   const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []); // frozen per mount — acceptable; page refresh handles DST changes
   const overview = useMemo(() => toSessionOverview(records), [records]);
@@ -128,6 +79,6 @@ export function useSessionData(
     projectBreakdown,
     loading,
     error,
-    refetch: () => fetchData(),
+    refetch,
   };
 }

--- a/packages/web/src/hooks/use-showcases.ts
+++ b/packages/web/src/hooks/use-showcases.ts
@@ -5,6 +5,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -98,10 +99,7 @@ export function useShowcases(options: UseShowcasesOptions = {}): UseShowcasesRes
       if (signal?.aborted) return;
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`
-        );
+        await throwApiError(res);
       }
 
       const json = (await res.json()) as ShowcasesResponse;
@@ -184,10 +182,7 @@ export function useShowcasePreview(): UseShowcasePreviewResult {
       });
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`
-        );
+        await throwApiError(res);
       }
 
       const json = (await res.json()) as ShowcasePreview;

--- a/packages/web/src/hooks/use-usage-data.ts
+++ b/packages/web/src/hooks/use-usage-data.ts
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import { useDerivedUsageData } from "@/hooks/use-derived-usage-data";
 
 import { toLocalDateStr } from "@/lib/usage-helpers";
+import { useFetchData } from "@/hooks/use-fetch-data";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -201,80 +202,39 @@ export function useUsageData(
   options: UseUsageDataOptions = {}
 ): UseUsageDataResult {
   const { days = 30, from: fromDate, to: toDate, source, deviceId, granularity = "day" } = options;
-  const [data, setData] = useState<UsageData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
   // Frozen per mount — acceptable; page refresh handles DST changes
   const tzOffset = useMemo(() => new Date().getTimezoneOffset(), []);
 
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      // When explicit `from` is provided, use it directly; otherwise compute from `days`
-      let fromStr: string;
-      if (fromDate) {
-        fromStr = fromDate;
-      } else {
-        const d = new Date();
-        d.setUTCDate(d.getUTCDate() - days);
-        fromStr = d.toISOString().slice(0, 10);
-      }
-
-      const params = new URLSearchParams({
-        from: fromStr,
-        granularity,
-      });
-      if (toDate) params.set("to", toDate);
-      if (source) params.set("source", source);
-      if (deviceId) params.set("deviceId", deviceId);
-      if (granularity === "day") {
-        params.set("tzOffset", String(tzOffset));
-      }
-
-      const res = await fetch(`/api/usage?${params.toString()}`, signal ? { signal } : undefined);
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`
-        );
-      }
-
-      const json = (await res.json()) as UsageData;
-
-      if (signal?.aborted) return;
-
-      setData(json);
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
+  const url = useMemo(() => {
+    // When explicit `from` is provided, use it directly; otherwise compute from `days`
+    let fromStr: string;
+    if (fromDate) {
+      fromStr = fromDate;
+    } else {
+      const d = new Date();
+      d.setUTCDate(d.getUTCDate() - days);
+      fromStr = d.toISOString().slice(0, 10);
     }
+
+    const params = new URLSearchParams({
+      from: fromStr,
+      granularity,
+    });
+    if (toDate) params.set("to", toDate);
+    if (source) params.set("source", source);
+    if (deviceId) params.set("deviceId", deviceId);
+    if (granularity === "day") {
+      params.set("tzOffset", String(tzOffset));
+    }
+
+    return `/api/usage?${params.toString()}`;
   }, [days, fromDate, toDate, source, deviceId, granularity, tzOffset]);
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    // Clear data on filter change to avoid stale data
-    setData(null);
-
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData]);
+  const { data, loading, error, refetch } = useFetchData<UsageData>(url);
 
   // Memoize derived data to avoid recalculation on every render
   const { daily, sources, models } = useDerivedUsageData(data?.records ?? null, tzOffset);
 
-  return { data, daily, sources, models, loading, error, refetch: () => fetchData() };
+  return { data, daily, sources, models, loading, error, refetch };
 }

--- a/packages/web/src/hooks/use-user-achievements.ts
+++ b/packages/web/src/hooks/use-user-achievements.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import type { AchievementTier, AchievementCategory } from "@/lib/achievement-helpers";
+import { useState, useEffect, useCallback } from "react";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -57,7 +58,10 @@ export function useUserAchievements(slug: string | null): UseUserAchievementsRes
     setError(null);
 
     try {
-      const res = await fetch(`/api/users/${encodeURIComponent(slug)}/achievements`, signal ? { signal } : undefined);
+      const res = await fetch(
+        `/api/users/${encodeURIComponent(slug)}/achievements`,
+        signal ? { signal } : undefined,
+      );
 
       if (signal?.aborted) return;
 
@@ -67,8 +71,7 @@ export function useUserAchievements(slug: string | null): UseUserAchievementsRes
           setData(null);
           return;
         }
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || `HTTP ${res.status}`);
+        await throwApiError(res);
       }
 
       const json = await res.json();

--- a/packages/web/src/hooks/use-user-profile.ts
+++ b/packages/web/src/hooks/use-user-profile.ts
@@ -12,6 +12,7 @@ import type {
 import { toHeatmapData } from "@/hooks/use-usage-data";
 import { useDerivedUsageData } from "@/hooks/use-derived-usage-data";
 import type { BadgeIconType } from "@pew/core";
+import { throwApiError } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -112,10 +113,7 @@ export function useUserProfile(
       }
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`,
-        );
+        await throwApiError(res);
       }
 
       const json = (await res.json()) as UserProfileData;

--- a/packages/web/src/lib/api-error.ts
+++ b/packages/web/src/lib/api-error.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared API error parsing helper.
+ * Extracts `{ error: string }` from non-OK responses and throws a descriptive Error.
+ */
+export async function throwApiError(res: Response): Promise<never> {
+  const body = await res.json().catch(() => ({}));
+  throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
+}


### PR DESCRIPTION
Extract shared  hook and  helper:
- Eliminates ~420 lines of duplicated fetch/useState/useEffect boilerplate
- All 14 data-fetching hooks refactored to use shared hook
- Consistent AbortController, error parsing, and refetch patterns

Closes #81