### PR TITLE
feat(security): add Next.js middleware for centralized route protection

### DIFF
--- a/packages/web/src/__tests__/middleware.test.ts
+++ b/packages/web/src/__tests__/middleware.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+
+import {
+  hasAuthCredentials,
+  isPublicApiRoute,
+  middleware,
+} from "@/middleware";
+
+function makeReq(
+  pathname: string,
+  init: { headers?: Record<string, string>; cookies?: Record<string, string> } = {},
+): NextRequest {
+  const url = `https://pew.example.com${pathname}`;
+  const req = new NextRequest(url, { headers: init.headers ?? {} });
+  if (init.cookies) {
+    for (const [name, value] of Object.entries(init.cookies)) {
+      req.cookies.set(name, value);
+    }
+  }
+  return req;
+}
+
+describe("isPublicApiRoute", () => {
+  it.each([
+    "/api/auth/signin",
+    "/api/auth/callback/google",
+    "/api/leaderboard",
+    "/api/leaderboard/season/foo",
+    "/api/live",
+    "/api/users/abc",
+    "/api/ingest",
+    "/api/health",
+  ])("treats %s as public", (path) => {
+    expect(isPublicApiRoute(path)).toBe(true);
+  });
+
+  it.each([
+    "/api/sessions",
+    "/api/admin/users",
+    "/api/account",
+    "/api/teams/123",
+    "/api/leaderboardx", // not a prefix match — must include `/` or end
+  ])("treats %s as protected", (path) => {
+    expect(isPublicApiRoute(path)).toBe(false);
+  });
+});
+
+describe("hasAuthCredentials", () => {
+  it("returns false when no cookie or auth header", () => {
+    expect(hasAuthCredentials(makeReq("/api/sessions"))).toBe(false);
+  });
+
+  it("returns true with insecure session cookie", () => {
+    const req = makeReq("/api/sessions", {
+      cookies: { "authjs.session-token": "abc" },
+    });
+    expect(hasAuthCredentials(req)).toBe(true);
+  });
+
+  it("returns true with __Secure- session cookie", () => {
+    const req = makeReq("/api/sessions", {
+      cookies: { "__Secure-authjs.session-token": "abc" },
+    });
+    expect(hasAuthCredentials(req)).toBe(true);
+  });
+
+  it("returns true with Bearer authorization header", () => {
+    const req = makeReq("/api/sessions", {
+      headers: { authorization: "Bearer some-token" },
+    });
+    expect(hasAuthCredentials(req)).toBe(true);
+  });
+
+  it("ignores non-Bearer authorization header", () => {
+    const req = makeReq("/api/sessions", {
+      headers: { authorization: "Basic dXNlcjpwYXNz" },
+    });
+    expect(hasAuthCredentials(req)).toBe(false);
+  });
+
+  it("ignores empty Bearer header", () => {
+    const req = makeReq("/api/sessions", {
+      headers: { authorization: "Bearer " },
+    });
+    expect(hasAuthCredentials(req)).toBe(false);
+  });
+});
+
+describe("middleware", () => {
+  it("allows public routes without credentials", () => {
+    const res = middleware(makeReq("/api/leaderboard"));
+    expect(res.status).toBe(200);
+  });
+
+  it("allows ingest without credentials (has its own API key)", () => {
+    const res = middleware(makeReq("/api/ingest"));
+    expect(res.status).toBe(200);
+  });
+
+  it("allows authed requests on protected routes", () => {
+    const res = middleware(
+      makeReq("/api/sessions", {
+        cookies: { "authjs.session-token": "abc" },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("allows Bearer-token requests on protected routes", () => {
+    const res = middleware(
+      makeReq("/api/admin/users", {
+        headers: { authorization: "Bearer xyz" },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 JSON on protected routes without credentials", async () => {
+    const res = middleware(makeReq("/api/sessions"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 401 on /api/admin without credentials", async () => {
+    const res = middleware(makeReq("/api/admin/users"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+});

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,0 +1,65 @@
+/**
+ * Next.js middleware — defense-in-depth auth pre-check for /api/* routes.
+ *
+ * This is a lightweight gate: it rejects requests that present neither a
+ * session cookie nor an `Authorization: Bearer` header. Individual routes
+ * still call `resolveUser()` for the actual user object — the middleware
+ * only prevents completely unauthenticated requests from reaching handlers.
+ *
+ * Public API routes (auth endpoints, leaderboard, live, public profiles,
+ * ingest, health) are whitelisted and skip the check.
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// Cookie names mirror the configuration in `auth.ts`.
+const SESSION_COOKIE_NAMES = [
+  "__Secure-authjs.session-token",
+  "authjs.session-token",
+] as const;
+
+// Patterns for routes that bypass the middleware auth check.
+// Anchored at the start; trailing `(.*)` accepts any sub-path.
+const PUBLIC_ROUTE_PATTERNS: readonly RegExp[] = [
+  /^\/api\/auth(\/.*)?$/,
+  /^\/api\/leaderboard(\/.*)?$/,
+  /^\/api\/live(\/.*)?$/,
+  /^\/api\/users(\/.*)?$/,
+  /^\/api\/ingest(\/.*)?$/,
+  /^\/api\/health(\/.*)?$/,
+];
+
+/** True when the path is whitelisted as public. Exported for testing. */
+export function isPublicApiRoute(pathname: string): boolean {
+  return PUBLIC_ROUTE_PATTERNS.some((re) => re.test(pathname));
+}
+
+/** True when the request carries a session cookie or Bearer token. Exported for testing. */
+export function hasAuthCredentials(req: NextRequest): boolean {
+  for (const name of SESSION_COOKIE_NAMES) {
+    const cookie = req.cookies.get(name);
+    if (cookie?.value) return true;
+  }
+  const authHeader = req.headers.get("authorization");
+  if (authHeader && /^Bearer\s+\S+/i.test(authHeader)) return true;
+  return false;
+}
+
+export function middleware(req: NextRequest): NextResponse {
+  const { pathname } = req.nextUrl;
+
+  if (isPublicApiRoute(pathname)) {
+    return NextResponse.next();
+  }
+
+  if (hasAuthCredentials(req)) {
+    return NextResponse.next();
+  }
+
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+export const config = {
+  matcher: ["/api/:path*"],
+};


### PR DESCRIPTION
Closes #117

## Changes
- New `middleware.ts` with deny-by-default for `/api/*`
- Whitelist for public routes (auth, leaderboard, live, users, ingest, health)
- Lightweight credential pre-check (session cookie or Bearer token)
- Tests added

## Severity: MEDIUM