### PR TITLE
fix(security): sanitize D1 error messages in worker responses

### DIFF
--- a/packages/worker-read/src/index.ts
+++ b/packages/worker-read/src/index.ts
@@ -217,8 +217,8 @@ async function handleLive(env: Env): Promise<Response> {
     await env.DB.prepare("SELECT 1 AS probe").first();
     database = { connected: true };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    database = { connected: false, error: msg.replace(/\bok\b/gi, "***") };
+    console.error(err);
+    database = { connected: false, error: "Internal server error" };
   }
 
   const healthy = database.connected;
@@ -266,9 +266,9 @@ async function handleQuery(body: unknown, env: Env): Promise<Response> {
       meta: result.meta ?? { changes: 0, duration: 0 },
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    console.error(err);
     return Response.json(
-      { error: `D1 query failed: ${message}` },
+      { error: "Internal server error" },
       { status: 500 },
     );
   }
@@ -359,9 +359,9 @@ async function handleRpc(body: unknown, env: Env): Promise<Response> {
         );
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    console.error(err);
     return Response.json(
-      { error: `RPC failed: ${message}` },
+      { error: "Internal server error" },
       { status: 500 },
     );
   }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -155,8 +155,8 @@ async function handleLive(env: Env): Promise<Response> {
     await env.DB.prepare("SELECT 1 AS probe").first();
     database = { connected: true };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    database = { connected: false, error: msg.replace(/\bok\b/gi, "***") };
+    console.error(err);
+    database = { connected: false, error: "Internal server error" };
   }
 
   const healthy = database.connected;
@@ -195,8 +195,8 @@ async function handleTokenIngest(body: unknown, env: Env): Promise<Response> {
 
     return Response.json({ ingested: records.length });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return Response.json({ error: `D1 batch failed: ${message}` }, { status: 500 });
+    console.error(err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
@@ -231,8 +231,8 @@ async function handleSessionIngest(body: unknown, env: Env): Promise<Response> {
 
     return Response.json({ ingested: records.length });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return Response.json({ error: `D1 batch failed: ${message}` }, { status: 500 });
+    console.error(err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 


### PR DESCRIPTION
Closes #111

## Changes
- Replace D1/SQLite error message exposure with generic `"Internal server error"` in both worker and worker-read
- Add `console.error(err)` for server-side logging
- HTTP status codes preserved

## Severity: HIGH