### PR TITLE
fix(security): strengthen E2E auth bypass guard

### DIFF
--- a/packages/web/src/__tests__/auth-helpers.test.ts
+++ b/packages/web/src/__tests__/auth-helpers.test.ts
@@ -52,6 +52,8 @@ describe("resolveUser", () => {
     vi.unstubAllEnvs();
     // Default: not in E2E mode
     delete process.env.E2E_SKIP_AUTH;
+    // Ensure production-only guard is not set during tests
+    delete process.env.RAILWAY_ENVIRONMENT;
   });
 
   afterEach(() => {
@@ -96,6 +98,22 @@ describe("resolveUser", () => {
 
       expect(result).toBeNull();
       expect(auth).toHaveBeenCalled();
+    });
+
+    it("should NOT bypass when RAILWAY_ENVIRONMENT is set (production guard)", async () => {
+      process.env.E2E_SKIP_AUTH = "true";
+      vi.stubEnv("NODE_ENV", "development");
+      process.env.RAILWAY_ENVIRONMENT = "production";
+      auth.mockResolvedValueOnce(null);
+
+      try {
+        const result = await resolveUser(makeRequest());
+
+        expect(result).toBeNull();
+        expect(auth).toHaveBeenCalled();
+      } finally {
+        delete process.env.RAILWAY_ENVIRONMENT;
+      }
     });
   });
 

--- a/packages/web/src/__tests__/auth-invite-gate.test.ts
+++ b/packages/web/src/__tests__/auth-invite-gate.test.ts
@@ -53,6 +53,8 @@ describe("handleInviteGate", () => {
     vi.clearAllMocks();
     mockDbRead = createMockDbRead();
     mockDbWrite = createMockDbWrite();
+    // Ensure production-only guard is not set during tests
+    delete process.env.RAILWAY_ENVIRONMENT;
   });
 
   afterEach(() => {
@@ -221,6 +223,30 @@ describe("handleInviteGate", () => {
 
     // Should NOT have queried the database at all
     expect(vi.mocked(mockDbRead.firstOrNull)).not.toHaveBeenCalled();
+  });
+
+  it("should NOT skip check when RAILWAY_ENVIRONMENT is set (production guard)", async () => {
+    vi.stubEnv("E2E_SKIP_AUTH", "true");
+    vi.stubEnv("NODE_ENV", "test");
+    process.env.RAILWAY_ENVIRONMENT = "production";
+
+    // New user (no existing account)
+    vi.mocked(mockDbRead.firstOrNull).mockResolvedValueOnce(null);
+
+    try {
+      const result = await handleInviteGate(
+        makeReq(), // no invite cookie
+        GOOGLE_ACCOUNT,
+        mockDbRead,
+        mockDbWrite
+      );
+      // Bypass should NOT trigger; full invite-gate logic runs and rejects
+      expect(typeof result).toBe("string");
+      expect(result).toContain("/login?error=InviteRequired");
+      expect(vi.mocked(mockDbRead.firstOrNull)).toHaveBeenCalled();
+    } finally {
+      delete process.env.RAILWAY_ENVIRONMENT;
+    }
   });
 
   it("should handle req=undefined gracefully (Server Component safety)", async () => {

--- a/packages/web/src/lib/auth-helpers.ts
+++ b/packages/web/src/lib/auth-helpers.ts
@@ -64,6 +64,7 @@ export async function resolveUser(
 function isE2EMode(): boolean {
   return (
     process.env.E2E_SKIP_AUTH === "true" &&
-    process.env.NODE_ENV === "development"
+    process.env.NODE_ENV === "development" &&
+    !process.env.RAILWAY_ENVIRONMENT
   );
 }

--- a/packages/web/src/lib/invite.ts
+++ b/packages/web/src/lib/invite.ts
@@ -100,7 +100,8 @@ export async function handleInviteGate(
   // E2E test bypass
   if (
     process.env.E2E_SKIP_AUTH === "true" &&
-    process.env.NODE_ENV !== "production"
+    process.env.NODE_ENV !== "production" &&
+    !process.env.RAILWAY_ENVIRONMENT
   ) {
     return true;
   }


### PR DESCRIPTION
Closes #116

## Changes
- Add `!process.env.RAILWAY_ENVIRONMENT` guard to E2E bypass in auth-helpers.ts and invite.ts
- Even if E2E_SKIP_AUTH leaks to prod, RAILWAY_ENVIRONMENT blocks the bypass
- Tests updated

## Severity: MEDIUM