### PR TITLE
fix(ui): align bg-card usage to B05 luminance spec

### DIFF
--- a/packages/web/src/app/(dashboard)/admin/invites/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/invites/page.tsx
@@ -490,7 +490,7 @@ export default function AdminInvitesPage() {
                 className={cn(
                   "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
                   statusFilter === opt
-                    ? "bg-card text-foreground shadow-sm"
+                    ? "bg-secondary text-foreground shadow-sm"
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >

--- a/packages/web/src/app/(dashboard)/admin/showcases/admin-showcases-content.tsx
+++ b/packages/web/src/app/(dashboard)/admin/showcases/admin-showcases-content.tsx
@@ -250,7 +250,7 @@ export function AdminShowcasesContent() {
                 className={cn(
                   "rounded-md px-3 py-1.5 text-xs font-medium transition-colors capitalize",
                   statusFilter === opt
-                    ? "bg-card text-foreground shadow-sm"
+                    ? "bg-secondary text-foreground shadow-sm"
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >

--- a/packages/web/src/app/(dashboard)/admin/storage/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/storage/page.tsx
@@ -543,7 +543,7 @@ export default function AdminStoragePage() {
                       placeholder="Filter users..."
                       value={search}
                       onChange={(e) => setSearch(e.target.value)}
-                      className="w-full rounded-lg border border-border bg-card pl-9 pr-8 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/20 transition-shadow"
+                      className="w-full rounded-lg border border-border bg-secondary pl-9 pr-8 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/20 transition-shadow"
                     />
                     {search && (
                       <button
@@ -562,7 +562,7 @@ export default function AdminStoragePage() {
 
               {/* User table */}
               {filteredUsers.length === 0 ? (
-                <div className="rounded-xl bg-card p-8 text-center text-sm text-muted-foreground">
+                <div className="rounded-xl bg-secondary p-8 text-center text-sm text-muted-foreground">
                   {search ? "No users match your filter." : "No users found."}
                 </div>
               ) : (
@@ -686,7 +686,7 @@ export default function AdminStoragePage() {
                   <button
                     onClick={fetchCacheKeys}
                     disabled={cacheLoading}
-                    className="inline-flex items-center gap-1.5 rounded-md bg-card px-3 py-1.5 text-xs font-medium hover:bg-accent transition-colors disabled:opacity-50"
+                    className="inline-flex items-center gap-1.5 rounded-md bg-secondary px-3 py-1.5 text-xs font-medium hover:bg-accent transition-colors disabled:opacity-50"
                   >
                     <RefreshCw
                       className={cn(
@@ -734,7 +734,7 @@ export default function AdminStoragePage() {
                     {Object.entries(cacheTypeCounts).map(([type, count]) => (
                       <span
                         key={type}
-                        className="inline-flex items-center gap-1 rounded-full bg-card px-2 py-0.5 text-xs"
+                        className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs"
                       >
                         <span className="text-muted-foreground">{type}:</span>
                         <span className="font-medium tabular-nums">{count}</span>
@@ -749,18 +749,18 @@ export default function AdminStoragePage() {
 
               {/* Cache key list */}
               {cacheLoading ? (
-                <div className="rounded-xl bg-card p-4 space-y-2">
+                <div className="rounded-xl bg-secondary p-4 space-y-2">
                   <Skeleton className="h-4 w-24" />
                   <Skeleton className="h-12 w-full" />
                   <Skeleton className="h-12 w-full" />
                 </div>
               ) : cacheKeys.length === 0 ? (
-                <div className="rounded-xl bg-card p-8 text-center text-sm text-muted-foreground">
+                <div className="rounded-xl bg-secondary p-8 text-center text-sm text-muted-foreground">
                   No cached entries. Cache will be populated as users access
                   pricing, seasons, and leaderboards.
                 </div>
               ) : (
-                <div className="rounded-xl bg-card p-1 space-y-1 flex-1 lg:overflow-y-auto min-h-0">
+                <div className="rounded-xl bg-secondary p-1 space-y-1 flex-1 lg:overflow-y-auto min-h-0">
                   {cacheKeys.map((key) => {
                     const { type, description } = describeCacheKey(key);
                     const isDeleting = cacheDeletingKey === key;
@@ -789,7 +789,7 @@ export default function AdminStoragePage() {
                                 type === "Achievement" &&
                                   "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
                                 type === "Unknown" &&
-                                  "bg-card text-muted-foreground"
+                                  "bg-secondary text-muted-foreground"
                               )}
                             >
                               {type}

--- a/packages/web/src/app/(dashboard)/projects/page.tsx
+++ b/packages/web/src/app/(dashboard)/projects/page.tsx
@@ -262,7 +262,7 @@ function TagEditor({
             autoFocus
           />
           {suggestions.length > 0 && (
-            <div className="absolute left-0 top-full z-10 mt-1 rounded-md border border-border bg-card shadow-md">
+            <div className="absolute left-0 top-full z-10 mt-1 rounded-md border border-border bg-secondary shadow-md">
               {suggestions.slice(0, 5).map((s) => (
                 <button
                   key={s}

--- a/packages/web/src/app/leaderboard/achievements/page.tsx
+++ b/packages/web/src/app/leaderboard/achievements/page.tsx
@@ -384,7 +384,7 @@ function AchievementCard({ achievement, index, isExpanded, onToggle, onUserClick
     <div
       className={cn(
         "flex flex-col rounded-xl p-4 transition-all animate-fade-up",
-        isUnlocked ? "bg-card/80 hover:bg-card" : "bg-muted/30 hover:bg-muted/50",
+        isUnlocked ? "bg-secondary/80 hover:bg-card" : "bg-muted/30 hover:bg-muted/50",
         isExpanded && "ring-1 ring-border",
       )}
       style={{ animationDelay: `${Math.min(index * 30, 400)}ms` }}
@@ -535,7 +535,7 @@ interface SummaryBarProps {
 
 function SummaryBar({ totalUnlocked, totalAchievements, diamondCount, currentStreak }: SummaryBarProps) {
   return (
-    <div className="flex flex-wrap items-center gap-4 rounded-xl bg-card/50 p-4 text-sm animate-fade-up" style={{ animationDelay: "120ms" }}>
+    <div className="flex flex-wrap items-center gap-4 rounded-xl bg-secondary/50 p-4 text-sm animate-fade-up" style={{ animationDelay: "120ms" }}>
       <div className="flex items-center gap-2">
         <Trophy className="h-4 w-4 text-chart-6" strokeWidth={1.5} />
         <span className="font-medium">{totalUnlocked}</span>

--- a/packages/web/src/components/dashboard/achievement-panel.tsx
+++ b/packages/web/src/components/dashboard/achievement-panel.tsx
@@ -169,7 +169,7 @@ export function AchievementCard({ achievement, className }: AchievementCardProps
     <div
       className={cn(
         "flex items-center gap-3 rounded-xl p-3 transition-colors",
-        isUnlocked ? "bg-card/50 hover:bg-card" : "bg-muted/30",
+        isUnlocked ? "bg-secondary/50 hover:bg-card" : "bg-muted/30",
         className
       )}
     >

--- a/packages/web/src/components/dashboard/peak-hours-card.tsx
+++ b/packages/web/src/components/dashboard/peak-hours-card.tsx
@@ -49,7 +49,7 @@ export function PeakHoursCard({ slots, className }: PeakHoursCardProps) {
     >
       {/* Header */}
       <div className="mb-4 flex items-center gap-2">
-        <div className="rounded-md bg-card p-2 text-muted-foreground">
+        <div className="rounded-md bg-background p-2 text-muted-foreground">
           <Flame className="h-5 w-5" strokeWidth={1.5} />
         </div>
         <p className="text-xs md:text-sm text-muted-foreground">Peak Hours</p>

--- a/packages/web/src/components/dashboard/period-selector.tsx
+++ b/packages/web/src/components/dashboard/period-selector.tsx
@@ -27,7 +27,7 @@ export function PeriodSelector({ value, onChange }: PeriodSelectorProps) {
           className={cn(
             "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
             value === opt.value
-              ? "bg-card text-foreground shadow-sm"
+              ? "bg-secondary text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground"
           )}
         >

--- a/packages/web/src/components/dashboard/salary-estimator-card.tsx
+++ b/packages/web/src/components/dashboard/salary-estimator-card.tsx
@@ -154,7 +154,7 @@ function SalaryEstimatorCard({
       {/* Header */}
       <div className="mb-4 flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
-          <div className="rounded-md bg-card p-2 text-primary">
+          <div className="rounded-md bg-background p-2 text-primary">
             <Banknote className="h-4 w-4" strokeWidth={1.5} />
           </div>
           <div>
@@ -432,7 +432,7 @@ function SalaryDisplay({
     <div
       className={cn(
         "rounded-lg p-3 text-center",
-        highlight ? "bg-card" : "bg-muted/30"
+        highlight ? "bg-secondary" : "bg-muted/30"
       )}
     >
       <p className="text-[10px] uppercase tracking-wider text-muted-foreground">

--- a/packages/web/src/components/dashboard/stat-card.tsx
+++ b/packages/web/src/components/dashboard/stat-card.tsx
@@ -138,7 +138,7 @@ export function StatCard({
           {/* Right: icon */}
           {Icon && (
             <div className="hidden md:flex md:items-start md:shrink-0">
-              <div className={cn("rounded-md bg-card p-2", iconColor)}>
+              <div className={cn("rounded-md bg-background p-2", iconColor)}>
                 <Icon className={cn(isPrimary ? "h-6 w-6" : "h-5 w-5")} strokeWidth={1.5} />
               </div>
             </div>
@@ -147,7 +147,7 @@ export function StatCard({
           <div className="md:hidden mt-3 flex items-start justify-between">
             <div className="flex-1">{TrendsContent}</div>
             {Icon && (
-              <div className={cn("rounded-md bg-card p-2 shrink-0", iconColor)}>
+              <div className={cn("rounded-md bg-background p-2 shrink-0", iconColor)}>
                 <Icon className={cn(isPrimary ? "h-6 w-6" : "h-5 w-5")} strokeWidth={1.5} />
               </div>
             )}
@@ -179,7 +179,7 @@ export function StatCard({
               )}
             </div>
             {Icon && (
-              <div className={cn("rounded-md bg-card p-2", iconColor)}>
+              <div className={cn("rounded-md bg-background p-2", iconColor)}>
                 <Icon className={cn(isPrimary ? "h-6 w-6" : "h-5 w-5")} strokeWidth={1.5} />
               </div>
             )}

--- a/packages/web/src/components/dashboard/top-achievement.tsx
+++ b/packages/web/src/components/dashboard/top-achievement.tsx
@@ -204,7 +204,7 @@ export function TopAchievement({
           return (
             <div
               key={ach.id}
-              className="flex items-center gap-3 rounded-xl bg-card/50 p-3"
+              className="flex items-center gap-3 rounded-xl bg-secondary/50 p-3"
             >
               {/* Icon */}
               <div className={cn(

--- a/packages/web/src/components/leaderboard/period-tabs.tsx
+++ b/packages/web/src/components/leaderboard/period-tabs.tsx
@@ -41,7 +41,7 @@ export function PeriodTabs({
           className={cn(
             "flex-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
             value === p.value
-              ? "bg-card text-foreground shadow-sm"
+              ? "bg-secondary text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground",
           )}
         >

--- a/packages/web/src/components/profile/profile-achievements.tsx
+++ b/packages/web/src/components/profile/profile-achievements.tsx
@@ -186,7 +186,7 @@ function AchievementCard({ achievement }: { achievement: UserAchievement }) {
     <div
       className={cn(
         "flex items-center gap-3 rounded-lg p-3 transition-colors",
-        isUnlocked ? "bg-card/60" : "bg-muted/20"
+        isUnlocked ? "bg-secondary/60" : "bg-muted/20"
       )}
     >
       <AchievementRing

--- a/packages/web/src/components/profile/profile-content.tsx
+++ b/packages/web/src/components/profile/profile-content.tsx
@@ -204,7 +204,7 @@ export function ProfileContent({
               className={cn(
                 "flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                 tab === t.id
-                  ? "bg-card text-foreground shadow-sm"
+                  ? "bg-secondary text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground",
               )}
             >


### PR DESCRIPTION
Closes #109\n\nReplace misused bg-card (L1) with bg-secondary (L2) for content cards inside the floating island, per Basalt B05 spec.