### PR TITLE
fix(security): CLI command injection and file security

### DIFF
--- a/packages/cli/src/__tests__/claude-hook.test.ts
+++ b/packages/cli/src/__tests__/claude-hook.test.ts
@@ -74,7 +74,7 @@ describe("Claude hook installer", () => {
           hooks: {
             SessionEnd: [
               {
-                hooks: [{ command: `/usr/bin/env node ${notifyPath} --source=claude-code` }],
+                hooks: [{ command: `/usr/bin/env node '${notifyPath}' --source=claude-code` }],
               },
             ],
           },
@@ -104,7 +104,7 @@ describe("Claude hook installer", () => {
                   { type: "command", command: "echo existing" },
                   {
                     type: "command",
-                    command: `/usr/bin/env node ${notifyPath} --source=claude-code`,
+                    command: `/usr/bin/env node '${notifyPath}' --source=claude-code`,
                   },
                 ],
               },
@@ -187,13 +187,13 @@ describe("Claude hook installer", () => {
     expect(result.backupPath).toContain(".bak.");
   });
 
-  it("quotes notify paths that contain spaces", async () => {
+  it("single-quotes notify paths that contain spaces", async () => {
     const spacedPath = join(tempDir, "notify dir", "notify.cjs");
 
     await installClaudeHook({ settingsPath, notifyPath: spacedPath });
     const saved = JSON.parse(await readFile(settingsPath, "utf8"));
 
-    expect(saved.hooks.SessionEnd[0].hooks[0].command).toContain(`"${spacedPath}"`);
+    expect(saved.hooks.SessionEnd[0].hooks[0].command).toContain(`'${spacedPath}'`);
   });
 
   it("re-throws non-ENOENT errors when reading settings", async () => {

--- a/packages/cli/src/__tests__/gemini-hook.test.ts
+++ b/packages/cli/src/__tests__/gemini-hook.test.ts
@@ -105,7 +105,7 @@ describe("Gemini hook installer", () => {
               {
                 matcher: "exit|clear|logout|prompt_input_exit|other",
                 hooks: [
-                  { name: "pew-tracker", type: "command", command: `/usr/bin/env node ${notifyPath} --source=gemini-cli` },
+                  { name: "pew-tracker", type: "command", command: `/usr/bin/env node '${notifyPath}' --source=gemini-cli` },
                   { name: "custom-hook", type: "command", command: "echo done" },
                 ],
               },
@@ -128,15 +128,15 @@ describe("Gemini hook installer", () => {
     expect(saved.hooks.SessionEnd[0].hooks[0].name).toBe("custom-hook");
   });
 
-  it("quotes notifyPath containing special characters", async () => {
+  it("single-quotes notifyPath containing special characters", async () => {
     const specialNotifyPath = "/tmp/my pew dir/bin/notify.cjs";
     const result = await installGeminiHook({ settingsPath, notifyPath: specialNotifyPath });
     const saved = JSON.parse(await readFile(settingsPath, "utf8"));
 
     expect(result.changed).toBe(true);
-    // The command should have quoted the path due to the space
+    // The command should have single-quoted the path due to the space
     const command = saved.hooks.SessionEnd[0].hooks[0].command as string;
-    expect(command).toContain('"');
+    expect(command).toContain("'");
     expect(command).toContain("my pew dir");
   });
 
@@ -303,7 +303,7 @@ describe("Gemini hook installer", () => {
   describe("normalizeEntry edge cases", () => {
     it("repairs hook name when it differs but command matches", async () => {
       // Hook has wrong name but matching command — should be repaired to "pew-tracker"
-      const command = `/usr/bin/env node ${notifyPath} --source=gemini-cli`;
+      const command = `/usr/bin/env node '${notifyPath}' --source=gemini-cli`;
       await writeFile(
         settingsPath,
         `${JSON.stringify(

--- a/packages/cli/src/__tests__/init-command.test.ts
+++ b/packages/cli/src/__tests__/init-command.test.ts
@@ -53,6 +53,7 @@ describe("executeInit", () => {
       })),
       installAllFn: vi.fn(async () => hooks),
       mkdirFn: vi.fn(async () => {}),
+      ensureSecureDirFn: vi.fn(),
     });
 
     expect(result.pewBin).toBe("/tmp/bin/pew");
@@ -107,6 +108,7 @@ describe("executeInit", () => {
       })),
       installDriverFn,
       mkdirFn: vi.fn(async () => {}),
+      ensureSecureDirFn: vi.fn(),
     });
 
     expect(installDriverFn).toHaveBeenCalledTimes(1);
@@ -139,6 +141,7 @@ describe("executeInit", () => {
       })),
       installDriverFn,
       mkdirFn: vi.fn(async () => {}),
+      ensureSecureDirFn: vi.fn(),
     });
 
     expect(result.hooks).toHaveLength(2);
@@ -158,6 +161,7 @@ describe("executeInit", () => {
         path: "/tmp/pew/bin/notify.cjs",
       })),
       mkdirFn: vi.fn(async () => {}),
+      ensureSecureDirFn: vi.fn(),
     });
 
     expect(result.hooks).toEqual([
@@ -227,6 +231,7 @@ describe("executeInit", () => {
       })),
       installDriverFn,
       mkdirFn: vi.fn(async () => {}),
+      ensureSecureDirFn: vi.fn(),
     });
 
     expect(result.hooks).toHaveLength(1);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,7 @@ import { executeUpdate } from "./commands/update.js";
 import { resolveNotifierPaths } from "./notifier/paths.js";
 import { statusAll } from "./notifier/registry.js";
 import { ConfigManager } from "./config/manager.js";
+import { ensureSecureDir } from "./storage/secure-mkdir.js";
 
 // ---------------------------------------------------------------------------
 // CLI version — read from package.json (single source of truth)
@@ -237,6 +238,7 @@ const syncCommand = defineCommand({
     }
 
     // Ensure a stable device ID exists for multi-device dedup
+    ensureSecureDir(paths.stateDir);
     const configManager = new ConfigManager(paths.stateDir, args.dev);
     const deviceId = await configManager.ensureDeviceId();
 
@@ -643,6 +645,7 @@ const notifyCommand = defineCommand({
     }
 
     // Ensure a stable device ID exists for multi-device dedup
+    ensureSecureDir(paths.stateDir);
     const notifyConfigManager = new ConfigManager(paths.stateDir);
     const notifyDeviceId = await notifyConfigManager.ensureDeviceId();
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -11,7 +11,7 @@ import {
   getDriver,
   installAll,
 } from "../notifier/registry.js";
-import { SECURE_DIR_MODE } from "../storage/secure-mkdir.js";
+import { SECURE_DIR_MODE, ensureSecureDir } from "../storage/secure-mkdir.js";
 
 export interface InitOptions {
   stateDir: string;
@@ -31,6 +31,7 @@ export interface InitOptions {
   ) => Promise<NotifierOperationResult>;
   getAllDriversFn?: typeof getAllDrivers;
   mkdirFn?: typeof mkdir;
+  ensureSecureDirFn?: typeof ensureSecureDir;
   spawn?: (cmd: string, args: string[], opts?: object) => { status: number | null };
 }
 
@@ -46,6 +47,7 @@ export async function executeInit(opts: InitOptions): Promise<InitResult> {
   const resolvePewBinFn = opts.resolvePewBinFn ?? resolvePewBin;
   const getAllDriversFn = opts.getAllDriversFn ?? getAllDrivers;
   const mkdirFn = opts.mkdirFn ?? mkdir;
+  const ensureSecureDirFn = opts.ensureSecureDirFn ?? ensureSecureDir;
 
   const pewBin = opts.pewBin ?? (await resolvePewBinFn());
   const paths = resolveNotifierPathsFn(opts.home, opts.env);
@@ -66,6 +68,9 @@ export async function executeInit(opts: InitOptions): Promise<InitResult> {
 
   await mkdirFn(paths.stateDir, { recursive: true, mode: SECURE_DIR_MODE });
   await mkdirFn(paths.binDir, { recursive: true, mode: SECURE_DIR_MODE });
+  // Repair existing directory permissions if they were created with a looser mode
+  ensureSecureDirFn(paths.stateDir);
+  ensureSecureDirFn(paths.binDir);
 
   const notifySource = buildNotifyHandler({
     stateDir: paths.stateDir,

--- a/packages/cli/src/notifier/claude-hook.ts
+++ b/packages/cli/src/notifier/claude-hook.ts
@@ -153,7 +153,10 @@ export async function getClaudeHookStatus(opts: ClaudeHookOptions): Promise<Noti
 }
 
 function buildClaudeHookCommand(notifyPath: string): string {
-  return `/usr/bin/env node ${quoteArg(notifyPath)} --source=${SOURCE}`;
+  if (/[`${}\\]/.test(notifyPath)) {
+    throw new Error("Notify path contains unsafe characters");
+  }
+  return `/usr/bin/env node ${shellEscape(notifyPath)} --source=${SOURCE}`;
 }
 
 async function loadSettings(
@@ -270,7 +273,11 @@ async function writeSettings(
   return backupPath;
 }
 
-function quoteArg(value: string): string {
-  if (/^[A-Za-z0-9_\-./:@]+$/.test(value)) return value;
-  return `"${value.replace(/"/g, '\\"')}"`;
+/**
+ * POSIX single-quote escaping: wraps in single quotes and escapes
+ * embedded single quotes as '\'' to prevent ALL shell expansion
+ * (including $(...) command substitution).
+ */
+function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
 }

--- a/packages/cli/src/notifier/gemini-hook.ts
+++ b/packages/cli/src/notifier/gemini-hook.ts
@@ -161,7 +161,10 @@ export async function getGeminiHookStatus(opts: GeminiHookOptions): Promise<Noti
 }
 
 function buildGeminiHookCommand(notifyPath: string): string {
-  return `/usr/bin/env node ${quoteArg(notifyPath)} --source=${SOURCE}`;
+  if (/[`${}\\]/.test(notifyPath)) {
+    throw new Error("Notify path contains unsafe characters");
+  }
+  return `/usr/bin/env node ${shellEscape(notifyPath)} --source=${SOURCE}`;
 }
 
 async function loadSettings(
@@ -283,7 +286,11 @@ async function writeSettings(
   return backupPath;
 }
 
-function quoteArg(value: string): string {
-  if (/^[A-Za-z0-9_\-./:@]+$/.test(value)) return value;
-  return `"${value.replace(/"/g, '\\"')}"`;
+/**
+ * POSIX single-quote escaping: wraps in single quotes and escapes
+ * embedded single quotes as '\'' to prevent ALL shell expansion
+ * (including $(...) command substitution).
+ */
+function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
 }

--- a/packages/cli/src/notifier/notify-handler.ts
+++ b/packages/cli/src/notifier/notify-handler.ts
@@ -43,7 +43,7 @@ export function buildNotifyHandler(opts: BuildNotifyHandlerOptions): string {
 // ${NOTIFY_HANDLER_MARKER} — Auto-generated, do not edit
 "use strict";
 
-const { appendFileSync, readFileSync, mkdirSync, existsSync } = require("node:fs");
+const { appendFileSync, readFileSync, mkdirSync, existsSync, chmodSync } = require("node:fs");
 const { join, resolve } = require("node:path");
 const { spawn } = require("node:child_process");
 const { homedir } = require("node:os");
@@ -72,7 +72,9 @@ for (let i = 0; i < rawArgs.length; i++) {
 
 try {
   mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
-  appendFileSync(join(STATE_DIR, "notify.signal"), "\\n", "utf8");
+  const signalPath = join(STATE_DIR, "notify.signal");
+  appendFileSync(signalPath, "\\n", "utf8");
+  chmodSync(signalPath, 0o600);
 } catch (_) {}
 
 const bin = existsSync(PEW_BIN) ? PEW_BIN : "npx";

--- a/packages/cli/src/notifier/opencode-plugin.ts
+++ b/packages/cli/src/notifier/opencode-plugin.ts
@@ -109,6 +109,10 @@ export async function getOpenCodePluginStatus(
 }
 
 function buildOpenCodePlugin({ notifyPath }: { notifyPath: string }): string {
+  if (/[`${}\\]/.test(notifyPath)) {
+    throw new Error("Notify path contains unsafe characters");
+  }
+  const escapedPath = shellEscape(notifyPath);
   return `// ${PLUGIN_MARKER}
 const notifyPath = ${JSON.stringify(notifyPath)};
 export const PewTrackerPlugin = async ({ $ }) => {
@@ -117,7 +121,7 @@ export const PewTrackerPlugin = async ({ $ }) => {
       if (!event || event.type !== "session.updated") return;
       try {
         if (!notifyPath) return;
-        const proc = $\`/usr/bin/env node ${"${notifyPath}"} --source=opencode\`;
+        const proc = $\`/usr/bin/env node ${escapedPath} --source=opencode\`;
         if (proc && typeof proc.catch === "function") proc.catch(() => {});
       } catch (_) {}
     }
@@ -136,4 +140,13 @@ async function readOptional(
     if ((err as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return null;
     throw err;
   }
+}
+
+/**
+ * POSIX single-quote escaping: wraps in single quotes and escapes
+ * embedded single quotes as '\'' to prevent ALL shell expansion
+ * (including $(...) command substitution).
+ */
+function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
 }

--- a/packages/cli/src/storage/base-cursor-store.ts
+++ b/packages/cli/src/storage/base-cursor-store.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
-import { SECURE_DIR_MODE } from "./secure-mkdir.js";
+import { SECURE_DIR_MODE, SECURE_FILE_MODE } from "./secure-mkdir.js";
 
 /**
  * Generic base class for persisting cursor state to disk as JSON.
@@ -31,6 +31,6 @@ export class BaseCursorStore<T> {
   async save(state: T): Promise<void> {
     const dir = dirname(this.filePath);
     await mkdir(dir, { recursive: true, mode: SECURE_DIR_MODE });
-    await writeFile(this.filePath, JSON.stringify(state, null, 2) + "\n");
+    await writeFile(this.filePath, JSON.stringify(state, null, 2) + "\n", { mode: SECURE_FILE_MODE });
   }
 }

--- a/packages/cli/src/storage/base-cursor-store.ts
+++ b/packages/cli/src/storage/base-cursor-store.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
-import { SECURE_DIR_MODE, SECURE_FILE_MODE } from "./secure-mkdir.js";
+import { SECURE_DIR_MODE, SECURE_FILE_MODE, chmodSecureFile } from "./secure-mkdir.js";
 
 /**
  * Generic base class for persisting cursor state to disk as JSON.
@@ -32,5 +32,6 @@ export class BaseCursorStore<T> {
     const dir = dirname(this.filePath);
     await mkdir(dir, { recursive: true, mode: SECURE_DIR_MODE });
     await writeFile(this.filePath, JSON.stringify(state, null, 2) + "\n", { mode: SECURE_FILE_MODE });
+    await chmodSecureFile(this.filePath);
   }
 }

--- a/packages/cli/src/storage/base-queue.ts
+++ b/packages/cli/src/storage/base-queue.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, appendFile, rename, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { SECURE_DIR_MODE } from "./secure-mkdir.js";
+import { SECURE_DIR_MODE, SECURE_FILE_MODE } from "./secure-mkdir.js";
 
 /** Optional callback invoked when a corrupted JSONL line is skipped */
 export type OnCorruptLine = (line: string, error: unknown) => void;
@@ -58,7 +58,7 @@ export class BaseQueue<T> {
   /** Append a single record to the queue */
   async append(record: T): Promise<void> {
     await this.ensureDir();
-    await appendFile(this.queuePath, JSON.stringify(record) + "\n");
+    await appendFile(this.queuePath, JSON.stringify(record) + "\n", { mode: SECURE_FILE_MODE });
   }
 
   /** Append multiple records to the queue in a single write */
@@ -66,7 +66,7 @@ export class BaseQueue<T> {
     if (records.length === 0) return;
     await this.ensureDir();
     const data = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
-    await appendFile(this.queuePath, data);
+    await appendFile(this.queuePath, data, { mode: SECURE_FILE_MODE });
   }
 
   /**
@@ -83,7 +83,7 @@ export class BaseQueue<T> {
         ? records.map((r) => JSON.stringify(r)).join("\n") + "\n"
         : "";
     const tmpPath = this.queuePath + ".tmp";
-    await writeFile(tmpPath, data);
+    await writeFile(tmpPath, data, { mode: SECURE_FILE_MODE });
     await rename(tmpPath, this.queuePath);
   }
 
@@ -150,7 +150,7 @@ export class BaseQueue<T> {
   /** Atomically persist the full state object. */
   async saveState(state: QueueState): Promise<void> {
     await this.ensureDir();
-    await writeFile(this.statePath, JSON.stringify(state) + "\n");
+    await writeFile(this.statePath, JSON.stringify(state) + "\n", { mode: SECURE_FILE_MODE });
   }
 
   /** Save the upload byte offset (preserves dirtyKeys). */

--- a/packages/cli/src/storage/base-queue.ts
+++ b/packages/cli/src/storage/base-queue.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, appendFile, rename, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { SECURE_DIR_MODE, SECURE_FILE_MODE } from "./secure-mkdir.js";
+import { SECURE_DIR_MODE, SECURE_FILE_MODE, chmodSecureFile } from "./secure-mkdir.js";
 
 /** Optional callback invoked when a corrupted JSONL line is skipped */
 export type OnCorruptLine = (line: string, error: unknown) => void;
@@ -59,6 +59,7 @@ export class BaseQueue<T> {
   async append(record: T): Promise<void> {
     await this.ensureDir();
     await appendFile(this.queuePath, JSON.stringify(record) + "\n", { mode: SECURE_FILE_MODE });
+    await chmodSecureFile(this.queuePath);
   }
 
   /** Append multiple records to the queue in a single write */
@@ -67,6 +68,7 @@ export class BaseQueue<T> {
     await this.ensureDir();
     const data = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
     await appendFile(this.queuePath, data, { mode: SECURE_FILE_MODE });
+    await chmodSecureFile(this.queuePath);
   }
 
   /**
@@ -84,6 +86,7 @@ export class BaseQueue<T> {
         : "";
     const tmpPath = this.queuePath + ".tmp";
     await writeFile(tmpPath, data, { mode: SECURE_FILE_MODE });
+    await chmodSecureFile(tmpPath);
     await rename(tmpPath, this.queuePath);
   }
 
@@ -151,6 +154,7 @@ export class BaseQueue<T> {
   async saveState(state: QueueState): Promise<void> {
     await this.ensureDir();
     await writeFile(this.statePath, JSON.stringify(state) + "\n", { mode: SECURE_FILE_MODE });
+    await chmodSecureFile(this.statePath);
   }
 
   /** Save the upload byte offset (preserves dirtyKeys). */

--- a/packages/cli/src/storage/secure-mkdir.ts
+++ b/packages/cli/src/storage/secure-mkdir.ts
@@ -1,13 +1,15 @@
 /**
- * Secure directory creation helpers for sensitive pew config directories.
+ * Secure directory and file helpers for sensitive pew config directories.
  *
  * Directories containing API keys, cursors, and other sensitive data should
  * use mode 0o700 (rwx------) to prevent other users from listing contents.
+ * Files should use mode 0o600 (rw-------) to prevent other users from reading.
  *
- * Note: File permissions (0o600) are already handled by @nocoo/cli-base's
- * ConfigManager. This module ensures directory permissions are also hardened.
+ * IMPORTANT: writeFile/appendFile `mode` only applies when *creating* a file.
+ * Pre-existing files retain their old permissions. Always call
+ * `chmodSync(path, SECURE_FILE_MODE)` after writing to enforce 0o600.
  */
-import { mkdir } from "node:fs/promises";
+import { mkdir, chmod } from "node:fs/promises";
 import { mkdirSync as mkdirSyncFs, chmodSync, statSync } from "node:fs";
 
 /** Restrictive mode for sensitive directories (owner rwx only) */
@@ -51,4 +53,23 @@ export function mkdirSecureSync(
   options?: { recursive?: boolean },
 ): void {
   mkdirSyncFs(path, { ...options, mode: SECURE_DIR_MODE });
+}
+
+/**
+ * Enforce secure permissions on a file after writing.
+ *
+ * writeFile/appendFile `mode` only takes effect when the file is *created*.
+ * If the file already existed, its permissions are unchanged. This async
+ * helper unconditionally sets the file to 0o600 (owner rw only).
+ */
+export async function chmodSecureFile(filePath: string): Promise<void> {
+  await chmod(filePath, SECURE_FILE_MODE);
+}
+
+/**
+ * Synchronous variant of chmodSecureFile for contexts where async is
+ * not possible (e.g. generated CJS notify handler).
+ */
+export function chmodSecureFileSync(filePath: string): void {
+  chmodSync(filePath, SECURE_FILE_MODE);
 }

--- a/packages/cli/src/storage/secure-mkdir.ts
+++ b/packages/cli/src/storage/secure-mkdir.ts
@@ -8,10 +8,28 @@
  * ConfigManager. This module ensures directory permissions are also hardened.
  */
 import { mkdir } from "node:fs/promises";
-import { mkdirSync as mkdirSyncFs } from "node:fs";
+import { mkdirSync as mkdirSyncFs, chmodSync, statSync } from "node:fs";
 
 /** Restrictive mode for sensitive directories (owner rwx only) */
 export const SECURE_DIR_MODE = 0o700;
+
+/** Restrictive mode for sensitive files (owner rw only) */
+export const SECURE_FILE_MODE = 0o600;
+
+/**
+ * Ensure a directory exists with secure permissions, repairing if needed.
+ *
+ * Creates the directory with 0o700 if it doesn't exist. If it already
+ * exists with looser permissions, tightens them to 0o700.
+ */
+export function ensureSecureDir(dir: string): void {
+  mkdirSyncFs(dir, { recursive: true, mode: SECURE_DIR_MODE });
+  // Repair existing directory permissions if too loose
+  const stat = statSync(dir);
+  if ((stat.mode & 0o777) !== SECURE_DIR_MODE) {
+    chmodSync(dir, SECURE_DIR_MODE);
+  }
+}
 
 /**
  * Async mkdir with secure permissions for sensitive directories.

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { readdirSync, existsSync, statSync } from "node:fs";
+import { readdirSync, existsSync, lstatSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -22,8 +22,8 @@ function discoverMulticaCodexDirs(home: string): string[] {
   }
 
   try {
-    const st = statSync(multicaRoot);
-    if (!st.isDirectory()) {
+    const st = lstatSync(multicaRoot);
+    if (st.isSymbolicLink() || !st.isDirectory()) {
       return [];
     }
   } catch {
@@ -38,19 +38,24 @@ function discoverMulticaCodexDirs(home: string): string[] {
     for (const workspace of workspaces) {
       const workspacePath = join(multicaRoot, workspace);
       try {
-        if (!statSync(workspacePath).isDirectory()) continue;
+        const wsStat = lstatSync(workspacePath);
+        if (wsStat.isSymbolicLink() || !wsStat.isDirectory()) continue;
 
         // ~/multica_workspaces/<workspace-id>/<task-id>/
         const tasks = readdirSync(workspacePath);
         for (const task of tasks) {
           const taskPath = join(workspacePath, task);
           try {
-            if (!statSync(taskPath).isDirectory()) continue;
+            const taskStat = lstatSync(taskPath);
+            if (taskStat.isSymbolicLink() || !taskStat.isDirectory()) continue;
 
             // ~/multica_workspaces/<workspace-id>/<task-id>/codex-home/sessions/
             const sessionsPath = join(taskPath, "codex-home", "sessions");
-            if (existsSync(sessionsPath) && statSync(sessionsPath).isDirectory()) {
-              results.push(sessionsPath);
+            if (existsSync(sessionsPath)) {
+              const sessStat = lstatSync(sessionsPath);
+              if (!sessStat.isSymbolicLink() && sessStat.isDirectory()) {
+                results.push(sessionsPath);
+              }
             }
           } catch {
             // Skip inaccessible task directories
@@ -83,8 +88,8 @@ function discoverHermesProfileDbs(hermesHome: string): Array<{ dbPath: string; d
   }
 
   try {
-    const st = statSync(profilesDir);
-    if (!st.isDirectory()) {
+    const st = lstatSync(profilesDir);
+    if (st.isSymbolicLink() || !st.isDirectory()) {
       return [];
     }
   } catch {
@@ -97,8 +102,8 @@ function discoverHermesProfileDbs(hermesHome: string): Array<{ dbPath: string; d
     for (const name of entries) {
       const profileDir = join(profilesDir, name);
       try {
-        const profileStat = statSync(profileDir);
-        if (!profileStat.isDirectory()) continue;
+        const profileStat = lstatSync(profileDir);
+        if (profileStat.isSymbolicLink() || !profileStat.isDirectory()) continue;
 
         const dbPath = join(profileDir, "state.db");
         if (existsSync(dbPath)) {

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -106,9 +106,13 @@ function discoverHermesProfileDbs(hermesHome: string): Array<{ dbPath: string; d
         if (profileStat.isSymbolicLink() || !profileStat.isDirectory()) continue;
 
         const dbPath = join(profileDir, "state.db");
-        if (existsSync(dbPath)) {
-          results.push({ dbPath, dbKey: `profiles/${name}` });
+        try {
+          const dbStat = lstatSync(dbPath);
+          if (dbStat.isSymbolicLink() || !dbStat.isFile()) continue;
+        } catch {
+          continue; // state.db does not exist or is inaccessible
         }
+        results.push({ dbPath, dbKey: `profiles/${name}` });
       } catch {
         // Skip inaccessible profile directories
       }

--- a/packages/web/src/__tests__/e2e/api-e2e.test.ts
+++ b/packages/web/src/__tests__/e2e/api-e2e.test.ts
@@ -2,7 +2,11 @@
  * L3 API E2E tests — hit real Next.js dev server on port 17020 with real D1.
  *
  * The server runs with E2E_SKIP_AUTH=true, so all requests are authenticated
- * as E2E_TEST_USER_ID ("e2e-test-user-id") without needing OAuth.
+ * as E2E_TEST_USER_ID without needing OAuth.
+ *
+ * To prevent concurrent CI runs from colliding on pew-db-test, the E2E runner
+ * (scripts/run-e2e.ts) generates a unique E2E_TEST_USER_ID per run and passes
+ * it via environment variables to both the Next.js server and this test file.
  *
  * Prerequisites:
  *   - Next.js dev server running on E2E_PORT (default 17020) with E2E_SKIP_AUTH=true
@@ -27,8 +31,10 @@ import { D1Client } from "../../lib/d1";
 const E2E_PORT = process.env.E2E_PORT || "17020";
 const BASE_URL = `http://localhost:${E2E_PORT}`;
 
-const TEST_USER_ID = "e2e-test-user-id";
-const TEST_USER_EMAIL = "e2e@test.local";
+// Per-run unique user ID/email — set by scripts/run-e2e.ts to isolate
+// concurrent CI runs sharing the same pew-db-test D1 database.
+const TEST_USER_ID = process.env.E2E_TEST_USER_ID || "e2e-test-user-id";
+const TEST_USER_EMAIL = process.env.E2E_TEST_USER_EMAIL || "e2e@test.local";
 
 /** Headers for ingest requests — includes version gate header */
 const INGEST_HEADERS = {

--- a/packages/web/src/lib/auth-helpers.ts
+++ b/packages/web/src/lib/auth-helpers.ts
@@ -1,16 +1,21 @@
 /**
  * Shared auth helper for API routes.
  *
- * In E2E mode (E2E_SKIP_AUTH=true + NODE_ENV=development), returns a
- * deterministic test user so that API tests can run without OAuth.
+ * In E2E mode (E2E_SKIP_AUTH=true + NODE_ENV=development), returns the
+ * test user configured via E2E_TEST_USER_ID / E2E_TEST_USER_EMAIL env vars
+ * so that API tests can run without OAuth. Defaults to a fixed ID for
+ * local dev; the E2E runner overrides these with a per-run unique ID to
+ * prevent concurrent CI jobs from colliding on the shared test database.
  */
 
 import { auth } from "@/auth";
 import { getDbRead } from "@/lib/db";
 
-/** The fixed user ID used when E2E auth is bypassed */
-export const E2E_TEST_USER_ID = "e2e-test-user-id";
-export const E2E_TEST_USER_EMAIL = "e2e@test.local";
+/** The user ID used when E2E auth is bypassed (overridable via env) */
+export const E2E_TEST_USER_ID =
+  process.env.E2E_TEST_USER_ID || "e2e-test-user-id";
+export const E2E_TEST_USER_EMAIL =
+  process.env.E2E_TEST_USER_EMAIL || "e2e@test.local";
 
 export interface AuthResult {
   userId: string;

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -8,11 +8,18 @@
  * 4. Cleans up
  */
 
+import { randomBytes } from "node:crypto";
 import { spawn, type Subprocess } from "bun";
 import { ensurePortFree, cleanupBuildDir, loadEnvLocal, loadEnvTest } from "./e2e-utils";
 import { validateAndOverride } from "./d1-test-guard";
 
 const E2E_PORT = process.env.E2E_PORT || "17020";
+
+// Generate a unique run ID to isolate concurrent E2E runs sharing pew-db-test.
+// Each run seeds/cleans its own user, so parallel CI jobs never collide.
+const RUN_ID = randomBytes(4).toString("hex");
+const E2E_TEST_USER_ID = `e2e-test-user-${RUN_ID}`;
+const E2E_TEST_USER_EMAIL = `e2e-${RUN_ID}@test.local`;
 
 const E2E_DIST_DIR = "packages/web/.next-e2e";
 
@@ -48,8 +55,14 @@ async function main() {
   const envLocal = loadEnvLocal();
   const envTest = loadEnvTest();
   const isolatedEnv = await validateAndOverride(envLocal, envTest);
-  console.log("🔒 D1 test isolation verified — using pew-db-test\n");
-  const mergedEnv = { ...process.env, ...isolatedEnv };
+  console.log("🔒 D1 test isolation verified — using pew-db-test");
+  console.log(`🆔 E2E run isolation: ${E2E_TEST_USER_ID}\n`);
+  const mergedEnv = {
+    ...process.env,
+    ...isolatedEnv,
+    E2E_TEST_USER_ID,
+    E2E_TEST_USER_EMAIL,
+  };
 
   console.log(`🌐 Starting E2E server on port ${E2E_PORT}...`);
   serverProcess = spawn(["bun", "run", "next", "dev", "-p", E2E_PORT], {


### PR DESCRIPTION
## Summary

Closes #97

### Changes
- **Shell injection prevention**: Hook generation now uses POSIX single-quote escaping instead of double-quote, preventing `$(...)` command substitution via crafted `$HOME`
- **Symlink protection**: Path discovery uses `lstatSync()` instead of `statSync()`/`existsSync()` to reject symlinks in Multica workspaces and Hermes profiles
- **File permissions**: State files written with explicit `mode: 0o600`, directories enforced to `0o700`, existing files/dirs repaired with `chmodSync` on write

### Security Impact
- CWE-78: Shell command injection via crafted notify paths eliminated
- CWE-59: Symlink traversal in source discovery blocked
- CWE-732: State file permissions enforced on both new and existing files
