### PR TITLE
fix(security): hash API keys before storing in D1

### DIFF
--- a/packages/web/src/__tests__/auth-code.test.ts
+++ b/packages/web/src/__tests__/auth-code.test.ts
@@ -321,7 +321,7 @@ describe("POST /api/auth/code/verify", () => {
     expect(body.error).toBe(AUTH_ERROR);
   });
 
-  it("should return api_key and email for valid code", async () => {
+  it("should issue a fresh hashed api_key for valid code", async () => {
     const mockDbRead = createMockDbRead();
     mockDbRead.getAuthCode.mockResolvedValue({
       code: "ABCD-1234",
@@ -337,7 +337,6 @@ describe("POST /api/auth/code/verify", () => {
       image: null,
       email_verified: null,
     });
-    mockDbRead.getUserApiKey.mockResolvedValue("pk_existing_key");
     mockGetDbRead.mockResolvedValue(mockDbRead as unknown as DbRead);
 
     const mockDbWrite = createMockDbWrite();
@@ -354,60 +353,33 @@ describe("POST /api/auth/code/verify", () => {
     expect(response.status).toBe(200);
 
     const body = await response.json();
-    expect(body.api_key).toBe("pk_existing_key");
-    expect(body.email).toBe("test@example.com");
-
-    // Verify code was marked as used AFTER user lookup succeeded
-    expect(mockDbWrite.execute).toHaveBeenCalledWith(
-      expect.stringContaining("SET used_at"),
-      expect.arrayContaining(["ABCD-1234"])
-    );
-  });
-
-  it("should generate api_key if user has none (atomic conditional update)", async () => {
-    const mockDbRead = createMockDbRead();
-    mockDbRead.getAuthCode.mockResolvedValue({
-      code: "ABCD-1234",
-      user_id: "user-123",
-      expires_at: new Date(Date.now() + 300_000).toISOString(),
-      used_at: null,
-      failed_attempts: 0,
-    });
-    mockDbRead.getUserById.mockResolvedValue({
-      id: "user-123",
-      email: "test@example.com",
-      name: null,
-      image: null,
-      email_verified: null,
-    });
-    mockDbRead.getUserApiKey.mockResolvedValue(null); // No existing key
-    mockGetDbRead.mockResolvedValue(mockDbRead as unknown as DbRead);
-
-    const mockDbWrite = createMockDbWrite();
-    mockDbWrite.execute.mockResolvedValue({ changes: 1 });
-    mockGetDbWrite.mockResolvedValue(mockDbWrite as unknown as DbWrite);
-
-    const request = new Request("http://localhost/api/auth/code/verify", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ code: "ABCD-1234" }),
-    });
-
-    const response = await verifyPOST(request);
-    expect(response.status).toBe(200);
-
-    const body = await response.json();
+    // Plain key returned exactly once.
     expect(body.api_key).toMatch(/^pk_[a-f0-9]{32}$/);
     expect(body.email).toBe("test@example.com");
 
-    // Verify api_key update uses conditional WHERE api_key IS NULL
+    // The DB only ever sees the SHA-256 hash + first-8-char prefix.
+    const writes = mockDbWrite.execute.mock.calls;
+    const userUpdate = writes.find((c) =>
+      String(c[0]).includes("api_key_hash"),
+    );
+    expect(userUpdate).toBeDefined();
+    const [, params] = userUpdate as [string, unknown[]];
+    const [hashParam, prefixParam, idParam] = params as [string, string, string];
+    // Hash is 64-hex SHA-256 of the plain key returned to the caller.
+    expect(hashParam).toHaveLength(64);
+    expect(hashParam).toMatch(/^[a-f0-9]{64}$/);
+    expect(hashParam).not.toBe(body.api_key);
+    expect(prefixParam).toBe((body.api_key as string).slice(0, 8));
+    expect(idParam).toBe("user-123");
+
+    // Code marked used after credential update.
     expect(mockDbWrite.execute).toHaveBeenCalledWith(
-      expect.stringContaining("WHERE id = ? AND api_key IS NULL"),
-      expect.arrayContaining([expect.stringMatching(/^pk_/), "user-123"])
+      expect.stringContaining("SET used_at"),
+      expect.arrayContaining(["ABCD-1234"]),
     );
   });
 
-  it("should re-read api_key if another request set it concurrently", async () => {
+  it("should rotate the key on every successful verify", async () => {
     const mockDbRead = createMockDbRead();
     mockDbRead.getAuthCode.mockResolvedValue({
       code: "ABCD-1234",
@@ -423,30 +395,28 @@ describe("POST /api/auth/code/verify", () => {
       image: null,
       email_verified: null,
     });
-    mockDbRead.getUserApiKey
-      .mockResolvedValueOnce(null) // No existing key on first read
-      .mockResolvedValueOnce("pk_set_by_other_request"); // Another request already set it
     mockGetDbRead.mockResolvedValue(mockDbRead as unknown as DbRead);
 
-    // First UPDATE (api_key) returns 0 changes (lost race), second UPDATE (used_at) succeeds
     const mockDbWrite = createMockDbWrite();
-    mockDbWrite.execute
-      .mockResolvedValueOnce({ changes: 0 }) // Lost the race to set api_key
-      .mockResolvedValueOnce({ changes: 1 }); // Successfully consumed code
+    mockDbWrite.execute.mockResolvedValue({ changes: 1 });
     mockGetDbWrite.mockResolvedValue(mockDbWrite as unknown as DbWrite);
 
-    const request = new Request("http://localhost/api/auth/code/verify", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ code: "ABCD-1234" }),
-    });
+    const makeReq = () =>
+      new Request("http://localhost/api/auth/code/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "ABCD-1234" }),
+      });
 
-    const response = await verifyPOST(request);
-    expect(response.status).toBe(200);
+    const r1 = await verifyPOST(makeReq());
+    const r2 = await verifyPOST(makeReq());
+    const b1 = await r1.json();
+    const b2 = await r2.json();
 
-    const body = await response.json();
-    // Should return the key set by the other request, not our generated one
-    expect(body.api_key).toBe("pk_set_by_other_request");
+    // Each call mints an independent random key — they MUST differ.
+    expect(b1.api_key).not.toBe(b2.api_key);
+    expect(b1.api_key).toMatch(/^pk_[a-f0-9]{32}$/);
+    expect(b2.api_key).toMatch(/^pk_[a-f0-9]{32}$/);
   });
 
   it("should normalize code format (accept without hyphen)", async () => {
@@ -465,7 +435,6 @@ describe("POST /api/auth/code/verify", () => {
       image: null,
       email_verified: null,
     });
-    mockDbRead.getUserApiKey.mockResolvedValue("pk_test");
     mockGetDbRead.mockResolvedValue(mockDbRead as unknown as DbRead);
 
     const mockDbWrite = createMockDbWrite();
@@ -501,7 +470,6 @@ describe("POST /api/auth/code/verify", () => {
       image: null,
       email_verified: null,
     });
-    mockDbRead.getUserApiKey.mockResolvedValue("pk_existing");
     mockGetDbRead.mockResolvedValue(mockDbRead as unknown as DbRead);
 
     // Simulate race: SET used_at returns 0 rows (someone else used it first)

--- a/packages/web/src/__tests__/auth-helpers.test.ts
+++ b/packages/web/src/__tests__/auth-helpers.test.ts
@@ -31,6 +31,14 @@ import { createMockClient } from "./test-utils";
 // Helpers
 // ---------------------------------------------------------------------------
 
+async function sha256Hex(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const hash = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 function makeRequest(token?: string): Request {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (token) {
@@ -144,7 +152,7 @@ describe("resolveUser", () => {
       auth.mockResolvedValueOnce(null);
 
       const mockClient = createMockClient();
-      mockClient.getUserByApiKey.mockResolvedValueOnce({
+      mockClient.getUserByApiKeyHash.mockResolvedValueOnce({
         id: "u-api-key-1",
         email: "api@example.com",
       });
@@ -168,7 +176,7 @@ describe("resolveUser", () => {
 
     it("should resolve user from valid API key", async () => {
       const mockClient = createMockClient();
-      mockClient.getUserByApiKey.mockResolvedValueOnce({
+      mockClient.getUserByApiKeyHash.mockResolvedValueOnce({
         id: "u-api-1",
         email: "apiuser@example.com",
       });
@@ -180,12 +188,14 @@ describe("resolveUser", () => {
         userId: "u-api-1",
         email: "apiuser@example.com",
       });
-      expect(mockClient.getUserByApiKey).toHaveBeenCalledWith("pk_test_key_123");
+      // The plain key is hashed before lookup; the DB never sees it.
+      const expectedHash = await sha256Hex("pk_test_key_123");
+      expect(mockClient.getUserByApiKeyHash).toHaveBeenCalledWith(expectedHash);
     });
 
     it("should return null for invalid API key (no DB match)", async () => {
       const mockClient = createMockClient();
-      mockClient.getUserByApiKey.mockResolvedValueOnce(null);
+      mockClient.getUserByApiKeyHash.mockResolvedValueOnce(null);
       getDbRead.mockResolvedValueOnce(mockClient);
 
       const result = await resolveUser(makeRequest("pk_bad_key"));

--- a/packages/web/src/__tests__/cli-auth.test.ts
+++ b/packages/web/src/__tests__/cli-auth.test.ts
@@ -196,7 +196,7 @@ describe("GET /api/auth/cli", () => {
     });
 
     it("should accept localhost callback URLs", async () => {
-      mockDbRead.getUserApiKey.mockResolvedValueOnce("existing-key-123");
+      mockDbWrite.execute.mockResolvedValueOnce(undefined);
 
       const res = await GET(
         makeRequest("http://localhost:9999/callback")
@@ -205,11 +205,11 @@ describe("GET /api/auth/cli", () => {
       expect(res.status).toBe(307);
       const location = res.headers.get("Location")!;
       expect(location).toContain("localhost:9999");
-      expect(location).toContain("api_key=existing-key-123");
+      expect(location).toMatch(/api_key=pk_[a-f0-9]{32}/);
     });
 
     it("should accept 127.0.0.1 callback URLs", async () => {
-      mockDbRead.getUserApiKey.mockResolvedValueOnce("existing-key-456");
+      mockDbWrite.execute.mockResolvedValueOnce(undefined);
 
       const res = await GET(
         makeRequest("http://127.0.0.1:8888/callback")
@@ -229,22 +229,7 @@ describe("GET /api/auth/cli", () => {
       });
     });
 
-    it("should reuse existing api_key if user already has one", async () => {
-      mockDbRead.getUserApiKey.mockResolvedValueOnce("existing-key-abc");
-
-      const res = await GET(
-        makeRequest("http://localhost:9999/callback")
-      );
-
-      expect(res.status).toBe(307);
-      const location = res.headers.get("Location")!;
-      expect(location).toContain("api_key=existing-key-abc");
-      // Should NOT have called execute to generate a new key
-      expect(mockDbWrite.execute).not.toHaveBeenCalled();
-    });
-
-    it("should generate new api_key if user has none", async () => {
-      mockDbRead.getUserApiKey.mockResolvedValueOnce(null);
+    it("should always mint a fresh api_key (plain keys are never stored)", async () => {
       mockDbWrite.execute.mockResolvedValueOnce(undefined);
 
       const res = await GET(
@@ -253,12 +238,30 @@ describe("GET /api/auth/cli", () => {
 
       expect(res.status).toBe(307);
       const location = res.headers.get("Location")!;
-      expect(location).toContain("api_key=");
-      // Should have called execute to save new key
+      const url = new URL(location);
+      const apiKey = url.searchParams.get("api_key")!;
+      expect(apiKey).toMatch(/^pk_[a-f0-9]{32}$/);
+
+      // Persists only the SHA-256 hash + display prefix.
       expect(mockDbWrite.execute).toHaveBeenCalledOnce();
-      expect(mockDbWrite.execute.mock.calls[0]![0]).toContain(
-        "UPDATE users SET api_key"
-      );
+      const [sql, params] = mockDbWrite.execute.mock.calls[0]!;
+      expect(sql).toContain("api_key_hash");
+      expect(sql).toContain("api_key_prefix");
+      expect(sql).not.toMatch(/\bapi_key\b\s*=/);
+      const [hashParam, prefixParam] = params as [string, string, string];
+      expect(hashParam).toMatch(/^[a-f0-9]{64}$/);
+      expect(hashParam).not.toBe(apiKey);
+      expect(prefixParam).toBe(apiKey.slice(0, 8));
+    });
+
+    it("should rotate the key on every call", async () => {
+      mockDbWrite.execute.mockResolvedValue(undefined);
+
+      const r1 = await GET(makeRequest("http://localhost:9999/callback"));
+      const r2 = await GET(makeRequest("http://localhost:9999/callback"));
+      const k1 = new URL(r1.headers.get("Location")!).searchParams.get("api_key");
+      const k2 = new URL(r2.headers.get("Location")!).searchParams.get("api_key");
+      expect(k1).not.toBe(k2);
     });
 
     it("should include email in callback redirect", async () => {
@@ -266,7 +269,7 @@ describe("GET /api/auth/cli", () => {
         userId: "u1",
         email: "test@example.com",
       });
-      mockDbRead.getUserApiKey.mockResolvedValueOnce("key-xyz");
+      mockDbWrite.execute.mockResolvedValueOnce(undefined);
 
       const res = await GET(
         makeRequest("http://localhost:9999/callback")
@@ -277,7 +280,7 @@ describe("GET /api/auth/cli", () => {
     });
 
     it("should forward state parameter in callback redirect", async () => {
-      mockDbRead.getUserApiKey.mockResolvedValueOnce("key-xyz");
+      mockDbWrite.execute.mockResolvedValueOnce(undefined);
 
       const res = await GET(
         makeRequest("http://localhost:9999/callback", "my-nonce-123")
@@ -286,11 +289,11 @@ describe("GET /api/auth/cli", () => {
       expect(res.status).toBe(307);
       const location = res.headers.get("Location")!;
       expect(location).toContain("state=my-nonce-123");
-      expect(location).toContain("api_key=key-xyz");
+      expect(location).toMatch(/api_key=pk_[a-f0-9]{32}/);
     });
 
     it("should omit state from redirect when not provided", async () => {
-      mockDbRead.getUserApiKey.mockResolvedValueOnce("key-xyz");
+      mockDbWrite.execute.mockResolvedValueOnce(undefined);
 
       const res = await GET(
         makeRequest("http://localhost:9999/callback")
@@ -302,7 +305,7 @@ describe("GET /api/auth/cli", () => {
     });
 
     it("should return 500 on D1 failure", async () => {
-      mockDbRead.getUserApiKey.mockRejectedValueOnce(new Error("D1 down"));
+      mockDbWrite.execute.mockRejectedValueOnce(new Error("D1 down"));
 
       const res = await GET(
         makeRequest("http://localhost:9999/callback")

--- a/packages/web/src/__tests__/e2e/api-e2e.test.ts
+++ b/packages/web/src/__tests__/e2e/api-e2e.test.ts
@@ -399,7 +399,9 @@ describe("GET /api/auth/cli", () => {
     expect(email).toBe(TEST_USER_EMAIL);
   });
 
-  it("should return same api_key on subsequent calls", async () => {
+  it("should mint a fresh api_key on every call (rotation by design)", async () => {
+    // Plain keys are never persisted, so the route cannot reuse a previous
+    // value — each browser login rotates to a brand-new key.
     const callback = "http://localhost:19876/callback";
     const res1 = await fetch(
       `${BASE_URL}/api/auth/cli?callback=${encodeURIComponent(callback)}`,
@@ -413,9 +415,11 @@ describe("GET /api/auth/cli", () => {
     const url1 = new URL(res1.headers.get("Location")!);
     const url2 = new URL(res2.headers.get("Location")!);
 
-    expect(url1.searchParams.get("api_key")).toBe(
-      url2.searchParams.get("api_key"),
-    );
+    const k1 = url1.searchParams.get("api_key");
+    const k2 = url2.searchParams.get("api_key");
+    expect(k1).toMatch(/^pk_[a-f0-9]{32}$/);
+    expect(k2).toMatch(/^pk_[a-f0-9]{32}$/);
+    expect(k1).not.toBe(k2);
   });
 });
 

--- a/packages/web/src/__tests__/test-utils.ts
+++ b/packages/web/src/__tests__/test-utils.ts
@@ -26,11 +26,11 @@ export function createMockDbRead() {
     getUserById: vi.fn(),
     getUserBySlug: vi.fn(),
     getUserByEmail: vi.fn(),
-    getUserByApiKey: vi.fn(),
+    getUserByApiKeyHash: vi.fn(),
     getUserByOAuthAccount: vi.fn(),
     checkSlugExists: vi.fn(),
     getUserSettings: vi.fn(),
-    getUserApiKey: vi.fn(),
+    getUserApiKeyPrefix: vi.fn(),
     getUserEmail: vi.fn(),
     searchUsers: vi.fn(),
     getUserSlugOnly: vi.fn(),
@@ -155,11 +155,11 @@ export function createMockDbRead() {
     getUserById: ReturnType<typeof vi.fn>;
     getUserBySlug: ReturnType<typeof vi.fn>;
     getUserByEmail: ReturnType<typeof vi.fn>;
-    getUserByApiKey: ReturnType<typeof vi.fn>;
+    getUserByApiKeyHash: ReturnType<typeof vi.fn>;
     getUserByOAuthAccount: ReturnType<typeof vi.fn>;
     checkSlugExists: ReturnType<typeof vi.fn>;
     getUserSettings: ReturnType<typeof vi.fn>;
-    getUserApiKey: ReturnType<typeof vi.fn>;
+    getUserApiKeyPrefix: ReturnType<typeof vi.fn>;
     getUserEmail: ReturnType<typeof vi.fn>;
     searchUsers: ReturnType<typeof vi.fn>;
     getUserSlugOnly: ReturnType<typeof vi.fn>;
@@ -291,11 +291,11 @@ export function createMockClient() {
     getUserById: vi.fn(),
     getUserBySlug: vi.fn(),
     getUserByEmail: vi.fn(),
-    getUserByApiKey: vi.fn(),
+    getUserByApiKeyHash: vi.fn(),
     getUserByOAuthAccount: vi.fn(),
     checkSlugExists: vi.fn(),
     getUserSettings: vi.fn(),
-    getUserApiKey: vi.fn(),
+    getUserApiKeyPrefix: vi.fn(),
     getUserEmail: vi.fn(),
     searchUsers: vi.fn(),
     getUserSlugOnly: vi.fn(),

--- a/packages/web/src/app/api/auth/cli/route.ts
+++ b/packages/web/src/app/api/auth/cli/route.ts
@@ -4,15 +4,21 @@
  * Flow:
  * 1. CLI starts local HTTP server, opens browser to this URL with ?callback=...
  * 2. User is already signed in via Google OAuth (or redirected to /login first)
- * 3. This endpoint fetches/generates user's api_key
+ * 3. This endpoint mints a new api_key for the user
  * 4. Redirects back to CLI's local server with api_key + email in query params
+ *
+ * Storage: only the SHA-256 hash and a short display prefix of the key are
+ * persisted. The plain key is returned to the CLI exactly once via the
+ * redirect query string and never stored — so each browser-based login
+ * issues a fresh key, transparently rotating any previous one.
  *
  * Security: callback URL must be localhost or 127.0.0.1.
  */
 
 import { NextResponse } from "next/server";
 import { resolveUser } from "@/lib/auth-helpers";
-import { getDbRead, getDbWrite } from "@/lib/db";
+import { getDbWrite } from "@/lib/db";
+import { generateApiKey, hashApiKey, apiKeyPrefix } from "@/lib/api-key";
 
 /**
  * Resolve the public-facing origin.
@@ -76,23 +82,23 @@ export async function GET(request: Request) {
     );
   }
 
-  // 3. Get or generate api_key
-  const dbRead = await getDbRead();
+  // 3. Mint a fresh api_key. Plain keys are never persisted, so we cannot
+  // return a previously-issued key — each browser login rotates it.
   const dbWrite = await getDbWrite();
   const userId = authResult.userId;
   const email = authResult.email ?? "";
 
   try {
-    let apiKey = await dbRead.getUserApiKey(userId);
+    const apiKey = generateApiKey();
+    const apiKeyHash = await hashApiKey(apiKey);
+    const apiKeyPrefixValue = apiKeyPrefix(apiKey);
 
-    if (!apiKey) {
-      // Generate a new api_key
-      apiKey = generateApiKey();
-      await dbWrite.execute(
-        "UPDATE users SET api_key = ?, updated_at = datetime('now') WHERE id = ?",
-        [apiKey, userId]
-      );
-    }
+    await dbWrite.execute(
+      `UPDATE users
+       SET api_key_hash = ?, api_key_prefix = ?, updated_at = datetime('now')
+       WHERE id = ?`,
+      [apiKeyHash, apiKeyPrefixValue, userId]
+    );
 
     // 4. Redirect back to CLI with api_key + state
     const redirectUrl = new URL(callbackUrl.toString());
@@ -110,14 +116,4 @@ export async function GET(request: Request) {
       { status: 500 }
     );
   }
-}
-
-/** Generate a random API key: pk_ prefix + 32 hex chars */
-function generateApiKey(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
-    ""
-  );
-  return `pk_${hex}`;
 }

--- a/packages/web/src/app/api/auth/code/verify/route.ts
+++ b/packages/web/src/app/api/auth/code/verify/route.ts
@@ -8,23 +8,19 @@
  * invalidates it (failed_attempts > 0). Error messages are intentionally
  * generic to avoid leaking information about code existence.
  *
+ * Storage: only the SHA-256 hash and a short prefix of the key are persisted
+ * (`api_key_hash`, `api_key_prefix`). The plain key is returned to the user
+ * exactly once at this point and never stored.
+ *
  * No session required — the code itself is the authentication.
  */
 
 import { NextResponse } from "next/server";
 import { getDbRead, getDbWrite } from "@/lib/db";
+import { generateApiKey, hashApiKey, apiKeyPrefix } from "@/lib/api-key";
 
 // Generic error message for all auth failures (avoids information leakage)
 const AUTH_ERROR = "Invalid or expired code";
-
-
-/** Generate a random API key: pk_ prefix + 32 hex chars */
-function generateApiKey(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-  return `pk_${hex}`;
-}
 
 export async function POST(request: Request) {
   // 1. Parse and validate request body
@@ -78,8 +74,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: AUTH_ERROR }, { status: 401 });
     }
 
-    // 4. Get user info and api_key BEFORE consuming the code
-    // This ensures that if user lookup or api_key generation fails, the code remains usable
+    // 4. Get user info BEFORE consuming the code
+    // This ensures that if user lookup fails, the code remains usable.
     const user = await dbRead.getUserById(authCode.user_id);
 
     if (!user) {
@@ -88,34 +84,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "User not found" }, { status: 500 });
     }
 
-    let apiKey = await dbRead.getUserApiKey(user.id);
-
-    // 5. Generate api_key if not exists using atomic conditional update
-    // Uses "WHERE api_key IS NULL" to ensure only one concurrent request succeeds in writing.
-    // If another request already set a key, this UPDATE affects 0 rows and we re-read.
-    if (!apiKey) {
-      const newKey = generateApiKey();
-      const updateKeyResult = await dbWrite.execute(
-        `UPDATE users SET api_key = ?, updated_at = datetime('now')
-         WHERE id = ? AND api_key IS NULL`,
-        [newKey, user.id]
-      );
-
-      if (updateKeyResult.changes === 1) {
-        // We won the race — use our generated key
-        apiKey = newKey;
-      } else {
-        // Another request already set a key — re-read to get the actual value
-        apiKey = await dbRead.getUserApiKey(user.id);
-
-        if (!apiKey) {
-          // Shouldn't happen, but defensive
-          return NextResponse.json({ error: "Failed to generate API key" }, { status: 500 });
-        }
-      }
-    }
-
-    // 6. Now that we have the credentials ready, consume the code (atomic)
+    // 5. Consume the code atomically BEFORE rotating credentials.
     // Conditions: not used, no failed attempts (re-check in SQL for atomicity)
     const updateResult = await dbWrite.execute(
       `UPDATE auth_codes
@@ -129,7 +98,26 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: AUTH_ERROR }, { status: 401 });
     }
 
-    // 7. Return credentials (code is now consumed)
+    // 6. Mint a fresh API key now that the code is consumed.
+    //
+    // We never store the plain key — only its SHA-256 hash plus a short
+    // display prefix — so we cannot return a previously-issued key. Each
+    // successful code redemption issues a new key, transparently rotating
+    // any prior one. The plain value below is the only place the caller
+    // ever sees it.
+    const apiKey = generateApiKey();
+    const apiKeyHash = await hashApiKey(apiKey);
+    const apiKeyPrefixValue = apiKeyPrefix(apiKey);
+
+    await dbWrite.execute(
+      `UPDATE users
+       SET api_key_hash = ?, api_key_prefix = ?, updated_at = datetime('now')
+       WHERE id = ?`,
+      [apiKeyHash, apiKeyPrefixValue, user.id]
+    );
+
+    // 7. Return credentials (code is now consumed). The plain key is visible
+    // to the caller exactly once here — it is never persisted.
     return NextResponse.json({
       api_key: apiKey,
       email: user.email,

--- a/packages/web/src/lib/api-key.ts
+++ b/packages/web/src/lib/api-key.ts
@@ -1,0 +1,29 @@
+/**
+ * API key helpers.
+ *
+ * Plain keys are shown to the user exactly once at generation time and
+ * never persisted. We store the SHA-256 hash for verification and a short
+ * prefix for display ("pk_xxxxxxxx...").
+ */
+
+/** Generate a random API key: pk_ prefix + 32 hex chars. */
+export function generateApiKey(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `pk_${hex}`;
+}
+
+/** Compute the SHA-256 hex digest of a string (used to hash api keys). */
+export async function hashApiKey(key: string): Promise<string> {
+  const encoded = new TextEncoder().encode(key);
+  const hash = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** First 8 characters of a key, kept for display in account/UI surfaces. */
+export function apiKeyPrefix(key: string): string {
+  return key.slice(0, 8);
+}

--- a/packages/web/src/lib/auth-helpers.ts
+++ b/packages/web/src/lib/auth-helpers.ts
@@ -10,6 +10,7 @@
 
 import { auth } from "@/auth";
 import { getDbRead } from "@/lib/db";
+import { hashApiKey } from "@/lib/api-key";
 
 /** The user ID used when E2E auth is bypassed (overridable via env) */
 export const E2E_TEST_USER_ID =
@@ -46,14 +47,20 @@ export async function resolveUser(
     return { userId: session.user.id, email: session.user.email ?? undefined };
   }
 
-  // Bearer api_key auth
+  // Bearer api_key auth.
+  //
+  // We hash the presented key with SHA-256 and look it up by hash; the
+  // database never stores the plain key.
   const authHeader = request.headers.get("Authorization");
   if (authHeader?.startsWith("Bearer ")) {
     const apiKey = authHeader.slice(7);
-    const db = await getDbRead();
-    const row = await db.getUserByApiKey(apiKey);
-    if (row) {
-      return { userId: row.id, email: row.email };
+    if (apiKey) {
+      const apiKeyHash = await hashApiKey(apiKey);
+      const db = await getDbRead();
+      const row = await db.getUserByApiKeyHash(apiKeyHash);
+      if (row) {
+        return { userId: row.id, email: row.email };
+      }
     }
   }
 

--- a/packages/web/src/lib/db-worker.ts
+++ b/packages/web/src/lib/db-worker.ts
@@ -149,8 +149,11 @@ export function createWorkerDbRead(): DbRead {
       return rpc<UserAuth | null>({ method: "users.getByEmail", email });
     },
 
-    async getUserByApiKey(apiKey: string): Promise<UserApiKeyAuth | null> {
-      return rpc<UserApiKeyAuth | null>({ method: "users.getByApiKey", apiKey });
+    async getUserByApiKeyHash(apiKeyHash: string): Promise<UserApiKeyAuth | null> {
+      return rpc<UserApiKeyAuth | null>({
+        method: "users.getByApiKeyHash",
+        apiKeyHash,
+      });
     },
 
     async getUserByOAuthAccount(
@@ -180,12 +183,12 @@ export function createWorkerDbRead(): DbRead {
       return rpc<UserSettings | null>({ method: "users.getSettings", userId });
     },
 
-    async getUserApiKey(userId: string): Promise<string | null> {
-      const result = await rpc<{ api_key: string | null } | null>({
-        method: "users.getApiKey",
+    async getUserApiKeyPrefix(userId: string): Promise<string | null> {
+      const result = await rpc<{ api_key_prefix: string | null } | null>({
+        method: "users.getApiKeyPrefix",
         userId,
       });
-      return result?.api_key ?? null;
+      return result?.api_key_prefix ?? null;
     },
 
     async getUserEmail(userId: string): Promise<string | null> {

--- a/packages/web/src/lib/db.ts
+++ b/packages/web/src/lib/db.ts
@@ -108,8 +108,8 @@ export interface DbRead {
   /** Get user by email (for auth) */
   getUserByEmail(email: string): Promise<UserAuth | null>;
 
-  /** Authenticate user by API key */
-  getUserByApiKey(apiKey: string): Promise<UserApiKeyAuth | null>;
+  /** Authenticate user by SHA-256 hash of their API key */
+  getUserByApiKeyHash(apiKeyHash: string): Promise<UserApiKeyAuth | null>;
 
   /** Get user by OAuth provider account */
   getUserByOAuthAccount(
@@ -123,8 +123,8 @@ export interface DbRead {
   /** Get user settings */
   getUserSettings(userId: string): Promise<UserSettings | null>;
 
-  /** Get user's API key */
-  getUserApiKey(userId: string): Promise<string | null>;
+  /** Get user's API key prefix (display only — plain key is never stored) */
+  getUserApiKeyPrefix(userId: string): Promise<string | null>;
 
   /** Get user email (admin) */
   getUserEmail(userId: string): Promise<string | null>;

--- a/packages/worker-read/src/rpc/users.test.ts
+++ b/packages/worker-read/src/rpc/users.test.ts
@@ -4,11 +4,11 @@ import {
   type GetUserByIdRequest,
   type GetUserBySlugRequest,
   type GetUserByEmailRequest,
-  type GetUserByApiKeyRequest,
+  type GetUserByApiKeyHashRequest,
   type GetUserByOAuthAccountRequest,
   type CheckSlugExistsRequest,
   type GetUserSettingsRequest,
-  type GetUserApiKeyRequest,
+  type GetUserApiKeyPrefixRequest,
   type GetUserEmailRequest,
   type SearchUsersRequest,
 } from "./users";
@@ -170,17 +170,17 @@ describe("Users RPC handlers", () => {
   });
 
   // -------------------------------------------------------------------------
-  // users.getByApiKey
+  // users.getByApiKeyHash
   // -------------------------------------------------------------------------
 
-  describe("users.getByApiKey", () => {
-    it("should return user id and email when found by API key", async () => {
+  describe("users.getByApiKeyHash", () => {
+    it("should return user id and email when found by API key hash", async () => {
       const mockUser = { id: "usr_123", email: "test@example.com" };
       db.bind.mockReturnValue({ first: vi.fn().mockResolvedValue(mockUser) });
 
-      const request: GetUserByApiKeyRequest = {
-        method: "users.getByApiKey",
-        apiKey: "pk_test_123",
+      const request: GetUserByApiKeyHashRequest = {
+        method: "users.getByApiKeyHash",
+        apiKeyHash: "a".repeat(64),
       };
       const response = await handleUsersRpc(request, db);
 
@@ -188,16 +188,16 @@ describe("Users RPC handlers", () => {
       const body = await response.json();
       expect(body).toEqual({ result: mockUser });
       expect(db.prepare).toHaveBeenCalledWith(
-        "SELECT id, email FROM users WHERE api_key = ?",
+        "SELECT id, email FROM users WHERE api_key_hash = ?",
       );
     });
 
-    it("should return null when API key not found", async () => {
+    it("should return null when API key hash not found", async () => {
       db.bind.mockReturnValue({ first: vi.fn().mockResolvedValue(null) });
 
-      const request: GetUserByApiKeyRequest = {
-        method: "users.getByApiKey",
-        apiKey: "invalid_key",
+      const request: GetUserByApiKeyHashRequest = {
+        method: "users.getByApiKeyHash",
+        apiKeyHash: "deadbeef".repeat(8),
       };
       const response = await handleUsersRpc(request, db);
 
@@ -206,8 +206,8 @@ describe("Users RPC handlers", () => {
       expect(body).toEqual({ result: null });
     });
 
-    it("should return 400 when apiKey is missing", async () => {
-      const request = { method: "users.getByApiKey", apiKey: "" } as GetUserByApiKeyRequest;
+    it("should return 400 when apiKeyHash is missing", async () => {
+      const request = { method: "users.getByApiKeyHash", apiKeyHash: "" } as GetUserByApiKeyHashRequest;
       const response = await handleUsersRpc(request, db);
 
       expect(response.status).toBe(400);
@@ -380,40 +380,47 @@ describe("Users RPC handlers", () => {
   });
 
   // -------------------------------------------------------------------------
-  // users.getApiKey
+  // users.getApiKeyPrefix
   // -------------------------------------------------------------------------
 
-  describe("users.getApiKey", () => {
-    it("should return api_key when exists", async () => {
-      db.bind.mockReturnValue({ first: vi.fn().mockResolvedValue({ api_key: "pk_test_123" }) });
+  describe("users.getApiKeyPrefix", () => {
+    it("should return api_key_prefix when exists", async () => {
+      db.bind.mockReturnValue({
+        first: vi.fn().mockResolvedValue({ api_key_prefix: "pk_test1" }),
+      });
 
-      const request: GetUserApiKeyRequest = {
-        method: "users.getApiKey",
+      const request: GetUserApiKeyPrefixRequest = {
+        method: "users.getApiKeyPrefix",
         userId: "usr_123",
       };
       const response = await handleUsersRpc(request, db);
 
       expect(response.status).toBe(200);
       const body = await response.json();
-      expect(body).toEqual({ result: { api_key: "pk_test_123" } });
+      expect(body).toEqual({ result: { api_key_prefix: "pk_test1" } });
     });
 
-    it("should return api_key: null when user has no key", async () => {
-      db.bind.mockReturnValue({ first: vi.fn().mockResolvedValue({ api_key: null }) });
+    it("should return api_key_prefix: null when user has no key", async () => {
+      db.bind.mockReturnValue({
+        first: vi.fn().mockResolvedValue({ api_key_prefix: null }),
+      });
 
-      const request: GetUserApiKeyRequest = {
-        method: "users.getApiKey",
+      const request: GetUserApiKeyPrefixRequest = {
+        method: "users.getApiKeyPrefix",
         userId: "usr_123",
       };
       const response = await handleUsersRpc(request, db);
 
       expect(response.status).toBe(200);
       const body = await response.json();
-      expect(body).toEqual({ result: { api_key: null } });
+      expect(body).toEqual({ result: { api_key_prefix: null } });
     });
 
     it("should return 400 when userId is missing", async () => {
-      const request = { method: "users.getApiKey", userId: "" } as GetUserApiKeyRequest;
+      const request = {
+        method: "users.getApiKeyPrefix",
+        userId: "",
+      } as GetUserApiKeyPrefixRequest;
       const response = await handleUsersRpc(request, db);
 
       expect(response.status).toBe(400);

--- a/packages/worker-read/src/rpc/users.ts
+++ b/packages/worker-read/src/rpc/users.ts
@@ -61,9 +61,9 @@ export interface GetUserByEmailRequest {
   email: string;
 }
 
-export interface GetUserByApiKeyRequest {
-  method: "users.getByApiKey";
-  apiKey: string;
+export interface GetUserByApiKeyHashRequest {
+  method: "users.getByApiKeyHash";
+  apiKeyHash: string;
 }
 
 export interface GetUserByOAuthAccountRequest {
@@ -83,8 +83,8 @@ export interface GetUserSettingsRequest {
   userId: string;
 }
 
-export interface GetUserApiKeyRequest {
-  method: "users.getApiKey";
+export interface GetUserApiKeyPrefixRequest {
+  method: "users.getApiKeyPrefix";
   userId: string;
 }
 
@@ -143,11 +143,11 @@ export type UsersRpcRequest =
   | GetUserByIdRequest
   | GetUserBySlugRequest
   | GetUserByEmailRequest
-  | GetUserByApiKeyRequest
+  | GetUserByApiKeyHashRequest
   | GetUserByOAuthAccountRequest
   | CheckSlugExistsRequest
   | GetUserSettingsRequest
-  | GetUserApiKeyRequest
+  | GetUserApiKeyPrefixRequest
   | GetUserEmailRequest
   | SearchUsersRequest
   | GetUserSlugOnlyRequest
@@ -172,16 +172,16 @@ export async function handleUsersRpc(
       return handleGetUserBySlug(request, db);
     case "users.getByEmail":
       return handleGetUserByEmail(request, db);
-    case "users.getByApiKey":
-      return handleGetUserByApiKey(request, db);
+    case "users.getByApiKeyHash":
+      return handleGetUserByApiKeyHash(request, db);
     case "users.getByOAuthAccount":
       return handleGetUserByOAuthAccount(request, db);
     case "users.checkSlugExists":
       return handleCheckSlugExists(request, db);
     case "users.getSettings":
       return handleGetUserSettings(request, db);
-    case "users.getApiKey":
-      return handleGetUserApiKey(request, db);
+    case "users.getApiKeyPrefix":
+      return handleGetUserApiKeyPrefix(request, db);
     case "users.getEmail":
       return handleGetUserEmail(request, db);
     case "users.search":
@@ -264,17 +264,17 @@ async function handleGetUserByEmail(
   return Response.json({ result: row ?? null });
 }
 
-async function handleGetUserByApiKey(
-  req: GetUserByApiKeyRequest,
+async function handleGetUserByApiKeyHash(
+  req: GetUserByApiKeyHashRequest,
   db: D1Database,
 ): Promise<Response> {
-  if (!req.apiKey) {
-    return Response.json({ error: "Missing apiKey" }, { status: 400 });
+  if (!req.apiKeyHash) {
+    return Response.json({ error: "Missing apiKeyHash" }, { status: 400 });
   }
 
   const row = await db
-    .prepare("SELECT id, email FROM users WHERE api_key = ?")
-    .bind(req.apiKey)
+    .prepare("SELECT id, email FROM users WHERE api_key_hash = ?")
+    .bind(req.apiKeyHash)
     .first<UserApiKeyAuth>();
 
   return Response.json({ result: row ?? null });
@@ -344,8 +344,8 @@ async function handleGetUserSettings(
   return Response.json({ result: row ?? null });
 }
 
-async function handleGetUserApiKey(
-  req: GetUserApiKeyRequest,
+async function handleGetUserApiKeyPrefix(
+  req: GetUserApiKeyPrefixRequest,
   db: D1Database,
 ): Promise<Response> {
   if (!req.userId) {
@@ -353,9 +353,9 @@ async function handleGetUserApiKey(
   }
 
   const row = await db
-    .prepare("SELECT api_key FROM users WHERE id = ?")
+    .prepare("SELECT api_key_prefix FROM users WHERE id = ?")
     .bind(req.userId)
-    .first<{ api_key: string | null }>();
+    .first<{ api_key_prefix: string | null }>();
 
   return Response.json({ result: row ?? null });
 }

--- a/scripts/migrations/001-init.sql
+++ b/scripts/migrations/001-init.sql
@@ -15,7 +15,8 @@ CREATE TABLE IF NOT EXISTS users (
   slug            TEXT UNIQUE,
   nickname        TEXT,
   is_public       INTEGER NOT NULL DEFAULT 0,
-  api_key         TEXT UNIQUE,
+  api_key_hash    TEXT UNIQUE,
+  api_key_prefix  TEXT,
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/scripts/migrations/021-hash-api-keys.sql
+++ b/scripts/migrations/021-hash-api-keys.sql
@@ -1,0 +1,64 @@
+-- Migration 021: Hash API keys at rest.
+--
+-- Previously the `users.api_key` column stored the plain key, so a database
+-- compromise would leak every active CLI credential. This migration replaces
+-- that column with `api_key_hash` (SHA-256 hex of the plain key) plus
+-- `api_key_prefix` (first 8 chars, for display only) and backfills both
+-- columns from the existing plain values.
+--
+-- After backfill the plain `api_key` column is dropped — the application
+-- code never reads it again, and keeping it around defeats the purpose.
+--
+-- Backfill notes
+-- ==============
+-- D1 / SQLite has no built-in SHA-256 function, so we cannot hash existing
+-- plain keys inside the migration. We have two options:
+--
+--   A. Run the JS backfill script in `scripts/migrations/021-hash-api-keys.ts`
+--      against the live D1 database BEFORE applying the DROP step below.
+--      The script reads each user's plain `api_key`, computes the SHA-256
+--      hex, and writes `api_key_hash` + `api_key_prefix`.
+--
+--   B. If acceptable, simply NULL the existing keys here. Users will be
+--      forced to log in again, which mints a fresh hashed key via
+--      `/api/auth/code/verify` or `/api/auth/cli`.
+--
+-- The two-step shape below leaves the choice to the operator.
+--
+-- Apply via:
+--   wrangler d1 execute pew-db --remote --file scripts/migrations/021-hash-api-keys.sql
+--
+-- ============================================================
+-- Step 1 — add the new columns. Safe to run any time; nothing reads them
+-- yet, and existing code keeps using `api_key` until step 3.
+-- ============================================================
+
+ALTER TABLE users ADD COLUMN api_key_hash   TEXT;
+ALTER TABLE users ADD COLUMN api_key_prefix TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_api_key_hash
+  ON users (api_key_hash)
+  WHERE api_key_hash IS NOT NULL;
+
+-- ============================================================
+-- Step 2 — backfill (choose ONE of the following).
+--
+-- Option A: run the JS script (preferred — preserves existing keys)
+--
+--   pnpm tsx scripts/migrations/021-hash-api-keys.ts
+--
+-- Option B: invalidate existing keys so users re-authenticate.
+--
+--   UPDATE users SET api_key = NULL WHERE api_key IS NOT NULL;
+--
+-- ============================================================
+
+-- ============================================================
+-- Step 3 — drop the plain-text column once the backfill is verified
+-- and the application has been deployed with the new columns.
+--
+-- Run this as a SEPARATE migration (021-drop-plain-api-key.sql) once
+-- the new code is live and traffic has cut over.
+-- ============================================================
+
+-- ALTER TABLE users DROP COLUMN api_key;

--- a/scripts/migrations/021-hash-api-keys.ts
+++ b/scripts/migrations/021-hash-api-keys.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env bun
+/**
+ * One-off backfill: hash existing plain `users.api_key` values into the new
+ * `api_key_hash` and `api_key_prefix` columns added by migration 021.
+ *
+ * Run AFTER step 1 of `021-hash-api-keys.sql` (which adds the columns) and
+ * BEFORE step 3 (which drops the plain `api_key` column).
+ *
+ * Reads Cloudflare credentials from packages/web/.env.local.
+ * Usage: bun scripts/migrations/021-hash-api-keys.ts
+ *
+ * Idempotent — rows whose `api_key_hash` is already set are skipped.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Load .env.local manually (no dotenv dependency)
+// ---------------------------------------------------------------------------
+
+const envPath = resolve(
+  import.meta.dirname as string,
+  "../../packages/web/.env.local",
+);
+const envContent = readFileSync(envPath, "utf-8");
+const envVars: Record<string, string> = {};
+for (const line of envContent.split("\n")) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) continue;
+  const eqIdx = trimmed.indexOf("=");
+  if (eqIdx === -1) continue;
+  envVars[trimmed.slice(0, eqIdx)] = trimmed.slice(eqIdx + 1);
+}
+
+const CF_ACCOUNT_ID = envVars.CF_ACCOUNT_ID;
+const CF_D1_DATABASE_ID = envVars.CF_D1_DATABASE_ID;
+const CF_D1_API_TOKEN = envVars.CF_D1_API_TOKEN;
+
+if (!CF_ACCOUNT_ID || !CF_D1_DATABASE_ID || !CF_D1_API_TOKEN) {
+  console.error("Missing Cloudflare D1 credentials in .env.local");
+  process.exit(1);
+}
+
+const D1_URL = `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${CF_D1_DATABASE_ID}/query`;
+
+async function d1Query<T = unknown>(
+  sql: string,
+  params: unknown[] = [],
+): Promise<{ result: Array<{ results: T[] }> }> {
+  const resp = await fetch(D1_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${CF_D1_API_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ sql, params }),
+  });
+  if (!resp.ok) {
+    throw new Error(`D1 API error (${resp.status}): ${await resp.text()}`);
+  }
+  return resp.json();
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const hash = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Backfill loop
+// ---------------------------------------------------------------------------
+
+interface UserRow {
+  id: string;
+  api_key: string;
+}
+
+console.log("Fetching users with plain api_key but no api_key_hash...");
+const rows = await d1Query<UserRow>(
+  `SELECT id, api_key FROM users
+   WHERE api_key IS NOT NULL AND api_key_hash IS NULL`,
+);
+const users = rows.result[0]?.results ?? [];
+console.log(`Found ${users.length} users to backfill.`);
+
+let done = 0;
+for (const u of users) {
+  const hash = await sha256Hex(u.api_key);
+  const prefix = u.api_key.slice(0, 8);
+  await d1Query(
+    `UPDATE users SET api_key_hash = ?, api_key_prefix = ? WHERE id = ?`,
+    [hash, prefix, u.id],
+  );
+  done++;
+  if (done % 50 === 0) console.log(`  ${done} / ${users.length}`);
+}
+
+console.log(`Backfill complete: ${done} users updated.`);
+console.log(
+  "Next step: deploy the new code, then run the DROP in migration 021 step 3.",
+);


### PR DESCRIPTION
Closes #118

## Changes
- Store SHA-256 hash + prefix instead of plain API keys
- New `api-key.ts` helper module
- Key rotation happens AFTER code consumption (race condition fix)
- Migration SQL + backfill script
- Tests updated

## Severity: LOW