### PR TITLE
feat(web): add legend isolate and cmd-click exclude filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,6 @@ This file records repository operations performed by agents.
 - Request: add chart legend filtering interaction.
 - Implementation: normal legend click isolates target; cmd/ctrl+click excludes target.
 - Git flow: create feature branch, commit changes, push branch, open PR to `nocoo/pew`.
-- PR: pending (to be updated after creation).
+- Branch: `feat/legend-click-command-filter`
+- Commit: `7c18697b`
+- PR: https://github.com/nocoo/pew/pull/91

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS Operation Log
+
+This file records repository operations performed by agents.
+
+## 2026-04-13
+- Request: add chart legend filtering interaction.
+- Implementation: normal legend click isolates target; cmd/ctrl+click excludes target.
+- Git flow: create feature branch, commit changes, push branch, open PR to `nocoo/pew`.
+- PR: pending (to be updated after creation).

--- a/packages/web/src/__tests__/chart-legend-filter.test.ts
+++ b/packages/web/src/__tests__/chart-legend-filter.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { nextHiddenLegendKeys } from "@/lib/chart-legend-filter";
+
+function toSortedArray(set: Set<string>): string[] {
+  return Array.from(set).sort();
+}
+
+describe("nextHiddenLegendKeys", () => {
+  const keys = ["a", "b", "c"];
+
+  it("isolates the clicked key on normal click", () => {
+    const next = nextHiddenLegendKeys({
+      keys,
+      hiddenKeys: new Set(),
+      targetKey: "b",
+    });
+
+    expect(toSortedArray(next)).toEqual(["a", "c"]);
+  });
+
+  it("resets to all visible when clicking the isolated key again", () => {
+    const next = nextHiddenLegendKeys({
+      keys,
+      hiddenKeys: new Set(["a", "c"]),
+      targetKey: "b",
+    });
+
+    expect(toSortedArray(next)).toEqual([]);
+  });
+
+  it("hides target key on meta/cmd click without isolating", () => {
+    const next = nextHiddenLegendKeys({
+      keys,
+      hiddenKeys: new Set(["c"]),
+      targetKey: "a",
+      metaKey: true,
+    });
+
+    expect(toSortedArray(next)).toEqual(["a", "c"]);
+  });
+
+  it("unhides target key on repeated meta/cmd click", () => {
+    const next = nextHiddenLegendKeys({
+      keys,
+      hiddenKeys: new Set(["a", "c"]),
+      targetKey: "a",
+      metaKey: true,
+    });
+
+    expect(toSortedArray(next)).toEqual(["c"]);
+  });
+
+  it("keeps current state when target key is unknown", () => {
+    const next = nextHiddenLegendKeys({
+      keys,
+      hiddenKeys: new Set(["a"]),
+      targetKey: "x",
+      metaKey: true,
+    });
+
+    expect(toSortedArray(next)).toEqual(["a"]);
+  });
+});

--- a/packages/web/src/components/dashboard/device-agent-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/device-agent-trend-chart.tsx
@@ -13,6 +13,7 @@ import { cn, formatTokens } from "@/lib/utils";
 import { chartAxis, agentColor } from "@/lib/palette";
 import { sourceLabel } from "@/hooks/use-usage-data";
 import type { SourceTrendPoint } from "@/lib/usage-helpers";
