### PR TITLE
test(l3): add Playwright spec for admin/compare/result

### DIFF
--- a/packages/web/e2e/admin.spec.ts
+++ b/packages/web/e2e/admin.spec.ts
@@ -11,6 +11,11 @@ test.describe("admin pages", () => {
     await expect(page.getByRole("heading", { level: 1 })).toContainText("Compare");
   });
 
+  test("compare result page loads", async ({ page }) => {
+    await page.goto("/admin/compare/result");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Compare");
+  });
+
   test("invites page loads", async ({ page }) => {
     await page.goto("/admin/invites");
     await expect(page.getByRole("heading", { level: 1 })).toContainText("Invite");


### PR DESCRIPTION
Closes #128

Adds the missing L3 Playwright spec for `/admin/compare/result` page.

Note: `/leaderboard/seasons` and `/leaderboard/seasons/[slug]` were already covered by existing tests in leaderboard.spec.ts (lines 41-51). Only `/admin/compare/result` was truly missing.

L3 page coverage: 35/36 → 36/36 (100%)