### PR TITLE
fix(security): remove user input reflection in error messages

### DIFF
--- a/packages/web/src/app/api/achievements/[id]/members/route.ts
+++ b/packages/web/src/app/api/achievements/[id]/members/route.ts
@@ -571,7 +571,7 @@ export async function GET(
   const def = getAchievementDef(id);
   if (!def) {
     return NextResponse.json(
-      { error: `Achievement not found: ${id}` },
+      { error: "Achievement not found" },
       { status: 404 },
     );
   }
@@ -579,7 +579,7 @@ export async function GET(
   // Timezone-dependent achievements have no social features
   if (TIMEZONE_DEPENDANT_IDS.has(id)) {
     return NextResponse.json(
-      { error: `Achievement "${id}" is timezone-dependent and has no social features` },
+      { error: "Achievement is timezone-dependent and has no social features" },
       { status: 404 },
     );
   }

--- a/packages/web/src/app/api/leaderboard/route.ts
+++ b/packages/web/src/app/api/leaderboard/route.ts
@@ -78,7 +78,7 @@ export async function GET(request: Request) {
   // Validate period
   if (!VALID_PERIODS.has(period)) {
     return NextResponse.json(
-      { error: `Invalid period: "${period}". Use week, month, or all.` },
+      { error: "Invalid period parameter. Use week, month, or all." },
       { status: 400 },
     );
   }
@@ -102,7 +102,7 @@ export async function GET(request: Request) {
   // Validate source filter
   if (sourceFilter && !VALID_SOURCES.has(sourceFilter)) {
     return NextResponse.json(
-      { error: `Invalid source: "${sourceFilter}"` },
+      { error: "Invalid source parameter" },
       { status: 400 },
     );
   }

--- a/packages/web/src/app/api/projects/[id]/route.ts
+++ b/packages/web/src/app/api/projects/[id]/route.ts
@@ -79,7 +79,7 @@ function validateAliases(
       };
     }
     if (!VALID_SOURCES.has(alias.source)) {
-      return { valid: [], error: `Invalid source: "${alias.source}"` };
+      return { valid: [], error: "Invalid source parameter" };
     }
     result.push({ source: alias.source, project_ref: alias.project_ref });
   }
@@ -145,7 +145,7 @@ export async function PATCH(
     // Check reserved names
     if (RESERVED_NAMES.has(trimmedName.toLowerCase())) {
       return NextResponse.json(
-        { error: `"${trimmedName}" is a reserved name and cannot be used` },
+        { error: "This name is reserved and cannot be used" },
         { status: 400 },
       );
     }
@@ -218,7 +218,7 @@ export async function PATCH(
       if (taken && taken.project_id !== projectId) {
         return NextResponse.json(
           {
-            error: `Alias (${alias.source}, ${alias.project_ref}) is already assigned to another project`,
+            error: "Alias is already assigned to another project",
           },
           { status: 409 },
         );
@@ -301,7 +301,7 @@ export async function PATCH(
       if (!TAG_REGEX.test(normalized)) {
         return NextResponse.json(
           {
-            error: `Invalid tag "${tag}": must be 1-30 chars, lowercase alphanumeric + hyphens`,
+            error: "Invalid tag: must be 1-30 chars, lowercase alphanumeric + hyphens",
           },
           { status: 400 },
         );

--- a/packages/web/src/app/api/projects/route.ts
+++ b/packages/web/src/app/api/projects/route.ts
@@ -237,7 +237,7 @@ export async function POST(request: Request) {
       }
       if (!VALID_SOURCES.has(alias.source)) {
         return NextResponse.json(
-          { error: `Invalid source: "${alias.source}"` },
+          { error: "Invalid source parameter" },
           { status: 400 },
         );
       }
@@ -263,7 +263,7 @@ export async function POST(request: Request) {
   // Check reserved names
   if (RESERVED_NAMES.has(trimmedName.toLowerCase())) {
     return NextResponse.json(
-      { error: `"${trimmedName}" is a reserved name and cannot be used` },
+      { error: "This name is reserved and cannot be used" },
       { status: 400 },
     );
   }
@@ -314,7 +314,7 @@ export async function POST(request: Request) {
       if (taken) {
         return NextResponse.json(
           {
-            error: `Alias (${alias.source}, ${alias.project_ref}) is already assigned to another project`,
+            error: "Alias is already assigned to another project",
           },
           { status: 409 },
         );

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -58,7 +58,7 @@ export async function GET(request: Request) {
   // Validate source filter
   if (sourceFilter && !VALID_SOURCES.has(sourceFilter)) {
     return NextResponse.json(
-      { error: `Invalid source: "${sourceFilter}"` },
+      { error: "Invalid source parameter" },
       { status: 400 },
     );
   }
@@ -66,7 +66,7 @@ export async function GET(request: Request) {
   // Validate kind filter
   if (kindFilter && !VALID_KINDS.has(kindFilter)) {
     return NextResponse.json(
-      { error: `Invalid kind: "${kindFilter}"` },
+      { error: "Invalid kind parameter" },
       { status: 400 },
     );
   }

--- a/packages/web/src/app/api/usage/route.ts
+++ b/packages/web/src/app/api/usage/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: Request) {
   // Validate source filter
   if (sourceFilter && !VALID_SOURCES.has(sourceFilter)) {
     return NextResponse.json(
-      { error: `Invalid source: "${sourceFilter}"` },
+      { error: "Invalid source parameter" },
       { status: 400 }
     );
   }
@@ -70,7 +70,7 @@ export async function GET(request: Request) {
   // Validate granularity
   if (!VALID_GRANULARITIES.has(granularity)) {
     return NextResponse.json(
-      { error: `Invalid granularity: "${granularity}"` },
+      { error: "Invalid granularity parameter" },
       { status: 400 }
     );
   }

--- a/packages/web/src/app/api/users/[slug]/route.ts
+++ b/packages/web/src/app/api/users/[slug]/route.ts
@@ -162,7 +162,7 @@ export async function GET(
 
   if (sourceFilter && !VALID_SOURCES.has(sourceFilter)) {
     return NextResponse.json(
-      { error: `Invalid source: "${sourceFilter}"` },
+      { error: "Invalid source parameter" },
       { status: 400 },
     );
   }


### PR DESCRIPTION
Closes #115

## Changes
- Remove `${variable}` interpolation from error response messages across 7 files
- Replace with static descriptive error strings

## Severity: LOW