+import { nextHiddenLegendKeys } from "@/lib/chart-legend-filter";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 import {
   ChartTooltip,
@@ -127,15 +128,14 @@ export function DeviceAgentTrendChart({
     );
   }
 
-  function toggleSource(source: string) {
+  function handleLegendClick(source: string, metaKey: boolean) {
     setHiddenSources((prev) => {
-      const next = new Set(prev);
-      if (next.has(source)) {
-        next.delete(source);
-      } else {
-        next.add(source);
-      }
-      return next;
+      return nextHiddenLegendKeys({
+        keys: sourceKeys,
+        hiddenKeys: prev,
+        targetKey: source,
+        metaKey,
+      });
     });
   }
 
@@ -159,7 +159,9 @@ export function DeviceAgentTrendChart({
               <button
                 key={source}
                 type="button"
-                onClick={() => toggleSource(source)}
+                onClick={(event) =>
+                  handleLegendClick(source, event.metaKey || event.ctrlKey)
+                }
                 className={cn(
                   "flex items-center gap-1.5 transition-opacity",
                   isHidden && "opacity-40",

--- a/packages/web/src/components/dashboard/device-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/device-trend-chart.tsx
@@ -15,6 +15,7 @@ import {
   toDeviceTrendPoints,
   buildDeviceLabelMap,
 } from "@/lib/device-helpers";
+import { nextHiddenLegendKeys } from "@/lib/chart-legend-filter";
 import type { DeviceAggregate, DeviceTimelinePoint } from "@pew/core";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 import {
@@ -100,7 +101,8 @@ function DeviceTrendTooltip({
 
 /**
  * Multi-line LineChart showing token usage per device over time.
- * Each device gets a distinct colored line. Click legend to toggle visibility.
+ * Each device gets a distinct colored line.
+ * Click legend to isolate, cmd/ctrl+click legend to toggle visibility.
  */
 export function DeviceTrendChart({
   timeline,
@@ -136,15 +138,14 @@ export function DeviceTrendChart({
     );
   }
 
-  function toggleDevice(deviceId: string) {
+  function handleLegendClick(deviceId: string, metaKey: boolean) {
     setHiddenDevices((prev) => {
-      const next = new Set(prev);
-      if (next.has(deviceId)) {
-        next.delete(deviceId);
-      } else {
-        next.add(deviceId);
-      }
-      return next;
+      return nextHiddenLegendKeys({
+        keys: deviceKeys,
+        hiddenKeys: prev,
+        targetKey: deviceId,
+        metaKey,
+      });
     });
   }
 
@@ -166,7 +167,9 @@ export function DeviceTrendChart({
               <button
                 key={deviceId}
                 type="button"
-                onClick={() => toggleDevice(deviceId)}
+                onClick={(event) =>
+                  handleLegendClick(deviceId, event.metaKey || event.ctrlKey)
+                }
                 className={cn(
                   "flex items-center gap-1.5 transition-opacity",
                   isHidden && "opacity-40"

--- a/packages/web/src/components/dashboard/project-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/project-trend-chart.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import { cn } from "@/lib/utils";
 import { chartAxis, CHART_COLORS } from "@/lib/palette";
+import { nextHiddenLegendKeys } from "@/lib/chart-legend-filter";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 import {
   ChartTooltip,
@@ -90,7 +91,8 @@ function ProjectTrendTooltip({
 
 /**
  * Multi-line LineChart showing daily session counts per project over time.
- * Each project gets a distinct colored line. Click legend to toggle visibility.
+ * Each project gets a distinct colored line.
+ * Click legend to isolate, cmd/ctrl+click legend to toggle visibility.
  */
 export function ProjectTrendChart({
   timeline,
@@ -129,15 +131,14 @@ export function ProjectTrendChart({
     );
   }
 
-  function toggleProject(name: string) {
+  function handleLegendClick(name: string, metaKey: boolean) {
     setHiddenProjects((prev) => {
-      const next = new Set(prev);
-      if (next.has(name)) {
-        next.delete(name);
-      } else {
-        next.add(name);
-      }
-      return next;
+      return nextHiddenLegendKeys({
+        keys: projectKeys,
+        hiddenKeys: prev,
+        targetKey: name,
+        metaKey,
+      });
     });
   }
 
@@ -159,7 +160,9 @@ export function ProjectTrendChart({
               <button
                 key={name}
                 type="button"
-                onClick={() => toggleProject(name)}
+                onClick={(event) =>
+                  handleLegendClick(name, event.metaKey || event.ctrlKey)
+                }
                 className={cn(
                   "flex items-center gap-1.5 transition-opacity",
                   isHidden && "opacity-40",

--- a/packages/web/src/components/dashboard/source-trend-chart.tsx
+++ b/packages/web/src/components/dashboard/source-trend-chart.tsx
@@ -14,6 +14,7 @@ import { chartAxis } from "@/lib/palette";
 import { agentColor } from "@/lib/palette";
 import { sourceLabel } from "@/hooks/use-usage-data";
 import type { SourceTrendPoint } from "@/lib/usage-helpers";
+import { nextHiddenLegendKeys } from "@/lib/chart-legend-filter";
 import { DashboardResponsiveContainer } from "./dashboard-responsive-container";
 import {
   ChartTooltip,
@@ -97,7 +98,8 @@ function SourceTrendTooltip({
 
 /**
  * Line chart showing token usage per source (tool) over time.
- * Each source gets a distinct colored line. Click legend to toggle visibility.
+ * Each source gets a distinct colored line.
+ * Click legend to isolate, cmd/ctrl+click legend to toggle visibility.
  */
 export function SourceTrendChart({ data, className }: SourceTrendChartProps) {
   const [hiddenSources, setHiddenSources] = useState<Set<string>>(new Set());
@@ -131,15 +133,14 @@ export function SourceTrendChart({ data, className }: SourceTrendChartProps) {
     );
   }
 
-  function toggleSource(source: string) {
+  function handleLegendClick(source: string, metaKey: boolean) {
     setHiddenSources((prev) => {
-      const next = new Set(prev);
-      if (next.has(source)) {
-        next.delete(source);
-      } else {
-        next.add(source);
-      }
-      return next;
+      return nextHiddenLegendKeys({
+        keys: sourceKeys,
+        hiddenKeys: prev,
+        targetKey: source,
+        metaKey,
+      });
     });
   }
 
@@ -163,7 +164,9 @@ export function SourceTrendChart({ data, className }: SourceTrendChartProps) {
               <button
                 key={source}
                 type="button"
-                onClick={() => toggleSource(source)}
+                onClick={(event) =>
+                  handleLegendClick(source, event.metaKey || event.ctrlKey)
+                }
                 className={cn(
                   "flex items-center gap-1.5 transition-opacity",
                   isHidden && "opacity-40"

--- a/packages/web/src/lib/chart-legend-filter.ts
+++ b/packages/web/src/lib/chart-legend-filter.ts
@@ -1,0 +1,36 @@
+export interface LegendFilterArgs {
+  keys: string[];
+  hiddenKeys: ReadonlySet<string>;
+  targetKey: string;
+  metaKey?: boolean;
+}
+
+/**
+ * Legend interaction rules:
+ * - click: isolate target (click target again to reset all visible)
+ * - cmd/ctrl+click: toggle target visibility while keeping others
+ */
+export function nextHiddenLegendKeys({
+  keys,
+  hiddenKeys,
+  targetKey,
+  metaKey = false,
+}: LegendFilterArgs): Set<string> {
+  if (!keys.includes(targetKey)) return new Set(hiddenKeys);
+
+  if (metaKey) {
+    const next = new Set(hiddenKeys);
+    if (next.has(targetKey)) {
+      next.delete(targetKey);
+    } else {
+      next.add(targetKey);
+    }
+    return next;
+  }
+
+  const visible = keys.filter((key) => !hiddenKeys.has(key));
+  const isAlreadyIsolated = visible.length === 1 && visible[0] === targetKey;
+  if (isAlreadyIsolated) return new Set();
+
+  return new Set(keys.filter((key) => key !== targetKey));
+}


### PR DESCRIPTION
## Summary\n- add reusable legend filtering logic for trend charts\n- normal click on legend isolates selected series\n- cmd/ctrl click toggles hide/show selected series while keeping others\n- apply behavior to source/device/project/device-agent trend charts\n- add unit tests for legend filtering behavior\n\n## Verification\n- bun run test packages/web/src/__tests__/chart-legend-filter.test.ts\n- bun x tsc --noEmit -p packages/web/tsconfig.json\n- bun run lint:typecheck