### PR TITLE
refactor(leaderboard): extract duplicated page components — FilterDropdown, PageTitle

### DIFF
--- a/packages/web/src/app/leaderboard/achievements/page.tsx
+++ b/packages/web/src/app/leaderboard/achievements/page.tsx
@@ -47,7 +47,7 @@ import {
   formatShortTokens,
 } from "@/lib/achievement-helpers";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
-import { PageHeader } from "@/components/leaderboard/page-header";
+import { LeaderboardPageTitle } from "@/components/leaderboard/leaderboard-page-title";
 import { Skeleton } from "@/components/ui/skeleton";
 import { UserProfileDialog } from "@/components/user-profile-dialog";
 
@@ -627,17 +627,10 @@ export default function AchievementsPage() {
   return (
     <>
       {/* Header */}
-      <PageHeader>
-        <h1 className="tracking-tight text-foreground">
-          <span className="text-[36px] font-bold font-handwriting leading-none mr-2">pew</span>
-          <span className="text-[19px] font-normal text-muted-foreground">
-            Achievements
-          </span>
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Track your AI coding milestones and compete with others.
-        </p>
-      </PageHeader>
+      <LeaderboardPageTitle
+        subtitle="Achievements"
+        description="Track your AI coding milestones and compete with others."
+      />
 
       {/* Main content */}
       <main className="flex-1 py-4 space-y-6">

--- a/packages/web/src/app/leaderboard/agents/page.tsx
+++ b/packages/web/src/app/leaderboard/agents/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/hooks/use-leaderboard";
 import { useLeaderboardScope } from "@/hooks/use-leaderboard-scope";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
-import { PageHeader } from "@/components/leaderboard/page-header";
+import { LeaderboardPageTitle } from "@/components/leaderboard/leaderboard-page-title";
 import { PeriodTabs } from "@/components/leaderboard/period-tabs";
 import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
 import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
@@ -121,17 +121,10 @@ function AgentsLeaderboardContent() {
   return (
     <>
       {/* Header */}
-      <PageHeader>
-        <h1 className="tracking-tight text-foreground">
-          <span className="text-[36px] font-bold font-handwriting leading-none mr-2">pew</span>
-          <span className="text-[19px] font-normal text-muted-foreground">
-            Leaderboard
-          </span>
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Top users by agent — who&apos;s burning the most tokens?
-        </p>
-      </PageHeader>
+      <LeaderboardPageTitle
+        subtitle="Leaderboard"
+        description="Top users by agent — who's burning the most tokens?"
+      />
 
       {/* Main content */}
       <main className="flex-1 py-4 space-y-4">

--- a/packages/web/src/app/leaderboard/agents/page.tsx
+++ b/packages/web/src/app/leaderboard/agents/page.tsx
@@ -18,6 +18,7 @@ import {
   FilterDropdown,
   type FilterDropdownItem,
 } from "@/components/leaderboard/filter-dropdown";
+import { PAGE_SIZE } from "@/lib/leaderboard-constants";
 
 // ---------------------------------------------------------------------------
 // Agent list (matches VALID_SOURCES in API route)
@@ -45,12 +46,6 @@ const AGENT_ITEMS: FilterDropdownItem[] = AGENTS.map((a) => ({
   label: sourceLabel(a),
   color: agentColor(a).color,
 }));
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const PAGE_SIZE = 20;
 
 // ---------------------------------------------------------------------------
 // Page

--- a/packages/web/src/app/leaderboard/agents/page.tsx
+++ b/packages/web/src/app/leaderboard/agents/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { Suspense, useState, useEffect, useCallback, useRef } from "react";
+import { Suspense, useState, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { ChevronDown } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { agentColor } from "@/lib/palette";
 import { sourceLabel } from "@/hooks/use-usage-data";
 import {
@@ -16,6 +14,10 @@ import { PageHeader } from "@/components/leaderboard/page-header";
 import { PeriodTabs } from "@/components/leaderboard/period-tabs";
 import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
 import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
+import {
+  FilterDropdown,
+  type FilterDropdownItem,
+} from "@/components/leaderboard/filter-dropdown";
 
 // ---------------------------------------------------------------------------
 // Agent list (matches VALID_SOURCES in API route)
@@ -38,86 +40,11 @@ const AGENTS = [
 const AGENT_SET = new Set<string>(AGENTS);
 const DEFAULT_AGENT = "claude-code";
 
-// ---------------------------------------------------------------------------
-// AgentSelector dropdown
-// ---------------------------------------------------------------------------
-
-function AgentSelector({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (source: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  const color = agentColor(value);
-
-  return (
-    <div ref={ref} className="relative shrink-0">
-      <button
-        onClick={() => setOpen(!open)}
-        className={cn(
-          "flex items-center gap-2 rounded-lg bg-secondary px-3 py-[10px] text-sm font-medium transition-colors",
-          "text-foreground hover:bg-accent",
-        )}
-      >
-        <span
-          className="h-2.5 w-2.5 shrink-0 rounded-full"
-          style={{ backgroundColor: color.color }}
-        />
-        {sourceLabel(value)}
-        <ChevronDown
-          className={cn(
-            "h-3.5 w-3.5 text-muted-foreground transition-transform duration-200",
-            open && "rotate-180",
-          )}
-          strokeWidth={1.5}
-        />
-      </button>
-      {open && (
-        <div className="absolute left-0 top-full z-50 mt-0.5 min-w-[200px] max-h-[320px] overflow-y-auto rounded-lg border border-border bg-background p-1 shadow-lg space-y-1">
-          {AGENTS.map((agent) => {
-            const c = agentColor(agent);
-            return (
-              <button
-                key={agent}
-                onClick={() => {
-                  onChange(agent);
-                  setOpen(false);
-                }}
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors",
-                  value === agent
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                )}
-              >
-                <span
-                  className="h-2.5 w-2.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: c.color }}
-                />
-                {sourceLabel(agent)}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
+const AGENT_ITEMS: FilterDropdownItem[] = AGENTS.map((a) => ({
+  key: a,
+  label: sourceLabel(a),
+  color: agentColor(a).color,
+}));
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -217,7 +144,11 @@ function AgentsLeaderboardContent() {
           style={{ animationDelay: "180ms" }}
         >
           {/* Agent selector */}
-          <AgentSelector value={selectedAgent} onChange={handleAgentChange} />
+          <FilterDropdown
+            value={selectedAgent}
+            items={AGENT_ITEMS}
+            onChange={handleAgentChange}
+          />
 
           {/* Period tabs */}
           <PeriodTabs value={period} onChange={setPeriod} />

--- a/packages/web/src/app/leaderboard/models/page.tsx
+++ b/packages/web/src/app/leaderboard/models/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/hooks/use-leaderboard";
 import { useLeaderboardScope } from "@/hooks/use-leaderboard-scope";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
-import { PageHeader } from "@/components/leaderboard/page-header";
+import { LeaderboardPageTitle } from "@/components/leaderboard/leaderboard-page-title";
 import { PeriodTabs } from "@/components/leaderboard/period-tabs";
 import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
 import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
@@ -134,17 +134,10 @@ function ModelsLeaderboardContent() {
   return (
     <>
       {/* Header */}
-      <PageHeader>
-        <h1 className="tracking-tight text-foreground">
-          <span className="text-[36px] font-bold font-handwriting leading-none mr-2">pew</span>
-          <span className="text-[19px] font-normal text-muted-foreground">
-            Leaderboard
-          </span>
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Top users by model — who&apos;s pushing each model the hardest?
-        </p>
-      </PageHeader>
+      <LeaderboardPageTitle
+        subtitle="Leaderboard"
+        description="Top users by model — who's pushing each model the hardest?"
+      />
 
       {/* Main content */}
       <main className="flex-1 py-4 space-y-4">

--- a/packages/web/src/app/leaderboard/models/page.tsx
+++ b/packages/web/src/app/leaderboard/models/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { Suspense, useState, useEffect, useCallback, useRef } from "react";
+import { Suspense, useState, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { ChevronDown } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { modelColor } from "@/lib/palette";
 import { shortModel } from "@/lib/model-helpers";
 import {
@@ -16,6 +14,10 @@ import { PageHeader } from "@/components/leaderboard/page-header";
 import { PeriodTabs } from "@/components/leaderboard/period-tabs";
 import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
 import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
+import {
+  FilterDropdown,
+  type FilterDropdownItem,
+} from "@/components/leaderboard/filter-dropdown";
 
 // ---------------------------------------------------------------------------
 // Model list — Top 20 by token usage from D1 (2026-04-10 snapshot)
@@ -49,86 +51,11 @@ const MODEL_LIST = [
 ];
 const DEFAULT_MODEL = "claude-opus-4.6-1m";
 
-// ---------------------------------------------------------------------------
-// ModelSelector dropdown
-// ---------------------------------------------------------------------------
-
-function ModelSelector({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (model: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  const color = modelColor(value);
-
-  return (
-    <div ref={ref} className="relative shrink-0">
-      <button
-        onClick={() => setOpen(!open)}
-        className={cn(
-          "flex items-center gap-2 rounded-lg bg-secondary px-3 py-[10px] text-sm font-medium transition-colors",
-          "text-foreground hover:bg-accent",
-        )}
-      >
-        <span
-          className="h-2.5 w-2.5 shrink-0 rounded-full"
-          style={{ backgroundColor: color.color }}
-        />
-        {shortModel(value)}
-        <ChevronDown
-          className={cn(
-            "h-3.5 w-3.5 text-muted-foreground transition-transform duration-200",
-            open && "rotate-180",
-          )}
-          strokeWidth={1.5}
-        />
-      </button>
-      {open && (
-        <div className="absolute left-0 top-full z-50 mt-0.5 min-w-[220px] max-h-[320px] overflow-y-auto rounded-lg border border-border bg-background p-1 shadow-lg space-y-1">
-          {MODEL_LIST.map((model) => {
-            const c = modelColor(model);
-            return (
-              <button
-                key={model}
-                onClick={() => {
-                  onChange(model);
-                  setOpen(false);
-                }}
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors",
-                  value === model
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                )}
-              >
-                <span
-                  className="h-2.5 w-2.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: c.color }}
-                />
-                {shortModel(model)}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
+const MODEL_ITEMS: FilterDropdownItem[] = MODEL_LIST.map((m) => ({
+  key: m,
+  label: shortModel(m),
+  color: modelColor(m).color,
+}));
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -230,7 +157,12 @@ function ModelsLeaderboardContent() {
           style={{ animationDelay: "180ms" }}
         >
           {/* Model selector */}
-          <ModelSelector value={selectedModel} onChange={handleModelChange} />
+          <FilterDropdown
+            value={selectedModel}
+            items={MODEL_ITEMS}
+            onChange={handleModelChange}
+            panelMinWidth="220px"
+          />
 
           {/* Period tabs */}
           <PeriodTabs value={period} onChange={setPeriod} />

--- a/packages/web/src/app/leaderboard/models/page.tsx
+++ b/packages/web/src/app/leaderboard/models/page.tsx
@@ -18,6 +18,7 @@ import {
   FilterDropdown,
   type FilterDropdownItem,
 } from "@/components/leaderboard/filter-dropdown";
+import { PAGE_SIZE } from "@/lib/leaderboard-constants";
 
 // ---------------------------------------------------------------------------
 // Model list — Top 20 by token usage from D1 (2026-04-10 snapshot)
@@ -56,12 +57,6 @@ const MODEL_ITEMS: FilterDropdownItem[] = MODEL_LIST.map((m) => ({
   label: shortModel(m),
   color: modelColor(m).color,
 }));
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const PAGE_SIZE = 20;
 
 // ---------------------------------------------------------------------------
 // Page

--- a/packages/web/src/app/leaderboard/page.tsx
+++ b/packages/web/src/app/leaderboard/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/hooks/use-leaderboard";
 import { useLeaderboardScope } from "@/hooks/use-leaderboard-scope";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
-import { PageHeader } from "@/components/leaderboard/page-header";
+import { LeaderboardPageTitle } from "@/components/leaderboard/leaderboard-page-title";
 import { PeriodTabs } from "@/components/leaderboard/period-tabs";
 import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
 import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
@@ -56,17 +56,10 @@ export default function LeaderboardPage() {
   return (
     <>
       {/* Header */}
-      <PageHeader>
-        <h1 className="tracking-tight text-foreground">
-          <span className="text-[36px] font-bold font-handwriting leading-none mr-2">pew</span>
-          <span className="text-[19px] font-normal text-muted-foreground">
-            Leaderboard
-          </span>
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Join the ultimate AI token horse race today.
-        </p>
-      </PageHeader>
+      <LeaderboardPageTitle
+        subtitle="Leaderboard"
+        description="Join the ultimate AI token horse race today."
+      />
 
       {/* Main content */}
       <main className="flex-1 py-4 space-y-4">

--- a/packages/web/src/app/leaderboard/page.tsx
+++ b/packages/web/src/app/leaderboard/page.tsx
@@ -11,12 +11,7 @@ import { LeaderboardPageTitle } from "@/components/leaderboard/leaderboard-page-
 import { PeriodTabs } from "@/components/leaderboard/period-tabs";
 import { ScopeDropdown } from "@/components/leaderboard/scope-dropdown";
 import { LeaderboardPageShell } from "@/components/leaderboard/leaderboard-page-shell";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const PAGE_SIZE = 20;
+import { PAGE_SIZE } from "@/lib/leaderboard-constants";
 
 // ---------------------------------------------------------------------------
 // Page

--- a/packages/web/src/app/leaderboard/seasons/page.tsx
+++ b/packages/web/src/app/leaderboard/seasons/page.tsx
@@ -17,7 +17,7 @@ import { formatSeasonDate } from "@/lib/seasons";
 import { CheckRuling } from "@/components/leaderboard/check-ruling";
 import { StatusBadge } from "@/components/leaderboard/status-badge";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
-import { PageHeader } from "@/components/leaderboard/page-header";
+import { LeaderboardPageTitle } from "@/components/leaderboard/leaderboard-page-title";
 
 // ---------------------------------------------------------------------------
 // Timeline dot — status indicator with optional pulse for active seasons
@@ -158,17 +158,10 @@ export default function SeasonsPage() {
   return (
     <>
       {/* Header */}
-      <PageHeader>
-        <h1 className="tracking-tight text-foreground">
-          <span className="text-[36px] font-bold font-handwriting leading-none mr-2">pew</span>
-          <span className="text-[19px] font-normal text-muted-foreground">
-            Seasons
-          </span>
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Compete as teams across time-boxed seasons.
-        </p>
-      </PageHeader>
+      <LeaderboardPageTitle
+        subtitle="Seasons"
+        description="Compete as teams across time-boxed seasons."
+      />
 
       {/* Main content */}
       <main className="flex-1 py-4 space-y-4">

--- a/packages/web/src/app/leaderboard/showcases/page.tsx
+++ b/packages/web/src/app/leaderboard/showcases/page.tsx
@@ -6,7 +6,7 @@
 
 import { auth } from "@/auth";
 import { LeaderboardNav } from "@/components/leaderboard/leaderboard-nav";
-import { PageHeader } from "@/components/leaderboard/page-header";
+import { LeaderboardPageTitle } from "@/components/leaderboard/leaderboard-page-title";
 import { ShowcasesContent } from "./showcases-content";
 
 export const metadata = {
@@ -20,17 +20,10 @@ export default async function ShowcasesPage() {
 
   return (
     <>
-      <PageHeader>
-        <h1 className="tracking-tight text-foreground">
-          <span className="text-[36px] font-bold font-handwriting leading-none mr-2">pew</span>
-          <span className="text-[19px] font-normal text-muted-foreground">
-            Showcases
-          </span>
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Community-submitted GitHub projects worth checking out.
-        </p>
-      </PageHeader>
+      <LeaderboardPageTitle
+        subtitle="Showcases"
+        description="Community-submitted GitHub projects worth checking out."
+      />
 
       <main className="flex-1 py-4 space-y-4">
         <LeaderboardNav />

--- a/packages/web/src/components/leaderboard/filter-dropdown.tsx
+++ b/packages/web/src/components/leaderboard/filter-dropdown.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// FilterDropdown — generic dropdown used by agent/model selectors
+// ---------------------------------------------------------------------------
+
+export interface FilterDropdownItem {
+  key: string;
+  label: string;
+  color: string;
+}
+
+interface FilterDropdownProps {
+  /** Currently selected item key */
+  value: string;
+  /** Available items */
+  items: readonly FilterDropdownItem[];
+  /** Fired when the user picks a different item */
+  onChange: (key: string) => void;
+  /** Optional minimum width for the dropdown panel (default "200px") */
+  panelMinWidth?: string;
+}
+
+export function FilterDropdown({
+  value,
+  items,
+  onChange,
+  panelMinWidth = "200px",
+}: FilterDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  const selected = items.find((i) => i.key === value);
+
+  return (
+    <div ref={ref} className="relative shrink-0">
+      <button
+        onClick={() => setOpen(!open)}
+        className={cn(
+          "flex items-center gap-2 rounded-lg bg-secondary px-3 py-[10px] text-sm font-medium transition-colors",
+          "text-foreground hover:bg-accent",
+        )}
+      >
+        {selected && (
+          <span
+            className="h-2.5 w-2.5 shrink-0 rounded-full"
+            style={{ backgroundColor: selected.color }}
+          />
+        )}
+        {selected?.label ?? value}
+        <ChevronDown
+          className={cn(
+            "h-3.5 w-3.5 text-muted-foreground transition-transform duration-200",
+            open && "rotate-180",
+          )}
+          strokeWidth={1.5}
+        />
+      </button>
+      {open && (
+        <div
+          className="absolute left-0 top-full z-50 mt-0.5 max-h-[320px] overflow-y-auto rounded-lg border border-border bg-background p-1 shadow-lg space-y-1"
+          style={{ minWidth: panelMinWidth }}
+        >
+          {items.map((item) => (
+            <button
+              key={item.key}
+              onClick={() => {
+                onChange(item.key);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors",
+                value === item.key
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground",
+              )}
+            >
+              <span
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: item.color }}
+              />
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/leaderboard/leaderboard-page-title.tsx
+++ b/packages/web/src/components/leaderboard/leaderboard-page-title.tsx
@@ -1,0 +1,31 @@
+import { PageHeader } from "@/components/leaderboard/page-header";
+
+// ---------------------------------------------------------------------------
+// LeaderboardPageTitle — shared "pew" heading used by every leaderboard page
+// ---------------------------------------------------------------------------
+
+interface LeaderboardPageTitleProps {
+  /** Text shown next to "pew" (e.g. "Leaderboard", "Seasons") */
+  subtitle: string;
+  /** Short description below the heading */
+  description: string;
+}
+
+export function LeaderboardPageTitle({
+  subtitle,
+  description,
+}: LeaderboardPageTitleProps) {
+  return (
+    <PageHeader>
+      <h1 className="tracking-tight text-foreground">
+        <span className="text-[36px] font-bold font-handwriting leading-none mr-2">
+          pew
+        </span>
+        <span className="text-[19px] font-normal text-muted-foreground">
+          {subtitle}
+        </span>
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+    </PageHeader>
+  );
+}

--- a/packages/web/src/lib/leaderboard-constants.ts
+++ b/packages/web/src/lib/leaderboard-constants.ts
@@ -1,0 +1,4 @@
+/** Shared constants for leaderboard pages. */
+
+/** Default number of rows fetched per page / load-more request. */
+export const PAGE_SIZE = 20;


### PR DESCRIPTION
Extract shared page components:
-  replaces duplicate /
-  replaces 6x copy-pasted header blocks
-  moved to shared 

Closes #82