### PR TITLE
feat: add Cursor editor session tracking support

### DIFF
--- a/packages/cli/src/__tests__/paths.test.ts
+++ b/packages/cli/src/__tests__/paths.test.ts
@@ -61,6 +61,7 @@ describe("resolveDefaultPaths", () => {
       "openclawDir",
       "vscodeCopilotDirs",
       "copilotCliLogsDir",
+      "cursorDbPaths",
     ];
     const paths = resolveDefaultPaths("/fakehome");
     expect(Object.keys(paths)).toHaveLength(keys.length);

--- a/packages/cli/src/__tests__/session-sync.test.ts
+++ b/packages/cli/src/__tests__/session-sync.test.ts
@@ -403,7 +403,7 @@ describe("executeSessionSync", () => {
     expect(result.totalSnapshots).toBe(0);
     expect(result.totalRecords).toBe(0);
     expect(result.filesScanned).toEqual({
-      claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0,
+      claude: 0, codex: 0, cursor: 0, gemini: 0, opencode: 0, openclaw: 0,
     });
   });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -170,6 +170,14 @@ const syncCommand = defineCommand({
       // Native SQLite module not available — SQLite sync will be skipped
     }
 
+    let openCursorDb: typeof import("./parsers/cursor-db.js").openCursorDb | undefined;
+    try {
+      const cursorMod = await import("./parsers/cursor-db.js");
+      openCursorDb = cursorMod.openCursorDb;
+    } catch {
+      // Native SQLite module not available — Cursor sync will be skipped
+    }
+
     // Ensure a stable device ID exists for multi-device dedup
     const configManager = new ConfigManager(paths.stateDir, args.dev);
     const deviceId = await configManager.ensureDeviceId();
@@ -242,6 +250,8 @@ const syncCommand = defineCommand({
       openCodeDbPath: paths.openCodeDbPath,
       openSessionDb,
       openclawDir: paths.openclawDir,
+      cursorDbPaths: paths.cursorDbPaths,
+      openCursorDb,
       onCorruptLine: handleCorruptLine,
       onProgress(event) {
         logSessionSyncProgress(event);
@@ -262,6 +272,7 @@ const syncCommand = defineCommand({
       if (sessionResult.sources.gemini > 0) sessParts.push(`Gemini: ${sessionResult.sources.gemini}`);
       if (sessionResult.sources.opencode > 0) sessParts.push(`OpenCode: ${sessionResult.sources.opencode}`);
       if (sessionResult.sources.openclaw > 0) sessParts.push(`OpenClaw: ${sessionResult.sources.openclaw}`);
+      if (sessionResult.sources.cursor > 0) sessParts.push(`Cursor: ${sessionResult.sources.cursor}`);
       if (sessParts.length > 0) {
         log.text(pc.dim(sessParts.join("  |  ")));
       }
@@ -275,6 +286,7 @@ const syncCommand = defineCommand({
     if (sfs.gemini > 0) sessScanParts.push(`Gemini: ${sfs.gemini}`);
     if (sfs.opencode > 0) sessScanParts.push(`OpenCode: ${sfs.opencode}`);
     if (sfs.openclaw > 0) sessScanParts.push(`OpenClaw: ${sfs.openclaw}`);
+    if (sfs.cursor > 0) sessScanParts.push(`Cursor: ${sfs.cursor}`);
     if (sessScanParts.length > 0) {
       log.text(`Files scanned: ${pc.dim(sessScanParts.join("  |  "))}`);
     }

--- a/packages/cli/src/commands/session-sync.ts
+++ b/packages/cli/src/commands/session-sync.ts
@@ -19,6 +19,7 @@ import type {
   SessionQueueRecord,
   SessionFileCursor,
   OpenCodeSqliteSessionCursor,
+  CursorSqliteCursor,
   Source,
 } from "@pew/core";
 import { SessionCursorStore } from "../storage/session-cursor-store.js";
@@ -56,6 +57,14 @@ export interface SessionSyncOptions {
   } | null;
   /** Override: OpenClaw data directory (~/.openclaw) */
   openclawDir?: string;
+  /** Override: Cursor state.vscdb paths */
+  cursorDbPaths?: string[];
+  /** Factory for opening the Cursor SQLite DB (DI for testability) */
+  openCursorDb?: (dbPath: string) => {
+    queryComposers: () => import("../parsers/cursor-db.js").CursorKVRow[];
+    queryItemTable: () => import("../parsers/cursor-db.js").CursorKVRow[];
+    close: () => void;
+  } | null;
   /** Progress callback */
   onProgress?: (event: SessionProgressEvent) => void;
   /** Callback invoked when a corrupted JSONL line is found in the queue */
@@ -81,6 +90,7 @@ export interface SessionSyncResult {
     gemini: number;
     opencode: number;
     openclaw: number;
+    cursor: number;
   };
   /** Total files/directories scanned per source */
   filesScanned: {
@@ -89,6 +99,7 @@ export interface SessionSyncResult {
     gemini: number;
     opencode: number;
     openclaw: number;
+    cursor: number;
   };
 }
 
@@ -134,6 +145,7 @@ function sourceKey(source: Source): keyof SessionSyncResult["sources"] | null {
     case "opencode": return "opencode";
     case "openclaw": return "openclaw";
     case "codex": return "codex";
+    case "cursor": return "cursor";
     case "vscode-copilot": return null;
     case "copilot-cli": return null;
   }
@@ -157,8 +169,8 @@ export async function executeSessionSync(
   const cursors = await cursorStore.load();
 
   const allSnapshots: SessionSnapshot[] = [];
-  const sourceCounts = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0 };
-  const filesScanned = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0 };
+  const sourceCounts = { claude: 0, codex: 0, cursor: 0, gemini: 0, opencode: 0, openclaw: 0 };
+  const filesScanned = { claude: 0, codex: 0, cursor: 0, gemini: 0, opencode: 0, openclaw: 0 };
 
   // Build driver sets from options
   const { fileDrivers, dbDrivers } = createSessionDrivers(opts);

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -64,6 +64,7 @@ export interface SyncResult {
   sources: {
     claude: number;
     codex: number;
+    cursor: number;
     gemini: number;
     opencode: number;
     openclaw: number;
@@ -74,6 +75,7 @@ export interface SyncResult {
   filesScanned: {
     claude: number;
     codex: number;
+    cursor: number;
     gemini: number;
     opencode: number;
     openclaw: number;
@@ -98,6 +100,7 @@ function sourceKey(source: Source): keyof SyncResult["sources"] {
     case "opencode": return "opencode";
     case "openclaw": return "openclaw";
     case "codex": return "codex";
+    case "cursor": return "cursor";
     case "vscode-copilot": return "vscodeCopilot";
     case "copilot-cli": return "copilotCli";
   }
@@ -181,8 +184,8 @@ export async function executeSync(opts: SyncOptions): Promise<SyncResult> {
   let replayDetected = false;
 
   const allDeltas: ParsedDelta[] = [];
-  const sourceCounts = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0, copilotCli: 0 };
-  const filesScanned = { claude: 0, codex: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0, copilotCli: 0 };
+  const sourceCounts = { claude: 0, codex: 0, cursor: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0, copilotCli: 0 };
+  const filesScanned = { claude: 0, codex: 0, cursor: 0, gemini: 0, opencode: 0, openclaw: 0, vscodeCopilot: 0, copilotCli: 0 };
 
   // Collect all discovered file paths (across all drivers) for knownFilePaths
   const discoveredFiles = new Set<string>();

--- a/packages/cli/src/drivers/registry.ts
+++ b/packages/cli/src/drivers/registry.ts
@@ -40,6 +40,10 @@ import {
   createOpenCodeSqliteSessionDriver,
   type OpenCodeSqliteSessionDriverOpts,
 } from "./session/opencode-sqlite-session-driver.js";
+import {
+  createCursorSqliteSessionDriver,
+  type CursorSqliteSessionDriverOpts,
+} from "./session/cursor-session-driver.js";
 
 // ---------------------------------------------------------------------------
 // Token driver registry options
@@ -126,6 +130,8 @@ export interface SessionDriverRegistryOpts {
   codexSessionsDir?: string;
   openCodeDbPath?: string;
   openSessionDb?: OpenCodeSqliteSessionDriverOpts["openSessionDb"];
+  cursorDbPaths?: string[];
+  openCursorDb?: CursorSqliteSessionDriverOpts["openCursorDb"];
 }
 
 export interface SessionDriverSet {
@@ -164,6 +170,16 @@ export function createSessionDrivers(opts: SessionDriverRegistryOpts): SessionDr
         openSessionDb: opts.openSessionDb,
       }),
     );
+  }
+  if (opts.cursorDbPaths && opts.openCursorDb) {
+    for (const dbPath of opts.cursorDbPaths) {
+      dbDrivers.push(
+        createCursorSqliteSessionDriver({
+          dbPath,
+          openCursorDb: opts.openCursorDb,
+        }),
+      );
+    }
   }
 
   return { fileDrivers, dbDrivers };

--- a/packages/cli/src/drivers/session/cursor-session-driver.ts
+++ b/packages/cli/src/drivers/session/cursor-session-driver.ts
@@ -1,0 +1,109 @@
+/**
+ * Cursor SQLite DB session driver.
+ *
+ * Reads composer conversations from Cursor's state.vscdb file.
+ * Uses lastUpdatedAt watermark for incremental sync.
+ */
+
+import { stat } from "node:fs/promises";
+import type { CursorSqliteCursor } from "@pew/core";
+import { collectCursorSessions } from "../../parsers/cursor-session.js";
+import type { CursorKVRow } from "../../parsers/cursor-db.js";
+import type { DbSessionDriver, DbSessionResult, SyncContext } from "../types.js";
+
+/** Options needed to construct the Cursor SQLite session driver */
+export interface CursorSqliteSessionDriverOpts {
+  /** Path to the Cursor state.vscdb database */
+  dbPath: string;
+  /** Factory for opening the DB (DI for testability) */
+  openCursorDb: (dbPath: string) => {
+    queryComposers: () => CursorKVRow[];
+    queryItemTable: () => CursorKVRow[];
+    close: () => void;
+  } | null;
+}
+
+export function createCursorSqliteSessionDriver(
+  opts: CursorSqliteSessionDriverOpts,
+): DbSessionDriver<CursorSqliteCursor> {
+  return {
+    kind: "db",
+    source: "cursor",
+
+    async run(
+      prevCursor: CursorSqliteCursor | undefined,
+      _ctx: SyncContext,
+    ): Promise<DbSessionResult<CursorSqliteCursor>> {
+      // Check if DB file exists
+      const dbStat = await stat(opts.dbPath).catch(() => null);
+      if (!dbStat) {
+        return {
+          snapshots: [],
+          cursor: prevCursor ?? {
+            lastUpdatedAt: 0,
+            inode: 0,
+            updatedAt: new Date().toISOString(),
+          },
+          rowCount: 0,
+        };
+      }
+
+      const dbInode = dbStat.ino;
+
+      // If inode changed (DB recreated), reset cursor
+      const lastUpdatedAt =
+        prevCursor && prevCursor.inode === dbInode
+          ? prevCursor.lastUpdatedAt
+          : 0;
+
+      const handle = opts.openCursorDb(opts.dbPath);
+      if (!handle) {
+        return {
+          snapshots: [],
+          cursor: prevCursor ?? {
+            lastUpdatedAt: 0,
+            inode: dbInode,
+            updatedAt: new Date().toISOString(),
+          },
+          rowCount: 0,
+        };
+      }
+
+      try {
+        const kvRows = handle.queryComposers();
+        const itemRows = handle.queryItemTable();
+        const totalRows = kvRows.length + itemRows.length;
+
+        // Parse all composers into snapshots
+        const allSnapshots = collectCursorSessions(kvRows, itemRows);
+
+        // Filter to only sessions updated since last cursor
+        const snapshots = lastUpdatedAt > 0
+          ? allSnapshots.filter((s) => {
+              const lastMsg = new Date(s.lastMessageAt).getTime();
+              return lastMsg > lastUpdatedAt;
+            })
+          : allSnapshots;
+
+        // Update watermark to the max lastMessageAt
+        let maxUpdatedAt = lastUpdatedAt;
+        for (const s of allSnapshots) {
+          const ts = new Date(s.lastMessageAt).getTime();
+          if (ts > maxUpdatedAt) maxUpdatedAt = ts;
+        }
+
+        return {
+          snapshots,
+          cursor: {
+            lastUpdatedAt: maxUpdatedAt,
+            inode: dbInode,
+            updatedAt: new Date().toISOString(),
+          },
+          rowCount: totalRows,
+        };
+      } finally {
+        handle.close();
+      }
+    },
+  };
+}

--- a/packages/cli/src/parsers/cursor-db.ts
+++ b/packages/cli/src/parsers/cursor-db.ts
@@ -1,0 +1,135 @@
+/**
+ * Cursor editor SQLite DB opener.
+ *
+ * Opens Cursor's state.vscdb (SQLite) in read-only mode and provides
+ * query functions for reading composer data from the cursorDiskKV table.
+ *
+ * Uses the same bun:sqlite / node:sqlite pattern as opencode-sqlite-db.ts.
+ */
+
+import { createRequire } from "node:module";
+
+const esmRequire = createRequire(import.meta.url);
+
+interface SqliteDb {
+  prepare(sql: string): SqliteStmt;
+  close(): void;
+}
+
+interface SqliteStmt {
+  all(...params: unknown[]): unknown[];
+}
+
+// Cache the resolved SQLite implementation
+let cachedSqliteImpl: ((dbPath: string) => SqliteDb) | null = null;
+let sqliteLoadAttempted = false;
+
+function getSqliteOpener(): ((dbPath: string) => SqliteDb) | null {
+  if (sqliteLoadAttempted) return cachedSqliteImpl;
+  sqliteLoadAttempted = true;
+
+  const isBun = typeof globalThis.Bun !== "undefined";
+
+  if (isBun) {
+    try {
+      const { Database } = esmRequire("bun:sqlite");
+      cachedSqliteImpl = (dbPath: string) => new Database(dbPath, { readonly: true });
+      return cachedSqliteImpl;
+    } catch {
+      // bun:sqlite not available
+    }
+  } else {
+    const origEmit = process.emit;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process as any).emit = function (event: string, ...args: unknown[]) {
+      if (
+        event === "warning" &&
+        args[0] instanceof Error &&
+        args[0].name === "ExperimentalWarning" &&
+        args[0].message.includes("SQLite")
+      ) {
+        return false;
+      }
+      return origEmit.apply(process, [event, ...args] as never);
+    };
+    try {
+      const { DatabaseSync } = esmRequire("node:sqlite");
+      cachedSqliteImpl = (dbPath: string) => new DatabaseSync(dbPath, { readOnly: true });
+      return cachedSqliteImpl;
+    } catch {
+      // node:sqlite not available
+    } finally {
+      process.emit = origEmit;
+    }
+  }
+
+  return null;
+}
+
+/** Row from cursorDiskKV table */
+export interface CursorKVRow {
+  key: string;
+  value: string;
+}
+
+/** Query function type for Cursor DB */
+export type QueryComposersFn = () => CursorKVRow[];
+
+/** Query function for the older ItemTable format */
+export type QueryItemTableFn = () => CursorKVRow[];
+
+/**
+ * Open a Cursor state.vscdb database in read-only mode
+ * and return query functions for reading composer data.
+ *
+ * Returns null if the database cannot be opened.
+ */
+export function openCursorDb(
+  dbPath: string,
+): {
+  queryComposers: QueryComposersFn;
+  queryItemTable: QueryItemTableFn;
+  close: () => void;
+} | null {
+  const opener = getSqliteOpener();
+  if (!opener) return null;
+
+  let db: SqliteDb;
+  try {
+    db = opener(dbPath);
+  } catch {
+    return null;
+  }
+
+  // Check which tables exist — cursorDiskKV is the modern format,
+  // ItemTable is the older format. Both may or may not exist.
+  let hasKVTable = false;
+  let hasItemTable = false;
+  try {
+    const tables = db.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('cursorDiskKV', 'ItemTable')`,
+    ).all() as { name: string }[];
+    for (const t of tables) {
+      if (t.name === "cursorDiskKV") hasKVTable = true;
+      if (t.name === "ItemTable") hasItemTable = true;
+    }
+  } catch {
+    // If we can't even query sqlite_master, bail
+    try { db.close(); } catch { /* ignore */ }
+    return null;
+  }
+
+  const composerStmt = hasKVTable
+    ? db.prepare(`SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'`)
+    : null;
+
+  const itemStmt = hasItemTable
+    ? db.prepare(`SELECT key, value FROM ItemTable WHERE key = 'composer.composerData'`)
+    : null;
+
+  return {
+    queryComposers: () => (composerStmt ? composerStmt.all() as CursorKVRow[] : []),
+    queryItemTable: () => (itemStmt ? itemStmt.all() as CursorKVRow[] : []),
+    close: () => db.close(),
+  };
+}

--- a/packages/cli/src/parsers/cursor-session.ts
+++ b/packages/cli/src/parsers/cursor-session.ts
@@ -1,0 +1,140 @@
+/**
+ * Cursor session parser.
+ *
+ * Extracts SessionSnapshot[] from Cursor's state.vscdb database.
+ * Reads composer conversations from the cursorDiskKV table (modern format)
+ * and ItemTable (older format).
+ */
+
+import type { SessionSnapshot } from "@pew/core";
+import type { CursorKVRow } from "./cursor-db.js";
+
+// ---------------------------------------------------------------------------
+// Internal types for Cursor's JSON data
+// ---------------------------------------------------------------------------
+
+interface CursorMessage {
+  type: number; // 1 = user, 2 = assistant
+  text?: string;
+  timestamp?: number;
+  modelType?: string;
+}
+
+interface ComposerData {
+  composerId: string;
+  name?: string;
+  createdAt?: number;
+  lastUpdatedAt?: number;
+  conversation?: CursorMessage[];
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse composer data rows into SessionSnapshots.
+ *
+ * Accepts rows from both cursorDiskKV (one composer per row) and
+ * ItemTable (all composers in a single row).
+ */
+export function collectCursorSessions(
+  kvRows: CursorKVRow[],
+  itemRows: CursorKVRow[],
+): SessionSnapshot[] {
+  const now = new Date().toISOString();
+  const composers = new Map<string, ComposerData>();
+
+  // Modern format: one composer per key
+  for (const row of kvRows) {
+    try {
+      const data = JSON.parse(row.value) as ComposerData;
+      if (data.composerId) {
+        composers.set(data.composerId, data);
+      }
+    } catch {
+      // Skip unparseable rows
+    }
+  }
+
+  // Older format: all composers in a single JSON object
+  for (const row of itemRows) {
+    try {
+      const parsed = JSON.parse(row.value);
+      // Could be an array or an object with composer entries
+      const entries: ComposerData[] = Array.isArray(parsed)
+        ? parsed
+        : typeof parsed === "object" && parsed !== null
+          ? Object.values(parsed)
+          : [];
+      for (const data of entries) {
+        if (data.composerId && !composers.has(data.composerId)) {
+          composers.set(data.composerId, data);
+        }
+      }
+    } catch {
+      // Skip unparseable rows
+    }
+  }
+
+  const snapshots: SessionSnapshot[] = [];
+
+  for (const composer of composers.values()) {
+    const conversation = composer.conversation ?? [];
+    if (conversation.length === 0) continue;
+
+    const userMessages = conversation.filter((m) => m.type === 1).length;
+    const assistantMessages = conversation.filter((m) => m.type === 2).length;
+
+    // Timestamps
+    const timestamps = conversation
+      .map((m) => m.timestamp)
+      .filter((t): t is number => typeof t === "number" && t > 0);
+
+    const firstTs = timestamps.length > 0
+      ? Math.min(...timestamps)
+      : composer.createdAt ?? 0;
+    const lastTs = timestamps.length > 0
+      ? Math.max(...timestamps)
+      : composer.lastUpdatedAt ?? firstTs;
+
+    if (firstTs === 0) continue; // No valid timestamps
+
+    const startedAt = new Date(firstTs).toISOString();
+    const lastMessageAt = new Date(lastTs).toISOString();
+    const durationSeconds = Math.max(0, Math.round((lastTs - firstTs) / 1000));
+
+    // Model: most frequent modelType from assistant messages
+    const modelCounts = new Map<string, number>();
+    for (const m of conversation) {
+      if (m.type === 2 && m.modelType) {
+        modelCounts.set(m.modelType, (modelCounts.get(m.modelType) ?? 0) + 1);
+      }
+    }
+    let model: string | null = null;
+    let maxCount = 0;
+    for (const [m, c] of modelCounts) {
+      if (c > maxCount) {
+        model = m;
+        maxCount = c;
+      }
+    }
+
+    snapshots.push({
+      sessionKey: `cursor:composer:${composer.composerId}`,
+      source: "cursor",
+      kind: "human",
+      startedAt,
+      lastMessageAt,
+      durationSeconds,
+      userMessages,
+      assistantMessages,
+      totalMessages: conversation.length,
+      projectRef: null,
+      model,
+      snapshotAt: now,
+    });
+  }
+
+  return snapshots;
+}

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -2,6 +2,39 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 /**
+ * Resolve the platform-specific Cursor state.vscdb paths.
+ *
+ * Returns an array of possible paths where Cursor stores its data.
+ */
+function resolveCursorDbPaths(home: string): string[] {
+  const platform = process.platform;
+  const paths: string[] = [];
+
+  if (platform === "darwin") {
+    paths.push(
+      join(home, "Library", "Application Support", "Cursor", "User", "globalStorage", "state.vscdb"),
+    );
+  } else if (platform === "win32") {
+    const appdata = process.env.APPDATA || join(home, "AppData", "Roaming");
+    paths.push(
+      join(appdata, "Cursor", "User", "globalStorage", "state.vscdb"),
+    );
+  } else {
+    // Linux
+    paths.push(
+      join(home, ".config", "Cursor", "User", "globalStorage", "state.vscdb"),
+    );
+  }
+
+  // Linux SSH remote server
+  paths.push(
+    join(home, ".cursor-server", "data", "User", "globalStorage", "state.vscdb"),
+  );
+
+  return paths;
+}
+
+/**
  * Resolve the platform-specific VSCode Copilot base directories.
  *
  * Returns an array of base dirs for both stable and Insiders builds:
@@ -74,5 +107,7 @@ export function resolveDefaultPaths(home = homedir()) {
     vscodeCopilotDirs: resolveVscodeCopilotDirs(home),
     /** GitHub Copilot CLI logs: ~/.copilot/logs */
     copilotCliLogsDir: join(home, ".copilot", "logs"),
+    /** Cursor state.vscdb paths (platform-aware) */
+    cursorDbPaths: resolveCursorDbPaths(home),
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,6 +14,7 @@
 export type Source =
   | "claude-code"
   | "codex"
+  | "cursor"
   | "gemini-cli"
   | "opencode"
   | "openclaw"
@@ -287,6 +288,16 @@ export interface OpenCodeSqliteSessionCursor {
   updatedAt: string;
 }
 
+/** Cursor for Cursor SQLite session data (state.vscdb) */
+export interface CursorSqliteCursor {
+  /** Max lastUpdatedAt seen from composer data (epoch ms) */
+  lastUpdatedAt: number;
+  /** DB file inode (detect replacement/recreation) */
+  inode: number;
+  /** ISO 8601 timestamp of last update */
+  updatedAt: string;
+}
+
 /** Top-level session cursor state */
 export interface SessionCursorState {
   version: 1;
@@ -294,6 +305,8 @@ export interface SessionCursorState {
   files: Record<string, SessionFileCursor>;
   /** OpenCode SQLite session cursor (separate from per-file cursors) */
   openCodeSqlite?: OpenCodeSqliteSessionCursor;
+  /** Cursor SQLite session cursor */
+  cursorSqlite?: CursorSqliteCursor;
   /** ISO 8601 timestamp of last update */
   updatedAt: string | null;
 }


### PR DESCRIPTION
## What
Add session tracking support for **Cursor** (AI code editor based on VS Code).

## Why
Cursor is a widely-used AI code editor that stores composer conversation data in local SQLite databases (`state.vscdb`). Adding support lets pew track Cursor AI usage alongside existing tools (Claude, Codex, Copilot, etc.).

## Changes

### New files (3)
- **`packages/cli/src/parsers/cursor-db.ts`** — SQLite DB opener for Cursor's `state.vscdb`, queries `cursorDiskKV` table (modern format) and `ItemTable` (older format). Uses same bun:sqlite/node:sqlite pattern as opencode-sqlite-db.
- **`packages/cli/src/parsers/cursor-session.ts`** — Parser (`collectCursorSessions()`) that extracts `SessionSnapshot[]` from Cursor's composer conversation data (message counts, timestamps, model detection).
- **`packages/cli/src/drivers/session/cursor-session-driver.ts`** — DB session driver with `lastUpdatedAt` watermark for incremental sync.

### Modified files (8)
- **`packages/core/src/types.ts`** — Added `"cursor"` to `Source` union type, `CursorSqliteCursor` interface, `cursorSqlite` to `SessionCursorState`
- **`packages/cli/src/drivers/registry.ts`** — Register cursor session driver, add `cursorDbPaths`/`openCursorDb` to opts
- **`packages/cli/src/utils/paths.ts`** — Cross-platform Cursor DB path discovery (macOS, Linux, Windows, SSH remote)
- **`packages/cli/src/commands/sync.ts`** — Add `cursor` to `sourceKey()` switch and result types
- **`packages/cli/src/commands/session-sync.ts`** — Wire cursor DB driver through options
- **`packages/cli/src/cli.ts`** — Connect cursor paths and add display lines
- **`packages/cli/src/__tests__/paths.test.ts`** — Update path property count assertion
- **`packages/cli/src/__tests__/session-sync.test.ts`** — Update `filesScanned` assertion to include `cursor`

## Notes
- **Session-only** — Cursor doesn't expose token usage data locally, so this is a session driver only (no token driver).
- Follows the same architecture as the existing opencode-sqlite driver.
- Supports both modern `cursorDiskKV` table format and older `ItemTable` format for backward compatibility.