### PR TITLE
refactor(web): replace manual useEffect+fetch with SWR to eliminate set-state-in-effect lint bypasses

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
         "react-dom": "^19.2.0",
         "recharts": "^3.8.0",
         "sharp": "^0.34.5",
+        "swr": "^2.4.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
       },
@@ -943,6 +944,8 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
@@ -1304,6 +1307,8 @@
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.2.0",
     "recharts": "^3.8.0",
     "sharp": "^0.34.5",
+    "swr": "^2.4.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/packages/web/src/app/(dashboard)/admin/badges/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/badges/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import Image from "next/image";
 import {
   Plus,
@@ -374,43 +376,33 @@ function AssignBadgeDialog({
 }: AssignBadgeDialogProps) {
   const [selectedBadgeId, setSelectedBadgeId] = useState<string>("");
   const [userQuery, setUserQuery] = useState("");
-  const [userResults, setUserResults] = useState<UserSearchResult[]>([]);
+  const [debouncedQuery, setDebouncedQuery] = useState("");
   const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(null);
   const [note, setNote] = useState("");
   const [loading, setLoading] = useState(false);
-  const [searching, setSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const activeBadges = badges.filter((b) => b.is_archived === 0);
   const selectedBadge = badges.find((b) => b.id === selectedBadgeId);
 
-  // Search users
+  // Debounce the user query
   useEffect(() => {
-    if (userQuery.length < 2) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-      setUserResults([]);
-      return;
-    }
-
-    const timer = setTimeout(async () => {
-      setSearching(true);
-      try {
-        const res = await fetch(
-          `/api/admin/users?q=${encodeURIComponent(userQuery)}&limit=10`,
-        );
-        if (res.ok) {
-          const data = await res.json();
-          setUserResults(data.users ?? []);
-        }
-      } catch {
-        // ignore
-      } finally {
-        setSearching(false);
-      }
+    const timer = setTimeout(() => {
+      setDebouncedQuery(userQuery);
     }, 300);
-
     return () => clearTimeout(timer);
   }, [userQuery]);
+
+  // Search users via SWR
+  const { data: searchData, isLoading: searching } = useSWR<{
+    users: UserSearchResult[];
+  }>(
+    debouncedQuery.length >= 2
+      ? `/api/admin/users?q=${encodeURIComponent(debouncedQuery)}&limit=10`
+      : null,
+    fetcher
+  );
+  const userResults = searchData?.users ?? [];
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -540,7 +532,8 @@ function AssignBadgeDialog({
                         type="button"
                         onClick={() => {
                           setSelectedUser(user);
-                          setUserResults([]);
+                          setUserQuery("");
+                          setDebouncedQuery("");
                         }}
                         className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-secondary"
                       >
@@ -629,17 +622,18 @@ interface RevokeDialogProps {
 function RevokeDialog({ open, isActive, onClose, onConfirm }: RevokeDialogProps) {
   const [reason, setReason] = useState("");
   const [loading, setLoading] = useState(false);
+  const [prevOpen, setPrevOpen] = useState(open);
 
   const action = isActive ? "Revoke" : "Clear";
 
-  /* eslint-disable react-hooks/set-state-in-effect -- reset state when dialog closes */
-  useEffect(() => {
+  // Reset form state when dialog closes (render-time)
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (!open) {
       setReason("");
       setLoading(false);
     }
-  }, [open]);
-  /* eslint-enable react-hooks/set-state-in-effect */
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -829,9 +823,6 @@ export default function AdminBadgesPage() {
   const { isAdmin, loading: adminLoading } = useAdmin();
 
   const [activeTab, setActiveTab] = useState<TabId>("definitions");
-  const [badges, setBadges] = useState<BadgeRow[]>([]);
-  const [assignments, setAssignments] = useState<BadgeAssignmentRow[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
@@ -846,54 +837,42 @@ export default function AdminBadgesPage() {
 
   const { confirm, dialogProps } = useConfirm();
 
-  // Load data
-  const loadBadges = useCallback(async () => {
-    try {
-      const res = await fetch("/api/admin/badges");
-      if (!res.ok) throw new Error("Failed to load badges");
-      const data = await res.json();
-      setBadges(data.badges ?? []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load badges");
-    }
-  }, []);
+  // SWR-backed data
+  const {
+    data: badgesData,
+    isLoading: badgesLoading,
+    mutate: mutateBadges,
+  } = useSWR<{ badges: BadgeRow[] }>(
+    isAdmin ? "/api/admin/badges" : null,
+    fetcher
+  );
+  const badges = badgesData?.badges ?? [];
 
-  const loadAssignments = useCallback(async () => {
-    try {
-      const statusParam = statusFilter === "all" ? "all" : statusFilter;
-      const res = await fetch(
-        `/api/admin/badges/assignments?status=${statusParam}&limit=100`,
-      );
-      if (!res.ok) throw new Error("Failed to load assignments");
-      const data = await res.json();
-      setAssignments(data.assignments ?? []);
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load assignments",
-      );
-    }
-  }, [statusFilter]);
+  const statusParam = statusFilter === "all" ? "all" : statusFilter;
+  const {
+    data: assignmentsData,
+    isLoading: assignmentsLoading,
+    mutate: mutateAssignments,
+  } = useSWR<{ assignments: BadgeAssignmentRow[] }>(
+    isAdmin ? `/api/admin/badges/assignments?status=${statusParam}&limit=100` : null,
+    fetcher
+  );
+  const assignments = assignmentsData?.assignments ?? [];
+
+  const loading = badgesLoading || assignmentsLoading;
+
+  const loadBadges = useCallback(() => mutateBadges(), [mutateBadges]);
+  const loadAssignments = useCallback(
+    () => mutateAssignments(),
+    [mutateAssignments]
+  );
 
   useEffect(() => {
     if (adminLoading) return;
     if (!isAdmin) {
       router.push("/dashboard");
-      return;
     }
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    setLoading(true);
-    Promise.all([loadBadges(), loadAssignments()]).finally(() =>
-      setLoading(false),
-    );
-  }, [isAdmin, adminLoading, router, loadBadges, loadAssignments]);
-
-  // Reload assignments when filter changes
-  useEffect(() => {
-    if (!isAdmin || loading) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    loadAssignments();
-  }, [statusFilter, isAdmin, loading, loadAssignments]);
+  }, [isAdmin, adminLoading, router]);
 
   // Actions
   const handleArchive = async (badgeId: string) => {

--- a/packages/web/src/app/(dashboard)/admin/compare/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/compare/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo, Suspense } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowUpDown,
@@ -44,6 +46,8 @@ type SortDir = "asc" | "desc";
 // ---------------------------------------------------------------------------
 // Skeleton
 // ---------------------------------------------------------------------------
+
+const EMPTY_USERS: StorageUserRow[] = [];
 
 function SelectionSkeleton() {
   return (
@@ -128,10 +132,17 @@ function ComparePageContent() {
   const searchParams = useSearchParams();
   const { isAdmin, loading: adminLoading } = useAdmin();
 
-  // Users data
-  const [users, setUsers] = useState<StorageUserRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data, error: swrError, isLoading } = useSWR<{
+    users: StorageUserRow[];
+    summary: StorageSummary;
+  }>(isAdmin ? "/api/admin/storage" : null, fetcher);
+  const users = data?.users ?? EMPTY_USERS;
+  const loading = isAdmin ? isLoading : false;
+  const error = swrError
+    ? swrError instanceof Error
+      ? swrError.message
+      : "Failed to load."
+    : null;
 
   // Selected users (restore from URL if present)
   const initialUserIds = useMemo(() => {
@@ -155,36 +166,6 @@ function ComparePageContent() {
       router.replace("/");
     }
   }, [adminLoading, isAdmin, router]);
-
-  // ---------------------------------------------------------------------------
-  // Fetch data
-  // ---------------------------------------------------------------------------
-
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch("/api/admin/storage");
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const json = (await res.json()) as {
-        users: StorageUserRow[];
-        summary: StorageSummary;
-      };
-      setUsers(json.users);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load.");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    if (isAdmin) fetchData();
-  }, [isAdmin, fetchData]);
 
   // ---------------------------------------------------------------------------
   // Sort handler

--- a/packages/web/src/app/(dashboard)/admin/compare/result/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/compare/result/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, Suspense } from "react";
+import { useState, useEffect, useMemo, Suspense } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import { formatTokens, formatTokensFull } from "@/lib/utils";
@@ -161,10 +163,27 @@ function CompareResultContent() {
   const [sourceFilter, setSourceFilter] = useState("");
   const [modelFilter, setModelFilter] = useState("");
 
-  // Data
-  const [data, setData] = useState<CompareResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Data via SWR
+  const swrKey = useMemo(() => {
+    if (!isAdmin || userIds.length === 0) return null;
+    const params = new URLSearchParams({
+      userIds: userIds.join(","),
+      from: dateFrom,
+      to: dateTo,
+      tzOffset: String(new Date().getTimezoneOffset()),
+    });
+    if (sourceFilter) params.set("source", sourceFilter);
+    if (modelFilter) params.set("model", modelFilter);
+    return `/api/admin/usage/compare?${params}`;
+  }, [isAdmin, userIds, dateFrom, dateTo, sourceFilter, modelFilter]);
+
+  const { data, error: swrError, isLoading } = useSWR<CompareResponse>(swrKey, fetcher);
+  const loading = swrKey ? isLoading : false;
+  const error = swrError
+    ? swrError instanceof Error
+      ? swrError.message
+      : "Failed to load."
+    : null;
 
   // ---------------------------------------------------------------------------
   // Redirect non-admins or invalid params
@@ -181,52 +200,6 @@ function CompareResultContent() {
       router.replace("/admin/compare");
     }
   }, [adminLoading, userIds.length, router]);
-
-  // ---------------------------------------------------------------------------
-  // Fetch comparison data
-  // ---------------------------------------------------------------------------
-
-  const fetchData = useCallback(async () => {
-    if (userIds.length === 0) {
-      setData(null);
-      return;
-    }
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const params = new URLSearchParams({
-        userIds: userIds.join(","),
-        from: dateFrom,
-        to: dateTo,
-        tzOffset: String(new Date().getTimezoneOffset()),
-      });
-      if (sourceFilter) params.set("source", sourceFilter);
-      if (modelFilter) params.set("model", modelFilter);
-
-      const res = await fetch(`/api/admin/usage/compare?${params}`);
-      if (!res.ok) {
-        const json = await res.json().catch(() => ({}));
-        throw new Error(
-          (json as { error?: string }).error ?? `HTTP ${res.status}`
-        );
-      }
-
-      const json = (await res.json()) as CompareResponse;
-      setData(json);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load.");
-      setData(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [userIds, dateFrom, dateTo, sourceFilter, modelFilter]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    if (isAdmin && userIds.length > 0) fetchData();
-  }, [isAdmin, userIds.length, fetchData]);
 
   // ---------------------------------------------------------------------------
   // Chart data

--- a/packages/web/src/app/(dashboard)/admin/invites/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/invites/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import { useRouter } from "next/navigation";
 import { Plus, Trash2, Copy, Check, ClipboardList } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -21,6 +23,8 @@ type StatusFilter = "all" | "available";
 // ---------------------------------------------------------------------------
 // Skeleton
 // ---------------------------------------------------------------------------
+
+const EMPTY_ROWS: InviteCodeRow[] = [];
 
 function InvitesSkeleton() {
   return (
@@ -94,14 +98,41 @@ export default function AdminInvitesPage() {
   const router = useRouter();
   const { isAdmin, loading: adminLoading } = useAdmin();
 
-  const [rows, setRows] = useState<InviteCodeRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    data: rowsData,
+    error: rowsError,
+    isLoading: rowsLoading,
+    mutate: mutateRows,
+  } = useSWR<{ rows: InviteCodeRow[] }>(
+    isAdmin ? "/api/admin/invites" : null,
+    fetcher,
+  );
+  const rows = rowsData?.rows ?? EMPTY_ROWS;
+  const loading = isAdmin ? rowsLoading : false;
+  const error = rowsError
+    ? rowsError instanceof Error
+      ? rowsError.message
+      : "Failed to load."
+    : null;
   const [message, setMessage] = useState<MessageBannerMsg | null>(null);
 
-  // Require invite code toggle
+  // Require invite code toggle — backed by SWR, synced to local state for optimistic toggles.
+  const {
+    data: settingsData,
+    isLoading: settingsLoading,
+    mutate: mutateSettings,
+  } = useSWR<{ settings: Array<{ key: string; value: string }> }>(
+    isAdmin ? "/api/admin/settings" : null,
+    fetcher,
+  );
   const [requireInvite, setRequireInvite] = useState(true);
-  const [requireInviteLoading, setRequireInviteLoading] = useState(true);
+  const [syncedSettings, setSyncedSettings] = useState<typeof settingsData>(undefined);
+  if (settingsData && settingsData !== syncedSettings) {
+    setSyncedSettings(settingsData);
+    const setting = settingsData.settings.find((s) => s.key === "require_invite_code");
+    setRequireInvite(setting?.value !== "false");
+  }
+  const requireInviteLoading = isAdmin ? settingsLoading : false;
   const [togglingRequireInvite, setTogglingRequireInvite] = useState(false);
 
   // Filter
@@ -137,58 +168,12 @@ export default function AdminInvitesPage() {
   }, [adminLoading, isAdmin, router]);
 
   // ---------------------------------------------------------------------------
-  // Fetch rows
+  // Refetch helper (after mutations)
   // ---------------------------------------------------------------------------
 
-  const fetchRows = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch("/api/admin/invites");
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const json = (await res.json()) as { rows: InviteCodeRow[] };
-      setRows(json.rows);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load.");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    if (isAdmin) fetchRows();
-  }, [isAdmin, fetchRows]);
-
-  // ---------------------------------------------------------------------------
-  // Fetch require_invite_code setting
-  // ---------------------------------------------------------------------------
-
-  const fetchRequireInvite = useCallback(async () => {
-    setRequireInviteLoading(true);
-    try {
-      const res = await fetch("/api/admin/settings");
-      if (res.ok) {
-        const json = (await res.json()) as {
-          settings: Array<{ key: string; value: string }>;
-        };
-        const setting = json.settings.find((s) => s.key === "require_invite_code");
-        setRequireInvite(setting?.value !== "false");
-      }
-    } catch {
-      // Silently fail, default to true
-    } finally {
-      setRequireInviteLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    if (isAdmin) fetchRequireInvite();
-  }, [isAdmin, fetchRequireInvite]);
+  const fetchRows = useCallback(() => {
+    void mutateRows();
+  }, [mutateRows]);
 
   // ---------------------------------------------------------------------------
   // Toggle require_invite_code
@@ -217,6 +202,7 @@ export default function AdminInvitesPage() {
       }
 
       setRequireInvite(newValue);
+      void mutateSettings();
       setMessage({
         type: "success",
         text: newValue

--- a/packages/web/src/app/(dashboard)/admin/organizations/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/organizations/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import {
   Plus,
   Pencil,
@@ -625,9 +627,21 @@ export default function AdminOrganizationsPage() {
   const router = useRouter();
   const { isAdmin, loading: adminLoading } = useAdmin();
 
-  const [rows, setRows] = useState<OrgRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    data: orgData,
+    error: swrError,
+    isLoading: loading,
+    mutate: mutateRows,
+  } = useSWR<{ organizations: OrgRow[] }>(
+    isAdmin ? "/api/admin/organizations" : null,
+    fetcher
+  );
+  const rows = orgData?.organizations ?? [];
+  const error = swrError
+    ? swrError instanceof Error
+      ? swrError.message
+      : "Failed to load."
+    : null;
   const [message, setMessage] = useState<MessageBannerMsg | null>(null);
 
   const [showCreate, setShowCreate] = useState(false);
@@ -644,25 +658,7 @@ export default function AdminOrganizationsPage() {
   }, [adminLoading, isAdmin, router]);
 
   // Fetch rows
-  const fetchRows = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch("/api/admin/organizations");
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = (await res.json()) as { organizations: OrgRow[] };
-      setRows(json.organizations);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load.");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    if (isAdmin) fetchRows();
-  }, [isAdmin, fetchRows]);
+  const fetchRows = () => mutateRows();
 
   // Delete org
   const handleDelete = async (org: OrgRow) => {

--- a/packages/web/src/app/(dashboard)/admin/seasons/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/seasons/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import {
   Plus,
   Pencil,
@@ -589,9 +591,21 @@ export default function AdminSeasonsPage() {
   const router = useRouter();
   const { isAdmin, loading: adminLoading } = useAdmin();
 
-  const [rows, setRows] = useState<SeasonRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    data: seasonData,
+    error: swrError,
+    isLoading: loading,
+    mutate: mutateRows,
+  } = useSWR<{ seasons: SeasonRow[] }>(
+    isAdmin ? "/api/admin/seasons" : null,
+    fetcher
+  );
+  const rows = seasonData?.seasons ?? [];
+  const error = swrError
+    ? swrError instanceof Error
+      ? swrError.message
+      : "Failed to load."
+    : null;
   const [message, setMessage] = useState<MessageBannerMsg | null>(null);
 
   // Create form toggle
@@ -628,28 +642,7 @@ export default function AdminSeasonsPage() {
   // Fetch rows
   // ---------------------------------------------------------------------------
 
-  const fetchRows = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch("/api/admin/seasons");
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const json = (await res.json()) as { seasons: SeasonRow[] };
-      setRows(json.seasons);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load.");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    if (isAdmin) fetchRows();
-  }, [isAdmin, fetchRows]);
+  const fetchRows = useCallback(() => mutateRows(), [mutateRows]);
 
   // ---------------------------------------------------------------------------
   // Fetch registered teams for a season

--- a/packages/web/src/app/(dashboard)/admin/showcases/admin-showcases-content.tsx
+++ b/packages/web/src/app/(dashboard)/admin/showcases/admin-showcases-content.tsx
@@ -4,7 +4,9 @@
 
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import {
   Eye,
   EyeOff,
@@ -69,113 +71,119 @@ const PAGE_SIZE = 50;
 type StatusFilter = "all" | "public" | "hidden";
 
 export function AdminShowcasesContent() {
-  const [data, setData] = useState<AdminShowcasesResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const { confirm, dialogProps } = useConfirm();
 
-  // Fetch data
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const queryString = (() => {
+    const params = new URLSearchParams();
+    params.set("limit", String(PAGE_SIZE));
+    params.set("offset", String(offset));
+    if (statusFilter === "public") params.set("is_public", "1");
+    if (statusFilter === "hidden") params.set("is_public", "0");
+    return params.toString();
+  })();
 
-    try {
-      const params = new URLSearchParams();
-      params.set("limit", String(PAGE_SIZE));
-      params.set("offset", String(offset));
-      if (statusFilter === "public") params.set("is_public", "1");
-      if (statusFilter === "hidden") params.set("is_public", "0");
+  const {
+    data,
+    error: swrError,
+    isLoading: loading,
+    mutate,
+  } = useSWR<AdminShowcasesResponse>(
+    `/api/admin/showcases?${queryString}`,
+    fetcher
+  );
+  const error = swrError
+    ? swrError instanceof Error
+      ? swrError.message
+      : "Unknown error"
+    : null;
 
-      const res = await fetch(`/api/admin/showcases?${params.toString()}`);
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
-      }
-
-      const json = (await res.json()) as AdminShowcasesResponse;
-      setData(json);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      setLoading(false);
-    }
-  }, [offset, statusFilter]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchData();
-  }, [fetchData]);
+  const fetchData = useCallback(() => mutate(), [mutate]);
 
   // Toggle visibility
-  const handleToggleVisibility = useCallback(async (id: string, currentPublic: boolean) => {
-    setActionLoading(id);
-    try {
-      const res = await fetch(`/api/showcases/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ is_public: !currentPublic }),
-      });
+  const handleToggleVisibility = useCallback(
+    async (id: string, currentPublic: boolean) => {
+      setActionLoading(id);
+      try {
+        const res = await fetch(`/api/showcases/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ is_public: !currentPublic }),
+        });
 
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error((body as { error?: string }).error ?? "Failed to update");
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(
+            (body as { error?: string }).error ?? "Failed to update"
+          );
+        }
+
+        // Optimistic update
+        await mutate(
+          (prev) =>
+            prev
+              ? {
+                  ...prev,
+                  showcases: prev.showcases.map((s) =>
+                    s.id === id ? { ...s, is_public: !currentPublic } : s
+                  ),
+                }
+              : prev,
+          { revalidate: false }
+        );
+      } catch (err) {
+        alert(err instanceof Error ? err.message : "Failed to update showcase");
+      } finally {
+        setActionLoading(null);
       }
-
-      // Optimistic update
-      setData((prev) =>
-        prev
-          ? {
-              ...prev,
-              showcases: prev.showcases.map((s) =>
-                s.id === id ? { ...s, is_public: !currentPublic } : s
-              ),
-            }
-          : null
-      );
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to update showcase");
-    } finally {
-      setActionLoading(null);
-    }
-  }, []);
+    },
+    [mutate]
+  );
 
   // Delete
-  const handleDelete = useCallback(async (id: string) => {
-    const confirmed = await confirm({
-      title: "Delete showcase?",
-      description: "Are you sure you want to delete this showcase? This action cannot be undone.",
-      confirmText: "Delete",
-      variant: "destructive",
-    });
-    if (!confirmed) return;
+  const handleDelete = useCallback(
+    async (id: string) => {
+      const confirmed = await confirm({
+        title: "Delete showcase?",
+        description:
+          "Are you sure you want to delete this showcase? This action cannot be undone.",
+        confirmText: "Delete",
+        variant: "destructive",
+      });
+      if (!confirmed) return;
 
-    setActionLoading(id);
-    try {
-      const res = await fetch(`/api/showcases/${id}`, { method: "DELETE" });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error((body as { error?: string }).error ?? "Failed to delete");
+      setActionLoading(id);
+      try {
+        const res = await fetch(`/api/showcases/${id}`, { method: "DELETE" });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(
+            (body as { error?: string }).error ?? "Failed to delete"
+          );
+        }
+
+        // Remove from list
+        await mutate(
+          (prev) =>
+            prev
+              ? {
+                  ...prev,
+                  showcases: prev.showcases.filter((s) => s.id !== id),
+                  total: prev.total - 1,
+                }
+              : prev,
+          { revalidate: false }
+        );
+      } catch (err) {
+        alert(err instanceof Error ? err.message : "Failed to delete showcase");
+      } finally {
+        setActionLoading(null);
       }
-
-      // Remove from list
-      setData((prev) =>
-        prev
-          ? {
-              ...prev,
-              showcases: prev.showcases.filter((s) => s.id !== id),
-              total: prev.total - 1,
-            }
-          : null
-      );
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to delete showcase");
-    } finally {
-      setActionLoading(null);
-    }
-  }, [confirm]);
+    },
+    [confirm, mutate]
+  );
 
   // Loading state
   if (loading && !data) {

--- a/packages/web/src/app/(dashboard)/admin/storage/page.tsx
+++ b/packages/web/src/app/(dashboard)/admin/storage/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import {
   ArrowUpDown,
   ArrowUp,
@@ -114,6 +116,9 @@ function describeCacheKey(key: string): { type: string; description: string } {
 // Skeleton
 // ---------------------------------------------------------------------------
 
+const EMPTY_USERS: StorageUserRow[] = [];
+const EMPTY_KEYS: string[] = [];
+
 function StorageSkeleton() {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -221,11 +226,23 @@ export default function AdminStoragePage() {
   const router = useRouter();
   const { isAdmin, loading: adminLoading } = useAdmin();
 
-  // DB data
-  const [users, setUsers] = useState<StorageUserRow[]>([]);
-  const [summary, setSummary] = useState<StorageSummary | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // DB data — SWR
+  const {
+    data: storageData,
+    error: storageError,
+    isLoading: storageLoading,
+  } = useSWR<{ users: StorageUserRow[]; summary: StorageSummary }>(
+    isAdmin ? "/api/admin/storage" : null,
+    fetcher
+  );
+  const users = storageData?.users ?? EMPTY_USERS;
+  const summary = storageData?.summary ?? null;
+  const loading = storageLoading;
+  const error = storageError
+    ? storageError instanceof Error
+      ? storageError.message
+      : "Failed to load."
+    : null;
 
   // Filter & sort
   const [search, setSearch] = useState("");
@@ -237,14 +254,31 @@ export default function AdminStoragePage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogTab, setDialogTab] = useState<ProfileDialogTab>("total");
 
-  // Cache management
-  const [cacheKeys, setCacheKeys] = useState<string[]>([]);
-  const [cacheCount, setCacheCount] = useState(0);
-  const [cacheTruncated, setCacheTruncated] = useState(false);
-  const [cacheLoading, setCacheLoading] = useState(false);
+  // Cache management — SWR
+  const {
+    data: cacheData,
+    error: cacheSwrError,
+    isLoading: cacheLoading,
+    mutate: mutateCache,
+  } = useSWR<CacheListResponse>(
+    isAdmin ? "/api/admin/cache" : null,
+    fetcher
+  );
+  const cacheKeys = cacheData?.keys ?? EMPTY_KEYS;
+  const cacheCount = cacheData?.count ?? 0;
+  const cacheTruncated = cacheData?.truncated ?? false;
   const [cacheClearing, setCacheClearing] = useState(false);
   const [cacheDeletingKey, setCacheDeletingKey] = useState<string | null>(null);
-  const [cacheError, setCacheError] = useState<string | null>(null);
+  const [cacheMutationError, setCacheMutationError] = useState<string | null>(
+    null
+  );
+  const cacheError =
+    cacheMutationError ??
+    (cacheSwrError
+      ? cacheSwrError instanceof Error
+        ? cacheSwrError.message
+        : "Failed to load"
+      : null);
 
   const openProfileDialog = useCallback(
     (user: StorageUserRow, tab: ProfileDialogTab = "total") => {
@@ -260,41 +294,31 @@ export default function AdminStoragePage() {
   // ---------------------------------------------------------------------------
 
   const fetchCacheKeys = useCallback(async () => {
-    setCacheLoading(true);
-    setCacheError(null);
-    try {
-      const res = await fetch("/api/admin/cache");
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = (await res.json()) as CacheListResponse;
-      setCacheKeys(data.keys);
-      setCacheCount(data.count);
-      setCacheTruncated(data.truncated);
-    } catch (err) {
-      setCacheError(err instanceof Error ? err.message : "Failed to load");
-    } finally {
-      setCacheLoading(false);
-    }
-  }, []);
+    setCacheMutationError(null);
+    await mutateCache();
+  }, [mutateCache]);
 
   const handleClearCache = useCallback(async () => {
     if (!confirm("Clear all cache entries? This cannot be undone.")) return;
     setCacheClearing(true);
-    setCacheError(null);
+    setCacheMutationError(null);
     try {
       const res = await fetch("/api/admin/cache", { method: "DELETE" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = (await res.json()) as CacheClearResponse;
       // Refresh list after clearing
-      await fetchCacheKeys();
+      await mutateCache();
       alert(
         `Cleared ${data.deleted} cache entries${data.truncated ? " (more remain)" : ""}`
       );
     } catch (err) {
-      setCacheError(err instanceof Error ? err.message : "Failed to clear");
+      setCacheMutationError(
+        err instanceof Error ? err.message : "Failed to clear"
+      );
     } finally {
       setCacheClearing(false);
     }
-  }, [fetchCacheKeys]);
+  }, [mutateCache]);
 
   const handleInvalidateKey = useCallback(
     async (key: string) => {
@@ -306,16 +330,16 @@ export default function AdminStoragePage() {
         );
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         // Refresh list
-        await fetchCacheKeys();
+        await mutateCache();
       } catch (err) {
-        setCacheError(
+        setCacheMutationError(
           err instanceof Error ? err.message : "Failed to invalidate"
         );
       } finally {
         setCacheDeletingKey(null);
       }
     },
-    [fetchCacheKeys]
+    [mutateCache]
   );
 
   // ---------------------------------------------------------------------------
@@ -327,40 +351,6 @@ export default function AdminStoragePage() {
       router.replace("/");
     }
   }, [adminLoading, isAdmin, router]);
-
-  // ---------------------------------------------------------------------------
-  // Fetch data
-  // ---------------------------------------------------------------------------
-
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch("/api/admin/storage");
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const json = (await res.json()) as {
-        users: StorageUserRow[];
-        summary: StorageSummary;
-      };
-      setUsers(json.users);
-      setSummary(json.summary);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load.");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (isAdmin) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-      fetchData();
-      fetchCacheKeys();
-    }
-  }, [isAdmin, fetchData, fetchCacheKeys]);
 
   // ---------------------------------------------------------------------------
   // Sort handler

--- a/packages/web/src/app/(dashboard)/manage-devices/page.tsx
+++ b/packages/web/src/app/(dashboard)/manage-devices/page.tsx
@@ -271,20 +271,19 @@ function AuthCodeModal({
   const [copiedCode, setCopiedCode] = useState(false);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Reset state when modal closes
-  useEffect(() => {
+  // Reset state when modal closes — render-time update pattern.
+  // (The countdown interval is cleaned up by the useEffect below when
+  // authCodeExpiresAt becomes null.)
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (!open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
       setAuthCode(null);
       setAuthCodeExpiresAt(null);
       setAuthCodeRemaining(0);
       setCopiedCode(false);
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
-        countdownRef.current = null;
-      }
     }
-  }, [open]);
+  }
 
   // Countdown timer for auth code
   useEffect(() => {

--- a/packages/web/src/app/(dashboard)/model-prices/page.tsx
+++ b/packages/web/src/app/(dashboard)/model-prices/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
 import { useAdmin } from "@/hooks/use-admin";
 import { invalidatePricingEntries } from "@/hooks/use-pricing-entries";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { Skeleton } from "@/components/ui/skeleton";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import type {
   DynamicPricingEntryDto,
   DynamicPricingMetaDto,
@@ -32,31 +33,13 @@ function PageSkeleton() {
 export default function ModelPricesPage() {
   const { isAdmin } = useAdmin();
 
-  const [data, setData] = useState<ModelsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchModels = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch("/api/pricing/models");
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const json = (await res.json()) as ModelsResponse;
-      setData(json);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load.");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: standard React pattern
-    fetchModels();
-  }, [fetchModels]);
+  const { data, error: swrError, isLoading: loading, mutate } =
+    useSWR<ModelsResponse>("/api/pricing/models", fetcher);
+  const error = swrError
+    ? swrError instanceof Error
+      ? swrError.message
+      : "Failed to load."
+    : null;
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -74,7 +57,7 @@ export default function ModelPricesPage() {
       {data && (
         <>
           <PricingMetaBanner meta={data.meta} servedFrom={data.servedFrom}>
-            {isAdmin && <ForceSyncButton onComplete={() => { fetchModels(); invalidatePricingEntries(); }} />}
+            {isAdmin && <ForceSyncButton onComplete={() => { void mutate(); invalidatePricingEntries(); }} />}
           </PricingMetaBanner>
           <PricingTable entries={data.entries} />
         </>

--- a/packages/web/src/app/(dashboard)/settings/general/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/general/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { useSession, signOut } from "next-auth/react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import {
   User,
   ExternalLink,
@@ -31,12 +33,26 @@ export default function SettingsPage() {
   const { data: session } = useSession();
 
   // User settings state
+  const { data: settingsData, mutate: mutateSettings } = useSWR<UserSettings>(
+    "/api/settings",
+    fetcher,
+  );
   const [settings, setSettings] = useState<UserSettings | null>(null);
   const [nickname, setNickname] = useState("");
   const [slug, setSlug] = useState("");
   const [isPublic, setIsPublic] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  // Sync SWR data to local form state once per arrival (render-time update pattern).
+  const [syncedSettings, setSyncedSettings] = useState<UserSettings | null>(null);
+  if (settingsData && settingsData !== syncedSettings) {
+    setSyncedSettings(settingsData);
+    setSettings(settingsData);
+    setNickname(settingsData.nickname ?? "");
+    setSlug(settingsData.slug ?? "");
+    setIsPublic(settingsData.is_public ?? false);
+  }
 
   // Delete account state
   const [deleteConfirmEmail, setDeleteConfirmEmail] = useState("");
@@ -52,30 +68,6 @@ export default function SettingsPage() {
   const [copiedUrl, setCopiedUrl] = useState(false);
   const profileIdentifier = slug || userId;
   const profileUrl = profileIdentifier ? `https://pew.md/u/${profileIdentifier}` : null;
-
-  // ---------------------------------------------------------------------------
-  // Fetch settings
-  // ---------------------------------------------------------------------------
-
-  const fetchSettings = useCallback(async () => {
-    try {
-      const res = await fetch("/api/settings");
-      if (res.ok) {
-        const data = await res.json();
-        setSettings(data);
-        setNickname(data.nickname ?? "");
-        setSlug(data.slug ?? "");
-        setIsPublic(data.is_public ?? false);
-      }
-    } catch {
-      // Silently fail on initial load
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchSettings();
-  }, [fetchSettings]);
 
   // ---------------------------------------------------------------------------
   // Save settings
@@ -112,7 +104,9 @@ export default function SettingsPage() {
       if (res.ok) {
         const data = await res.json();
         setSettings(data);
+        setSyncedSettings(data);
         setIsPublic(data.is_public ?? false);
+        void mutateSettings(data, { revalidate: false });
         setSaveMessage({ type: "success", text: "Settings saved." });
       } else {
         const data = await res.json().catch(() => ({}));

--- a/packages/web/src/app/(dashboard)/settings/general/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/general/page.tsx
@@ -32,10 +32,12 @@ interface UserSettings {
 export default function SettingsPage() {
   const { data: session } = useSession();
 
-  // User settings state
+  // User settings state — disable focus revalidation to prevent overwriting
+  // unsaved form edits when the user tabs away and back.
   const { data: settingsData, mutate: mutateSettings } = useSWR<UserSettings>(
     "/api/settings",
     fetcher,
+    { revalidateOnFocus: false },
   );
   const [settings, setSettings] = useState<UserSettings | null>(null);
   const [nickname, setNickname] = useState("");

--- a/packages/web/src/app/(dashboard)/settings/organizations/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/organizations/page.tsx
@@ -90,8 +90,9 @@ export default function OrganizationsPage() {
           next.set(orgId, { joined: true, delta: 1 });
           return next;
         });
-        void mutateAll();
-        void mutateMine();
+        await mutateAll();
+        await mutateMine();
+        setOverrides(new Map());
       }
     } finally {
       setPendingAction(null);
@@ -108,8 +109,9 @@ export default function OrganizationsPage() {
           next.set(orgId, { joined: false, delta: -1 });
           return next;
         });
-        void mutateAll();
-        void mutateMine();
+        await mutateAll();
+        await mutateMine();
+        setOverrides(new Map());
       }
     } finally {
       setPendingAction(null);

--- a/packages/web/src/app/(dashboard)/settings/organizations/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/organizations/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import { Building2, Users, Check, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -34,50 +36,45 @@ interface OrgMember {
 // ---------------------------------------------------------------------------
 
 export default function OrganizationsPage() {
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
-  const [myOrgIds, setMyOrgIds] = useState<Set<string>>(new Set());
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data: allData, error: allError, isLoading: allLoading, mutate: mutateAll } =
+    useSWR<{ organizations: Organization[] }>("/api/organizations", fetcher);
+  const { data: mineData, error: mineError, isLoading: mineLoading, mutate: mutateMine } =
+    useSWR<{ organizations: Organization[] }>("/api/organizations/mine", fetcher);
+
+  const [overrides, setOverrides] = useState<
+    Map<string, { joined: boolean; delta: number }>
+  >(new Map());
   const [pendingAction, setPendingAction] = useState<string | null>(null);
+
+  const baseMyOrgIds = useMemo(
+    () => new Set((mineData?.organizations ?? []).map((o) => o.id)),
+    [mineData],
+  );
+
+  const myOrgIds = useMemo(() => {
+    const set = new Set(baseMyOrgIds);
+    for (const [id, ov] of overrides) {
+      if (ov.joined) set.add(id);
+      else set.delete(id);
+    }
+    return set;
+  }, [baseMyOrgIds, overrides]);
+
+  const organizations = useMemo(() => {
+    const base = allData?.organizations ?? [];
+    return base.map((o) => {
+      const ov = overrides.get(o.id);
+      return ov ? { ...o, memberCount: Math.max(0, o.memberCount + ov.delta) } : o;
+    });
+  }, [allData, overrides]);
+
+  const loading = allLoading || mineLoading;
+  const error = allError || mineError ? "Failed to load organizations" : null;
 
   // Members modal state
   const [membersModalOrg, setMembersModalOrg] = useState<Organization | null>(null);
   const [members, setMembers] = useState<OrgMember[]>([]);
   const [loadingMembers, setLoadingMembers] = useState(false);
-
-  // ---------------------------------------------------------------------------
-  // Fetch organizations
-  // ---------------------------------------------------------------------------
-
-  const fetchData = useCallback(async () => {
-    try {
-      setLoading(true);
-      const [allRes, mineRes] = await Promise.all([
-        fetch("/api/organizations"),
-        fetch("/api/organizations/mine"),
-      ]);
-
-      if (!allRes.ok || !mineRes.ok) {
-        setError("Failed to load organizations");
-        return;
-      }
-
-      const allData = await allRes.json();
-      const mineData = await mineRes.json();
-
-      setOrganizations(allData.organizations || []);
-      setMyOrgIds(new Set((mineData.organizations || []).map((o: { id: string }) => o.id)));
-    } catch {
-      setError("Failed to load organizations");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchData();
-  }, [fetchData]);
 
   // ---------------------------------------------------------------------------
   // Join / Leave
@@ -88,11 +85,13 @@ export default function OrganizationsPage() {
     try {
       const res = await fetch(`/api/organizations/${orgId}/join`, { method: "POST" });
       if (res.ok) {
-        setMyOrgIds((prev) => new Set([...prev, orgId]));
-        // Update member count
-        setOrganizations((prev) =>
-          prev.map((o) => (o.id === orgId ? { ...o, memberCount: o.memberCount + 1 } : o))
-        );
+        setOverrides((prev) => {
+          const next = new Map(prev);
+          next.set(orgId, { joined: true, delta: 1 });
+          return next;
+        });
+        void mutateAll();
+        void mutateMine();
       }
     } finally {
       setPendingAction(null);
@@ -104,15 +103,13 @@ export default function OrganizationsPage() {
     try {
       const res = await fetch(`/api/organizations/${orgId}/leave`, { method: "DELETE" });
       if (res.ok) {
-        setMyOrgIds((prev) => {
-          const next = new Set(prev);
-          next.delete(orgId);
+        setOverrides((prev) => {
+          const next = new Map(prev);
+          next.set(orgId, { joined: false, delta: -1 });
           return next;
         });
-        // Update member count
-        setOrganizations((prev) =>
-          prev.map((o) => (o.id === orgId ? { ...o, memberCount: Math.max(0, o.memberCount - 1) } : o))
-        );
+        void mutateAll();
+        void mutateMine();
       }
     } finally {
       setPendingAction(null);

--- a/packages/web/src/app/(dashboard)/teams/[teamId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/teams/[teamId]/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useCallback, useRef } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import { useParams, useRouter } from "next/navigation";
 import {
   Users,
@@ -349,9 +351,13 @@ export default function TeamDetailPage() {
   const router = useRouter();
   const teamId = params.teamId;
 
-  const [team, setTeam] = useState<TeamDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data: team, error: swrError, isLoading: loading, mutate: mutateTeam } =
+    useSWR<TeamDetail>(teamId ? `/api/teams/${teamId}` : null, fetcher);
+  const error = swrError
+    ? swrError instanceof Error
+      ? swrError.message
+      : "Failed to load team"
+    : null;
   const [message, setMessage] = useState<MessageBannerMsg | null>(null);
 
   // Profile dialog state
@@ -374,40 +380,24 @@ export default function TeamDetailPage() {
   const [savingName, setSavingName] = useState(false);
   const editInputRef = useRef<HTMLInputElement>(null);
 
-  // Auto-register state (for conditional rendering of season list)
+  // Auto-register: sync from SWR data using render-time update pattern.
   const [autoRegisterEnabled, setAutoRegisterEnabled] = useState(false);
+  const [prevTeamId, setPrevTeamId] = useState<string | null>(null);
+  const [prevAutoRegister, setPrevAutoRegister] = useState<boolean | null>(null);
+  if (team && (team.id !== prevTeamId || team.auto_register_season !== prevAutoRegister)) {
+    setPrevTeamId(team.id);
+    setPrevAutoRegister(team.auto_register_season);
+    setAutoRegisterEnabled(team.auto_register_season);
+  }
 
   const handleMemberClick = useCallback((member: TeamMember) => {
     setDialogMember(member);
     setDialogOpen(true);
   }, []);
 
-  const fetchTeam = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch(`/api/teams/${teamId}`);
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `HTTP ${res.status}`,
-        );
-      }
-      const data = (await res.json()) as TeamDetail;
-      setTeam(data);
-      setAutoRegisterEnabled(data.auto_register_season);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load team");
-    } finally {
-      setLoading(false);
-    }
-  }, [teamId]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchTeam();
-  }, [fetchTeam]);
+  const fetchTeam = useCallback(() => {
+    void mutateTeam();
+  }, [mutateTeam]);
 
   // -------------------------------------------------------------------------
   // Logo upload/remove (owner only)

--- a/packages/web/src/app/(dashboard)/teams/page.tsx
+++ b/packages/web/src/app/(dashboard)/teams/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useState } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
@@ -190,7 +192,11 @@ function TeamCard({
 // ---------------------------------------------------------------------------
 
 export default function TeamsPage() {
-  const [teams, setTeams] = useState<Team[]>([]);
+  const { data: teamsData, mutate: mutateTeams } = useSWR<{ teams: Team[] }>(
+    "/api/teams",
+    fetcher,
+  );
+  const teams = teamsData?.teams ?? [];
   const [showCreateTeam, setShowCreateTeam] = useState(false);
   const [newTeamName, setNewTeamName] = useState("");
   const [creatingTeam, setCreatingTeam] = useState(false);
@@ -201,26 +207,9 @@ export default function TeamsPage() {
   const { data: session } = useSession();
   const currentUserId = session?.user?.id ?? null;
 
-  // ---------------------------------------------------------------------------
-  // Fetch teams
-  // ---------------------------------------------------------------------------
-
-  const fetchTeams = useCallback(async () => {
-    try {
-      const res = await fetch("/api/teams");
-      if (res.ok) {
-        const data = await res.json();
-        setTeams(data.teams ?? []);
-      }
-    } catch {
-      // Silently fail
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchTeams();
-  }, [fetchTeams]);
+  const fetchTeams = useCallback(() => {
+    void mutateTeams();
+  }, [mutateTeams]);
 
   // ---------------------------------------------------------------------------
   // Create team

--- a/packages/web/src/components/showcase/showcase-form-modal.tsx
+++ b/packages/web/src/components/showcase/showcase-form-modal.tsx
@@ -91,16 +91,20 @@ export function ShowcaseFormModal({
     og_image_url: string;
   } | null>(null);
 
-  // Initialize form for edit mode
-  useEffect(() => {
+  // Initialize / reset form when open state changes. Runs during render via
+  // the "reset state on prop change" pattern rather than inside an effect.
+  const [prevOpen, setPrevOpen] = useState(open);
+  const [prevEditId, setPrevEditId] = useState<string | null>(editData?.id ?? null);
+  const currentEditId = editData?.id ?? null;
+  if (prevOpen !== open || prevEditId !== currentEditId) {
+    setPrevOpen(open);
+    setPrevEditId(currentEditId);
     if (editMode && editData && open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
       setGithubUrl(editData.github_url);
       setTagline(editData.tagline || "");
       setIsPublic(editData.is_public);
       setRefreshedData(null);
     } else if (!open) {
-      // Reset on close
       setGithubUrl("");
       setTagline("");
       setIsPublic(true);
@@ -108,7 +112,7 @@ export function ShowcaseFormModal({
       resetPreview();
       setRefreshedData(null);
     }
-  }, [editMode, editData, open, resetPreview]);
+  }
 
   // Invalidate preview when URL changes after successful preview (add mode only)
   useEffect(() => {

--- a/packages/web/src/components/showcase/upvote-button.tsx
+++ b/packages/web/src/components/showcase/upvote-button.tsx
@@ -1,10 +1,6 @@
-/**
- * Upvote button with optimistic toggle.
- */
-
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -18,6 +14,11 @@ interface UpvoteButtonProps {
   disabled?: boolean;
 }
 
+interface OverrideState {
+  count: number;
+  upvoted: boolean;
+}
+
 export function UpvoteButton({
   showcaseId,
   initialCount,
@@ -27,16 +28,20 @@ export function UpvoteButton({
   onUpvoteChange,
   disabled = false,
 }: UpvoteButtonProps) {
-  const [count, setCount] = useState(initialCount);
-  const [upvoted, setUpvoted] = useState(initialUpvoted === true);
+  const [override, setOverride] = useState<OverrideState | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Sync with parent when props change (e.g., after refetch)
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    setCount(initialCount);
-    setUpvoted(initialUpvoted === true);
-  }, [initialCount, initialUpvoted]);
+  // Reset optimistic override when parent props change (update-state-during-render pattern)
+  const [prevInitialCount, setPrevInitialCount] = useState(initialCount);
+  const [prevInitialUpvoted, setPrevInitialUpvoted] = useState(initialUpvoted);
+  if (prevInitialCount !== initialCount || prevInitialUpvoted !== initialUpvoted) {
+    setPrevInitialCount(initialCount);
+    setPrevInitialUpvoted(initialUpvoted);
+    setOverride(null);
+  }
+
+  const count = override?.count ?? initialCount;
+  const upvoted = override?.upvoted ?? initialUpvoted === true;
 
   const handleClick = useCallback(async () => {
     if (!isLoggedIn) {
@@ -46,11 +51,10 @@ export function UpvoteButton({
 
     if (loading || disabled) return;
 
-    // Optimistic update
-    const prevCount = count;
-    const prevUpvoted = upvoted;
-    setUpvoted(!upvoted);
-    setCount(upvoted ? count - 1 : count + 1);
+    const prevOverride = override;
+    const nextUpvoted = !upvoted;
+    const nextCount = upvoted ? count - 1 : count + 1;
+    setOverride({ count: nextCount, upvoted: nextUpvoted });
     setLoading(true);
 
     try {
@@ -59,26 +63,19 @@ export function UpvoteButton({
       });
 
       if (!res.ok) {
-        // Rollback on error
-        setUpvoted(prevUpvoted);
-        setCount(prevCount);
+        setOverride(prevOverride);
         return;
       }
 
       const data = (await res.json()) as { upvoted: boolean; upvote_count: number };
-      // Sync with server state
-      setUpvoted(data.upvoted);
-      setCount(data.upvote_count);
-      // Notify parent to refetch for sorting
+      setOverride({ count: data.upvote_count, upvoted: data.upvoted });
       onUpvoteChange?.();
     } catch {
-      // Rollback on network error
-      setUpvoted(prevUpvoted);
-      setCount(prevCount);
+      setOverride(prevOverride);
     } finally {
       setLoading(false);
     }
-  }, [showcaseId, count, upvoted, loading, disabled, isLoggedIn, onLoginRequired, onUpvoteChange]);
+  }, [showcaseId, count, upvoted, override, loading, disabled, isLoggedIn, onLoginRequired, onUpvoteChange]);
 
   return (
     <button

--- a/packages/web/src/hooks/use-achievements.ts
+++ b/packages/web/src/hooks/use-achievements.ts
@@ -2,8 +2,9 @@
 
 import type { AchievementTier, AchievementCategory } from "@/lib/achievement-helpers";
 import { useFetchData } from "@/hooks/use-fetch-data";
-import { useState, useEffect, useCallback, useMemo } from "react";
-import { throwApiError } from "@/lib/api-error";
+import { useCallback, useMemo } from "react";
+import useSWRInfinite from "swr/infinite";
+import { fetcher } from "@/lib/fetcher";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -108,81 +109,43 @@ export function useAchievementMembers(
   achievementId: string | null,
   limit = 20
 ): UseAchievementMembersResult {
-  const [data, setData] = useState<AchievementMembersData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [cursor, setCursor] = useState<string | null>(null);
-
-  const fetchData = useCallback(async (nextCursor?: string, signal?: AbortSignal) => {
-    if (!achievementId) return;
-
-    setLoading(true);
-    setError(null);
-
-    try {
+  const getKey = useCallback(
+    (pageIndex: number, previousPageData: AchievementMembersData | null) => {
+      if (!achievementId) return null;
+      if (previousPageData && previousPageData.cursor === null) return null;
       const params = new URLSearchParams({ limit: String(limit) });
-      if (nextCursor) params.set("cursor", nextCursor);
-
-      const res = await fetch(`/api/achievements/${achievementId}/members?${params}`, signal ? { signal } : undefined);
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        await throwApiError(res);
+      if (pageIndex > 0 && previousPageData?.cursor) {
+        params.set("cursor", previousPageData.cursor);
       }
+      return `/api/achievements/${achievementId}/members?${params}`;
+    },
+    [achievementId, limit],
+  );
 
-      const json: AchievementMembersData = await res.json();
+  const { data, error, isLoading, isValidating, size, setSize } =
+    useSWRInfinite<AchievementMembersData>(getKey, fetcher, {
+      revalidateFirstPage: false,
+    });
 
-      if (signal?.aborted) return;
-
-      if (nextCursor) {
-        // Append to existing data
-        setData((prev) => ({
-          members: [...(prev?.members ?? []), ...json.members],
-          cursor: json.cursor,
-        }));
-      } else {
-        setData(json);
+  const lastCursor = data && data.length > 0 ? data[data.length - 1]?.cursor ?? null : null;
+  const combined: AchievementMembersData | null = data
+    ? {
+        members: data.flatMap((d) => d.members),
+        cursor: lastCursor,
       }
-      setCursor(json.cursor);
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
-    }
-  }, [achievementId, limit]);
-
-  useEffect(() => {
-    if (achievementId) {
-      const controller = new AbortController();
-
-      // Reset data when achievementId changes to avoid stale data
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-      setData(null);
-      setCursor(null);
-
-      fetchData(undefined, controller.signal);
-
-      return () => {
-        controller.abort();
-      };
-    }
-  }, [achievementId, fetchData]);
+    : null;
 
   const loadMore = useCallback(() => {
-    if (cursor && !loading) {
-      fetchData(cursor);
+    if (lastCursor && !isValidating) {
+      void setSize(size + 1);
     }
-  }, [cursor, loading, fetchData]);
+  }, [lastCursor, isValidating, setSize, size]);
 
   return {
-    data,
-    loading,
-    error,
+    data: combined,
+    loading: isLoading || (isValidating && size > 1),
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
     loadMore,
-    hasMore: cursor !== null,
+    hasMore: lastCursor !== null,
   };
 }

--- a/packages/web/src/hooks/use-devices.ts
+++ b/packages/web/src/hooks/use-devices.ts
@@ -1,12 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useCallback } from "react";
+import useSWR from "swr";
 import type { DevicesResponse } from "@pew/core";
 import { throwApiError } from "@/lib/api-error";
-
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
+import { fetcher } from "@/lib/fetcher";
 
 interface UseDevicesResult {
   data: DevicesResponse | null;
@@ -22,39 +20,11 @@ interface UseDevicesResult {
   ) => Promise<{ success: boolean; error?: string }>;
 }
 
-/**
- * Fetch device list from GET /api/devices and expose alias mutation.
- * Refetches full list after every successful mutation.
- */
 export function useDevices(): UseDevicesResult {
-  const [data, setData] = useState<DevicesResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch("/api/devices");
-
-      if (!res.ok) {
-        await throwApiError(res);
-      }
-
-      const json = (await res.json()) as DevicesResponse;
-      setData(json);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchData();
-  }, [fetchData]);
+  const { data, error, isLoading, mutate } = useSWR<DevicesResponse>(
+    "/api/devices",
+    fetcher,
+  );
 
   const updateAlias = useCallback(
     async (
@@ -72,8 +42,7 @@ export function useDevices(): UseDevicesResult {
           await throwApiError(res);
         }
 
-        // Refetch full list after mutation
-        await fetchData();
+        await mutate();
         return { success: true };
       } catch (err) {
         const errorMsg =
@@ -81,7 +50,7 @@ export function useDevices(): UseDevicesResult {
         return { success: false, error: errorMsg };
       }
     },
-    [fetchData]
+    [mutate]
   );
 
   const deleteDevice = useCallback(
@@ -99,8 +68,7 @@ export function useDevices(): UseDevicesResult {
           await throwApiError(res);
         }
 
-        // Refetch full list after deletion
-        await fetchData();
+        await mutate();
         return { success: true };
       } catch (err) {
         const errorMsg =
@@ -108,8 +76,17 @@ export function useDevices(): UseDevicesResult {
         return { success: false, error: errorMsg };
       }
     },
-    [fetchData]
+    [mutate]
   );
 
-  return { data, loading, error, refetch: fetchData, updateAlias, deleteDevice };
+  return {
+    data: data ?? null,
+    loading: isLoading,
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
+    refetch: () => {
+      void mutate();
+    },
+    updateAlias,
+    deleteDevice,
+  };
 }

--- a/packages/web/src/hooks/use-fetch-data.ts
+++ b/packages/web/src/hooks/use-fetch-data.ts
@@ -1,11 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
-import { throwApiError } from "@/lib/api-error";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 
 interface UseFetchDataOptions {
   /** When false, skip fetching entirely. Defaults to true. */
@@ -21,91 +17,28 @@ interface UseFetchDataResult<T> {
   refetch: () => void;
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
 /**
- * Shared data-fetching hook that encapsulates the
- * `useState / useEffect / fetch / AbortController` boilerplate.
+ * Shared data-fetching hook backed by SWR. Kept for backward compatibility
+ * with consumers that expect `{ data, loading, error, refetch }`.
  *
- * @param url - The URL to fetch. Pass `null` to skip fetching (conditional hooks).
+ * @param url - The URL to fetch. Pass `null` to skip fetching.
  * @param options - Optional configuration.
  */
 export function useFetchData<T>(
   url: string | null,
   options?: UseFetchDataOptions,
 ): UseFetchDataResult<T> {
-  const { enabled = true, initialLoading = true } = options ?? {};
+  const { enabled = true } = options ?? {};
 
-  const [data, setData] = useState<T | null>(null);
-  const [loading, setLoading] = useState(initialLoading);
-  const [error, setError] = useState<string | null>(null);
+  const key = enabled && url ? url : null;
+  const { data, error, isLoading, mutate } = useSWR<T>(key, fetcher);
 
-  // Stable ref so `refetch` never causes extra renders / effect re-runs
-  const urlRef = useRef(url);
-  // eslint-disable-next-line react-hooks/refs -- ref kept in sync with prop to avoid effect re-runs
-  urlRef.current = url;
-
-  const fetchData = useCallback(
-    async (signal?: AbortSignal) => {
-      const target = urlRef.current;
-      if (!target || !enabled) return;
-
-      setLoading(true);
-      setError(null);
-
-      try {
-        const res = await fetch(target, signal ? { signal } : undefined);
-
-        if (signal?.aborted) return;
-
-        if (!res.ok) {
-          await throwApiError(res);
-        }
-
-        const json = (await res.json()) as T;
-
-        if (signal?.aborted) return;
-
-        setData(json);
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") return;
-        setData(null);
-        setError(err instanceof Error ? err.message : "Unknown error");
-      } finally {
-        if (!signal?.aborted) {
-          setLoading(false);
-        }
-      }
+  return {
+    data: data ?? null,
+    loading: key ? isLoading : false,
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
+    refetch: () => {
+      void mutate();
     },
-    // `url` is intentionally included so the effect re-runs when the URL changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [url, enabled],
-  );
-
-  useEffect(() => {
-    if (!url || !enabled) {
-      // Reset state when disabled / no URL
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-
-    const controller = new AbortController();
-
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData, url, enabled]);
-
-  const refetch = useCallback(() => {
-    fetchData();
-  }, [fetchData]);
-
-  return { data, loading, error, refetch };
+  };
 }

--- a/packages/web/src/hooks/use-leaderboard-scope.ts
+++ b/packages/web/src/hooks/use-leaderboard-scope.ts
@@ -73,8 +73,10 @@ export function useLeaderboardScope(): UseLeaderboardScopeReturn {
   const scopeInitialized = isSessionLoading ? false : isAuthenticated ? orgsLoaded : true;
 
   // Derived, validated scope: drops back to global when stored id is no longer valid.
+  // When unauthenticated, always force global — localStorage may contain stale org/team scope.
   const scope = useMemo<ScopeSelection>(() => {
-    if (!scopeInitialized || !isAuthenticated) return rawScope;
+    if (!isAuthenticated) return { type: "global" };
+    if (!scopeInitialized) return rawScope;
     if (rawScope.type === "org" && rawScope.id) {
       const valid = organizations.some((o) => o.id === rawScope.id);
       return valid ? rawScope : { type: "global" };

--- a/packages/web/src/hooks/use-leaderboard-scope.ts
+++ b/packages/web/src/hooks/use-leaderboard-scope.ts
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
 import {
   loadScopeFromStorage,
   saveScopeToStorage,
@@ -9,10 +11,6 @@ import {
   type Organization,
   type Team,
 } from "@/lib/leaderboard-scope";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 export interface UseLeaderboardScopeReturn {
   /** Current scope selection */
@@ -37,106 +35,62 @@ export interface UseLeaderboardScopeReturn {
   orgId: string | null;
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
+interface OrgsResponse {
+  organizations?: Organization[];
+}
 
-/**
- * Shared hook for leaderboard scope management.
- * Handles:
- * - Auth-gated scope initialization
- * - Organization/team fetching with orgsLoaded guard
- * - Scope validation (reset invalid stored scope)
- * - localStorage persistence
- */
+interface TeamsResponse {
+  teams?: Team[];
+}
+
 export function useLeaderboardScope(): UseLeaderboardScopeReturn {
   const { status } = useSession();
   const isAuthenticated = status === "authenticated";
   const isSessionLoading = status === "loading";
 
-  const [scope, setScopeState] = useState<ScopeSelection>({ type: "global" });
-  const [scopeInitialized, setScopeInitialized] = useState(false);
-  const [orgsLoaded, setOrgsLoaded] = useState(false);
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
-  const [teams, setTeams] = useState<Team[]>([]);
+  // Lazy initializer reads localStorage once on mount — no effect needed.
+  const [rawScope, setRawScope] = useState<ScopeSelection>(() => {
+    if (typeof window === "undefined") return { type: "global" };
+    return loadScopeFromStorage() ?? { type: "global" };
+  });
 
-  // Fetch user's organizations and teams
-  const fetchOrgsAndTeams = useCallback(async () => {
-    try {
-      const [orgsRes, teamsRes] = await Promise.all([
-        fetch("/api/organizations/mine"),
-        fetch("/api/teams"),
-      ]);
+  const orgsKey = isAuthenticated ? "/api/organizations/mine" : null;
+  const teamsKey = isAuthenticated ? "/api/teams" : null;
 
-      if (orgsRes.ok) {
-        const orgsJson = await orgsRes.json();
-        setOrganizations(orgsJson.organizations ?? []);
-      }
-      if (teamsRes.ok) {
-        const teamsJson = await teamsRes.json();
-        setTeams(teamsJson.teams ?? []);
-      }
-    } catch {
-      // Silently fail — scope dropdown optional
-    } finally {
-      setOrgsLoaded(true);
+  const { data: orgsData, isLoading: orgsLoading, error: orgsError } =
+    useSWR<OrgsResponse>(orgsKey, fetcher);
+  const { data: teamsData, isLoading: teamsLoading, error: teamsError } =
+    useSWR<TeamsResponse>(teamsKey, fetcher);
+
+  const organizations = useMemo(() => orgsData?.organizations ?? [], [orgsData]);
+  const teams = useMemo(() => teamsData?.teams ?? [], [teamsData]);
+
+  // orgsLoaded: authenticated → orgs + teams fetch settled (success or error); unauthenticated → immediately true
+  const orgsLoaded = isAuthenticated
+    ? (!orgsLoading && !teamsLoading) || Boolean(orgsError) || Boolean(teamsError)
+    : !isSessionLoading;
+
+  const scopeInitialized = isSessionLoading ? false : isAuthenticated ? orgsLoaded : true;
+
+  // Derived, validated scope: drops back to global when stored id is no longer valid.
+  const scope = useMemo<ScopeSelection>(() => {
+    if (!scopeInitialized || !isAuthenticated) return rawScope;
+    if (rawScope.type === "org" && rawScope.id) {
+      const valid = organizations.some((o) => o.id === rawScope.id);
+      return valid ? rawScope : { type: "global" };
     }
-  }, []);
-
-  // Initialize scope from localStorage and fetch orgs/teams
-  // Wait for session to resolve before deciding auth state
-  useEffect(() => {
-    // Still loading session - wait
-    if (isSessionLoading) {
-      return;
+    if (rawScope.type === "team" && rawScope.id) {
+      const valid = teams.some((t) => t.id === rawScope.id);
+      return valid ? rawScope : { type: "global" };
     }
+    return rawScope;
+  }, [rawScope, scopeInitialized, isAuthenticated, organizations, teams]);
 
-    // Unauthenticated - use global scope immediately
-    if (!isAuthenticated) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-      setScopeInitialized(true);
-      setOrgsLoaded(true);
-      return;
-    }
-
-    // Authenticated - fetch orgs/teams and restore scope
-    fetchOrgsAndTeams().then(() => {
-      const stored = loadScopeFromStorage();
-      if (stored) {
-        setScopeState(stored);
-      }
-      setScopeInitialized(true);
-    });
-  }, [isSessionLoading, isAuthenticated, fetchOrgsAndTeams]);
-
-  // Validate stored scope against available orgs/teams
-  // (intentionally calling setState in effect to correct invalid state after async load)
-  useEffect(() => {
-    if (!scopeInitialized) return;
-
-    if (scope.type === "org" && scope.id) {
-      const valid = organizations.some((o) => o.id === scope.id);
-      if (!valid) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-        setScopeState({ type: "global" });
-        saveScopeToStorage({ type: "global" });
-      }
-    } else if (scope.type === "team" && scope.id) {
-      const valid = teams.some((t) => t.id === scope.id);
-      if (!valid) {
-        setScopeState({ type: "global" });
-        saveScopeToStorage({ type: "global" });
-      }
-    }
-  }, [scopeInitialized, scope, organizations, teams]);
-
-  // Handle scope change with persistence
   const setScope = useCallback((newScope: ScopeSelection) => {
-    setScopeState(newScope);
+    setRawScope(newScope);
     saveScopeToStorage(newScope);
   }, []);
 
-  // Computed IDs for useLeaderboard
   const teamId = scope.type === "team" ? scope.id ?? null : null;
   const orgId = scope.type === "org" ? scope.id ?? null : null;
 

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -1,11 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
+import useSWR from "swr";
 import { throwApiError } from "@/lib/api-error";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { fetcher } from "@/lib/fetcher";
 
 export interface ProjectAliasInput {
   source: string;
@@ -52,10 +50,6 @@ export interface UseProjectsOptions {
   to?: string;
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
 interface UseProjectsResult {
   data: ProjectsData | null;
   /** All unique tags across all projects, sorted alphabetically. */
@@ -83,66 +77,19 @@ interface UseProjectsResult {
 export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
   const from = options?.from;
   const to = options?.to;
-  const [data, setData] = useState<ProjectsData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  // ---------------------------------------------------------------------------
-  // Fetch
-  // ---------------------------------------------------------------------------
-
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const params = new URLSearchParams();
-      if (from) {
-        params.set("from", from);
-        if (to) params.set("to", to);
-      }
-      const qs = params.toString();
-      const url = qs ? `/api/projects?${qs}` : "/api/projects";
-      const res = await fetch(url, signal ? { signal } : undefined);
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        await throwApiError(res);
-      }
-
-      const json = (await res.json()) as ProjectsData;
-
-      if (signal?.aborted) return;
-
-      setData(json);
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
+  const url = useMemo(() => {
+    const params = new URLSearchParams();
+    if (from) {
+      params.set("from", from);
+      if (to) params.set("to", to);
     }
+    const qs = params.toString();
+    return qs ? `/api/projects?${qs}` : "/api/projects";
   }, [from, to]);
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    // Clear data on filter change to avoid stale data
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    setData(null);
-
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData]);
-
-  // ---------------------------------------------------------------------------
-  // Derived: all unique tags
-  // ---------------------------------------------------------------------------
+  const { data, error, isLoading, mutate } = useSWR<ProjectsData>(url, fetcher);
+  const [mutationError, setMutationError] = useState<string | null>(null);
 
   const allTags = useMemo(() => {
     const set = new Set<string>();
@@ -151,10 +98,6 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
     }
     return Array.from(set).sort();
   }, [data]);
-
-  // ---------------------------------------------------------------------------
-  // Mutations
-  // ---------------------------------------------------------------------------
 
   const createProject = useCallback(
     async (
@@ -167,21 +110,16 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name, aliases }),
         });
-
-        if (!res.ok) {
-          await throwApiError(res);
-        }
-
+        if (!res.ok) await throwApiError(res);
         const project = (await res.json()) as Project;
-        // Refetch to get updated data (unassigned list changes)
-        await fetchData();
+        await mutate();
         return project;
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error");
+        setMutationError(err instanceof Error ? err.message : "Unknown error");
         return null;
       }
     },
-    [fetchData],
+    [mutate],
   );
 
   const updateProject = useCallback(
@@ -201,49 +139,43 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(updates),
         });
-
-        if (!res.ok) {
-          await throwApiError(res);
-        }
-
+        if (!res.ok) await throwApiError(res);
         const project = (await res.json()) as Project;
-        await fetchData();
+        await mutate();
         return project;
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error");
+        setMutationError(err instanceof Error ? err.message : "Unknown error");
         return null;
       }
     },
-    [fetchData],
+    [mutate],
   );
 
   const deleteProject = useCallback(
     async (id: string): Promise<boolean> => {
       try {
-        const res = await fetch(`/api/projects/${id}`, {
-          method: "DELETE",
-        });
-
-        if (!res.ok) {
-          await throwApiError(res);
-        }
-
-        await fetchData();
+        const res = await fetch(`/api/projects/${id}`, { method: "DELETE" });
+        if (!res.ok) await throwApiError(res);
+        await mutate();
         return true;
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error");
+        setMutationError(err instanceof Error ? err.message : "Unknown error");
         return false;
       }
     },
-    [fetchData],
+    [mutate],
   );
 
   return {
-    data,
+    data: data ?? null,
     allTags,
-    loading,
-    error,
-    refetch: () => fetchData(),
+    loading: isLoading,
+    error:
+      mutationError ??
+      (error ? (error instanceof Error ? error.message : String(error)) : null),
+    refetch: () => {
+      void mutate();
+    },
     createProject,
     updateProject,
     deleteProject,

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -104,6 +104,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
       name: string,
       aliases?: ProjectAliasInput[],
     ): Promise<Project | null> => {
+      setMutationError(null);
       try {
         const res = await fetch("/api/projects", {
           method: "POST",
@@ -133,6 +134,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
         remove_tags?: string[];
       },
     ): Promise<Project | null> => {
+      setMutationError(null);
       try {
         const res = await fetch(`/api/projects/${id}`, {
           method: "PATCH",
@@ -153,6 +155,7 @@ export function useProjects(options?: UseProjectsOptions): UseProjectsResult {
 
   const deleteProject = useCallback(
     async (id: string): Promise<boolean> => {
+      setMutationError(null);
       try {
         const res = await fetch(`/api/projects/${id}`, { method: "DELETE" });
         if (!res.ok) await throwApiError(res);

--- a/packages/web/src/hooks/use-season-leaderboard.ts
+++ b/packages/web/src/hooks/use-season-leaderboard.ts
@@ -1,12 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
+import useSWR from "swr";
 import type { SeasonStatus } from "@pew/core";
-import { throwApiError } from "@/lib/api-error";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { fetcher } from "@/lib/fetcher";
 
 export interface SeasonTeamEntry {
   rank: number;
@@ -51,10 +48,6 @@ export interface SeasonLeaderboardData {
   entries: SeasonTeamEntry[];
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
 interface UseSeasonLeaderboardResult {
   data: SeasonLeaderboardData | null;
   loading: boolean;
@@ -70,68 +63,17 @@ interface UseSeasonLeaderboardResult {
 export function useSeasonLeaderboard(
   seasonIdOrSlug: string | null,
 ): UseSeasonLeaderboardResult {
-  const [data, setData] = useState<SeasonLeaderboardData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const key = seasonIdOrSlug ? `/api/seasons/${seasonIdOrSlug}/leaderboard` : null;
+  const { data, error, isLoading, isValidating, mutate } =
+    useSWR<SeasonLeaderboardData>(key, fetcher);
+
+  const fetchedTeamsRef = useRef<Set<string>>(new Set());
+  const loadingTeamIdsRef = useRef<Set<string>>(new Set());
   const [loadingTeamIds, setLoadingTeamIds] = useState<Set<string>>(new Set());
 
-  // Track if initial load has completed to avoid stale closure issues
-  const hasLoadedRef = useRef(false);
-
-  // Track which teams have already been fetched to avoid duplicate requests
-  const fetchedTeamsRef = useRef<Set<string>>(new Set());
-
-  // Track team IDs currently being loaded (ref for stable closure)
-  const loadingTeamIdsRef = useRef<Set<string>>(new Set());
-
-  // Initial fetch without expand=members for faster load
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    if (!seasonIdOrSlug) return;
-
-    if (!hasLoadedRef.current) {
-      setLoading(true);
-    } else {
-      setRefreshing(true);
-    }
-    setError(null);
-    // Reset fetched teams on full refetch
-    fetchedTeamsRef.current = new Set();
-
-    try {
-      const res = await fetch(
-        `/api/seasons/${seasonIdOrSlug}/leaderboard`,
-        signal ? { signal } : undefined,
-      );
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        await throwApiError(res);
-      }
-
-      const json = (await res.json()) as SeasonLeaderboardData;
-
-      if (signal?.aborted) return;
-
-      setData(json);
-      hasLoadedRef.current = true;
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-        setRefreshing(false);
-      }
-    }
-  }, [seasonIdOrSlug]);
-
-  // Load members for a specific team on-demand
   const loadTeamMembers = useCallback(
     async (teamId: string) => {
       if (!seasonIdOrSlug || !data) return;
-      // Skip if already fetched or currently loading (use ref for stable identity)
       if (fetchedTeamsRef.current.has(teamId) || loadingTeamIdsRef.current.has(teamId)) {
         return;
       }
@@ -149,25 +91,23 @@ export function useSeasonLeaderboard(
         }
 
         const json = (await res.json()) as SeasonLeaderboardData;
-        // Find the team entry with members
-        const teamWithMembers = json.entries.find(
-          (e) => e.team.id === teamId,
-        );
+        const teamWithMembers = json.entries.find((e) => e.team.id === teamId);
 
         if (teamWithMembers?.members) {
           const members = teamWithMembers.members;
           fetchedTeamsRef.current.add(teamId);
-          setData((prev) => {
-            if (!prev) return prev;
-            return {
-              ...prev,
-              entries: prev.entries.map((entry): SeasonTeamEntry =>
-                entry.team.id === teamId
-                  ? { ...entry, members }
-                  : entry,
-              ),
-            };
-          });
+          await mutate(
+            (prev) => {
+              if (!prev) return prev;
+              return {
+                ...prev,
+                entries: prev.entries.map((entry): SeasonTeamEntry =>
+                  entry.team.id === teamId ? { ...entry, members } : entry,
+                ),
+              };
+            },
+            { revalidate: false },
+          );
         }
       } catch {
         // Silently fail — user can retry by collapsing/expanding again
@@ -180,26 +120,18 @@ export function useSeasonLeaderboard(
         });
       }
     },
-    [seasonIdOrSlug, data],
+    [seasonIdOrSlug, data, mutate],
   );
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData]);
-
   return {
-    data,
-    loading,
-    refreshing,
-    error,
-    refetch: () => fetchData(),
+    data: data ?? null,
+    loading: isLoading,
+    refreshing: isValidating && !isLoading,
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
+    refetch: () => {
+      fetchedTeamsRef.current = new Set();
+      void mutate();
+    },
     loadTeamMembers,
     loadingTeamIds,
   };

--- a/packages/web/src/hooks/use-season-leaderboard.ts
+++ b/packages/web/src/hooks/use-season-leaderboard.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 import type { SeasonStatus } from "@pew/core";
 import { fetcher } from "@/lib/fetcher";
@@ -70,6 +70,18 @@ export function useSeasonLeaderboard(
   const fetchedTeamsRef = useRef<Set<string>>(new Set());
   const loadingTeamIdsRef = useRef<Set<string>>(new Set());
   const [loadingTeamIds, setLoadingTeamIds] = useState<Set<string>>(new Set());
+
+  // Reset lazy-member tracking when season changes.
+  // Without this, team IDs fetched in season A would be skipped in season B.
+  const [prevSeasonKey, setPrevSeasonKey] = useState(seasonIdOrSlug);
+  if (prevSeasonKey !== seasonIdOrSlug) {
+    setPrevSeasonKey(seasonIdOrSlug);
+    setLoadingTeamIds(new Set());
+  }
+  useEffect(() => {
+    fetchedTeamsRef.current = new Set();
+    loadingTeamIdsRef.current = new Set();
+  }, [seasonIdOrSlug]);
 
   const loadTeamMembers = useCallback(
     async (teamId: string) => {

--- a/packages/web/src/hooks/use-season-registration.ts
+++ b/packages/web/src/hooks/use-season-registration.ts
@@ -1,12 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useMemo, useState } from "react";
+import useSWR from "swr";
 import type { SeasonStatus } from "@pew/core";
 import { throwApiError } from "@/lib/api-error";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { fetcher } from "@/lib/fetcher";
 
 export interface AvailableSeason {
   id: string;
@@ -26,97 +24,76 @@ interface UseSeasonRegistrationOptions {
 }
 
 interface UseSeasonRegistrationResult {
-  /** Upcoming + active seasons with registration status */
   seasons: AvailableSeason[];
   loading: boolean;
   error: string | null;
-  /** Register team for a season */
   register: (seasonId: string) => Promise<boolean>;
-  /** Withdraw team from a season (upcoming only) */
   withdraw: (seasonId: string) => Promise<boolean>;
-  /** Re-fetch data */
   refetch: () => void;
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
+interface SeasonsResponse {
+  seasons: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    start_date: string;
+    end_date: string;
+    status: SeasonStatus;
+    team_count: number;
+    allow_late_registration: boolean;
+    allow_late_withdrawal: boolean;
+  }>;
+}
+
+interface TeamResponse {
+  registered_season_ids?: string[];
+}
 
 export function useSeasonRegistration(
   options: UseSeasonRegistrationOptions,
 ): UseSeasonRegistrationResult {
   const { teamId } = options;
-  const [seasons, setSeasons] = useState<AvailableSeason[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  // -------------------------------------------------------------------------
-  // Fetch available seasons + registration status
-  // -------------------------------------------------------------------------
+  const {
+    data: seasonsData,
+    error: seasonsError,
+    isLoading: seasonsLoading,
+    mutate: mutateSeasons,
+  } = useSWR<SeasonsResponse>("/api/seasons", fetcher);
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const {
+    data: teamData,
+    isLoading: teamLoading,
+    mutate: mutateTeam,
+  } = useSWR<TeamResponse>(`/api/teams/${teamId}`, fetcher);
 
-    try {
-      // Fetch all seasons and team details (which includes registered_season_ids)
-      const [seasonsRes, teamRes] = await Promise.all([
-        fetch("/api/seasons"),
-        fetch(`/api/teams/${teamId}`),
-      ]);
+  const [overrides, setOverrides] = useState<
+    Map<string, { is_registered: boolean; delta: number }>
+  >(new Map());
+  const [mutationError, setMutationError] = useState<string | null>(null);
 
-      if (!seasonsRes.ok) {
-        await throwApiError(seasonsRes);
-      }
-
-      const seasonsData = (await seasonsRes.json()) as {
-        seasons: Array<{
-          id: string;
-          name: string;
-          slug: string;
-          start_date: string;
-          end_date: string;
-          status: SeasonStatus;
-          team_count: number;
-          allow_late_registration: boolean;
-          allow_late_withdrawal: boolean;
-        }>;
-      };
-
-      // Get registered season IDs from team details
-      let registeredIds = new Set<string>();
-      if (teamRes.ok) {
-        const teamData = (await teamRes.json()) as {
-          registered_season_ids?: string[];
-        };
-        registeredIds = new Set(teamData.registered_season_ids ?? []);
-      }
-
-      // Filter to upcoming + active (active seasons may allow late
-      // registration/withdrawal depending on admin toggles)
-      const available = seasonsData.seasons
-        .filter((s) => s.status === "upcoming" || s.status === "active")
-        .map((s) => ({
+  const seasons = useMemo<AvailableSeason[]>(() => {
+    if (!seasonsData) return [];
+    const registeredIds = new Set(teamData?.registered_season_ids ?? []);
+    return seasonsData.seasons
+      .filter((s) => s.status === "upcoming" || s.status === "active")
+      .map((s) => {
+        const override = overrides.get(s.id);
+        const baseRegistered = registeredIds.has(s.id);
+        return {
           ...s,
-          is_registered: registeredIds.has(s.id),
-        }));
+          is_registered: override ? override.is_registered : baseRegistered,
+          team_count: s.team_count + (override?.delta ?? 0),
+        };
+      });
+  }, [seasonsData, teamData, overrides]);
 
-      setSeasons(available);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      setLoading(false);
-    }
-  }, [teamId]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchData();
-  }, [fetchData]);
-
-  // -------------------------------------------------------------------------
-  // Register
-  // -------------------------------------------------------------------------
+  const refetch = useCallback(() => {
+    setOverrides(new Map());
+    void mutateSeasons();
+    void mutateTeam();
+  }, [mutateSeasons, mutateTeam]);
 
   const register = useCallback(
     async (seasonId: string): Promise<boolean> => {
@@ -126,31 +103,20 @@ export function useSeasonRegistration(
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ team_id: teamId }),
         });
-
-        if (!res.ok) {
-          await throwApiError(res);
-        }
-
-        // Optimistic update
-        setSeasons((prev) =>
-          prev.map((s) =>
-            s.id === seasonId
-              ? { ...s, is_registered: true, team_count: s.team_count + 1 }
-              : s,
-          ),
-        );
+        if (!res.ok) await throwApiError(res);
+        setOverrides((prev) => {
+          const next = new Map(prev);
+          next.set(seasonId, { is_registered: true, delta: 1 });
+          return next;
+        });
         return true;
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Registration failed");
+        setMutationError(err instanceof Error ? err.message : "Registration failed");
         return false;
       }
     },
     [teamId],
   );
-
-  // -------------------------------------------------------------------------
-  // Withdraw
-  // -------------------------------------------------------------------------
 
   const withdraw = useCallback(
     async (seasonId: string): Promise<boolean> => {
@@ -160,27 +126,33 @@ export function useSeasonRegistration(
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ team_id: teamId }),
         });
-
-        if (!res.ok) {
-          await throwApiError(res);
-        }
-
-        // Optimistic update
-        setSeasons((prev) =>
-          prev.map((s) =>
-            s.id === seasonId
-              ? { ...s, is_registered: false, team_count: Math.max(0, s.team_count - 1) }
-              : s,
-          ),
-        );
+        if (!res.ok) await throwApiError(res);
+        setOverrides((prev) => {
+          const next = new Map(prev);
+          next.set(seasonId, { is_registered: false, delta: -1 });
+          return next;
+        });
         return true;
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Withdrawal failed");
+        setMutationError(err instanceof Error ? err.message : "Withdrawal failed");
         return false;
       }
     },
     [teamId],
   );
 
-  return { seasons, loading, error, register, withdraw, refetch: fetchData };
+  return {
+    seasons,
+    loading: seasonsLoading || teamLoading,
+    error:
+      mutationError ??
+      (seasonsError
+        ? seasonsError instanceof Error
+          ? seasonsError.message
+          : String(seasonsError)
+        : null),
+    register,
+    withdraw,
+    refetch,
+  };
 }

--- a/packages/web/src/hooks/use-seasons.ts
+++ b/packages/web/src/hooks/use-seasons.ts
@@ -1,12 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useMemo } from "react";
+import useSWR from "swr";
 import type { SeasonStatus } from "@pew/core";
-import { throwApiError } from "@/lib/api-error";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { fetcher } from "@/lib/fetcher";
 
 export interface SeasonListItem {
   id: string;
@@ -24,10 +21,6 @@ interface SeasonsData {
   seasons: SeasonListItem[];
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
 interface UseSeasonsOptions {
   status?: SeasonStatus;
 }
@@ -44,49 +37,26 @@ export function useSeasons(
   options: UseSeasonsOptions = {},
 ): UseSeasonsResult {
   const { status } = options;
-  const [data, setData] = useState<SeasonsData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  // Track if initial load has completed to avoid stale closure issues
-  const hasLoadedRef = useRef(false);
-
-  const fetchData = useCallback(async () => {
-    if (!hasLoadedRef.current) {
-      setLoading(true);
-    } else {
-      setRefreshing(true);
-    }
-    setError(null);
-
-    try {
-      const params = new URLSearchParams();
-      if (status) params.set("status", status);
-
-      const qs = params.toString();
-      const url = qs ? `/api/seasons?${qs}` : "/api/seasons";
-      const res = await fetch(url);
-
-      if (!res.ok) {
-        await throwApiError(res);
-      }
-
-      const json = (await res.json()) as SeasonsData;
-      setData(json);
-      hasLoadedRef.current = true;
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
+  const url = useMemo(() => {
+    const params = new URLSearchParams();
+    if (status) params.set("status", status);
+    const qs = params.toString();
+    return qs ? `/api/seasons?${qs}` : "/api/seasons";
   }, [status]);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    fetchData();
-  }, [fetchData]);
+  const { data, error, isLoading, isValidating, mutate } = useSWR<SeasonsData>(
+    url,
+    fetcher,
+  );
 
-  return { data, loading, refreshing, error, refetch: fetchData };
+  return {
+    data: data ?? null,
+    loading: isLoading,
+    refreshing: isValidating && !isLoading,
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
+    refetch: () => {
+      void mutate();
+    },
+  };
 }

--- a/packages/web/src/hooks/use-showcases.ts
+++ b/packages/web/src/hooks/use-showcases.ts
@@ -4,8 +4,10 @@
 
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback, useMemo, useState } from "react";
+import useSWR from "swr";
 import { throwApiError } from "@/lib/api-error";
+import { fetcher } from "@/lib/fetcher";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -71,71 +73,28 @@ export interface UseShowcasesResult {
 export function useShowcases(options: UseShowcasesOptions = {}): UseShowcasesResult {
   const { mine = false, limit = 20, offset = 0 } = options;
 
-  const [data, setData] = useState<ShowcasesResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Track whether we have data to determine loading vs refreshing
-  const hasDataRef = useRef(false);
-
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    // Use ref to check if we have data (avoids data in deps)
-    if (!hasDataRef.current) {
-      setLoading(true);
-    } else {
-      setRefreshing(true);
-    }
-    setError(null);
-
-    try {
-      const params = new URLSearchParams();
-      if (mine) params.set("mine", "1");
-      params.set("limit", String(limit));
-      params.set("offset", String(offset));
-
-      const res = await fetch(`/api/showcases?${params.toString()}`, signal ? { signal } : undefined);
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        await throwApiError(res);
-      }
-
-      const json = (await res.json()) as ShowcasesResponse;
-
-      if (signal?.aborted) return;
-
-      setData(json);
-      hasDataRef.current = true;
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-        setRefreshing(false);
-      }
-    }
+  const url = useMemo(() => {
+    const params = new URLSearchParams();
+    if (mine) params.set("mine", "1");
+    params.set("limit", String(limit));
+    params.set("offset", String(offset));
+    return `/api/showcases?${params.toString()}`;
   }, [mine, limit, offset]);
 
-  useEffect(() => {
-    const controller = new AbortController();
+  const { data, error, isLoading, isValidating, mutate } = useSWR<ShowcasesResponse>(
+    url,
+    fetcher,
+  );
 
-    // Reset hasDataRef when params change to show loading state
-    hasDataRef.current = false;
-    // Clear data on param change to avoid stale data
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    setData(null);
-
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData]);
-
-  return { data, loading, refreshing, error, refetch: () => fetchData() };
+  return {
+    data: data ?? null,
+    loading: isLoading,
+    refreshing: isValidating && !isLoading,
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
+    refetch: () => {
+      void mutate();
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/hooks/use-user-achievements.ts
+++ b/packages/web/src/hooks/use-user-achievements.ts
@@ -1,12 +1,8 @@
 "use client";
 
 import type { AchievementTier, AchievementCategory } from "@/lib/achievement-helpers";
-import { useState, useEffect, useCallback } from "react";
+import useSWR from "swr";
 import { throwApiError } from "@/lib/api-error";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 export interface UserAchievement {
   id: string;
@@ -35,10 +31,6 @@ export interface UserAchievementData {
   summary: UserAchievementSummary;
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
 interface UseUserAchievementsResult {
   data: UserAchievementData | null;
   loading: boolean;
@@ -46,66 +38,30 @@ interface UseUserAchievementsResult {
   refetch: () => void;
 }
 
+async function userAchievementsFetcher(url: string): Promise<UserAchievementData | null> {
+  const res = await fetch(url);
+  if (res.status === 404) {
+    return null;
+  }
+  if (!res.ok) {
+    await throwApiError(res);
+  }
+  return res.json() as Promise<UserAchievementData>;
+}
+
 export function useUserAchievements(slug: string | null): UseUserAchievementsResult {
-  const [data, setData] = useState<UserAchievementData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const key = slug ? `/api/users/${encodeURIComponent(slug)}/achievements` : null;
+  const { data, error, isLoading, mutate } = useSWR<UserAchievementData | null>(
+    key,
+    userAchievementsFetcher,
+  );
 
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    if (!slug) return;
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch(
-        `/api/users/${encodeURIComponent(slug)}/achievements`,
-        signal ? { signal } : undefined,
-      );
-
-      if (signal?.aborted) return;
-
-      if (!res.ok) {
-        if (res.status === 404) {
-          // User not found or not public - not an error, just no data
-          setData(null);
-          return;
-        }
-        await throwApiError(res);
-      }
-
-      const json = await res.json();
-
-      if (signal?.aborted) return;
-
-      setData(json);
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
-    }
-  }, [slug]);
-
-  useEffect(() => {
-    if (slug) {
-      const controller = new AbortController();
-
-      // Reset data when slug changes to avoid showing stale user's data
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-      setData(null);
-
-      fetchData(controller.signal);
-
-      return () => {
-        controller.abort();
-      };
-    } else {
-      setData(null);
-    }
-  }, [slug, fetchData]);
-
-  return { data, loading, error, refetch: () => fetchData() };
+  return {
+    data: data ?? null,
+    loading: key ? isLoading : false,
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
+    refetch: () => {
+      void mutate();
+    },
+  };
 }

--- a/packages/web/src/hooks/use-user-profile.ts
+++ b/packages/web/src/hooks/use-user-profile.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useMemo } from "react";
+import useSWR from "swr";
 import type {
   UsageRow,
   UsageSummary,
@@ -14,10 +15,6 @@ import { useDerivedUsageData } from "@/hooks/use-derived-usage-data";
 import { useTzOffset } from "@/hooks/use-tz-offset";
 import type { BadgeIconType } from "@pew/core";
 import { throwApiError } from "@/lib/api-error";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 export interface UserProfileBadge {
   text: string;
@@ -42,20 +39,11 @@ export interface UserProfileData {
   summary: UsageSummary;
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
 interface UseUserProfileOptions {
-  /** User slug (takes precedence over userId) */
   slug?: string;
-  /** Number of days to look back (default 30, max 365) */
   days?: number;
-  /** Start datetime (ISO 8601) - takes precedence over days */
   from?: string;
-  /** End datetime (ISO 8601) - requires from */
   to?: string;
-  /** Source filter (optional) */
   source?: string;
 }
 
@@ -72,82 +60,46 @@ interface UseUserProfileResult {
   refetch: () => void;
 }
 
+type ProfileResult =
+  | { kind: "ok"; data: UserProfileData }
+  | { kind: "not_found" };
+
+async function userProfileFetcher(url: string): Promise<ProfileResult> {
+  const res = await fetch(url);
+  if (res.status === 404) return { kind: "not_found" };
+  if (!res.ok) {
+    await throwApiError(res);
+  }
+  const data = (await res.json()) as UserProfileData;
+  return { kind: "ok", data };
+}
+
 export function useUserProfile(
   options: UseUserProfileOptions,
 ): UseUserProfileResult {
   const { slug, days = 30, from, to, source } = options;
-  const [data, setData] = useState<UserProfileData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [notFound, setNotFound] = useState(false);
 
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
-    if (!slug) {
-      setLoading(false);
-      return;
+  const url = useMemo(() => {
+    if (!slug) return null;
+    const params = new URLSearchParams();
+    if (from && to) {
+      params.set("from", from);
+      params.set("to", to);
+    } else {
+      params.set("days", String(days));
     }
-
-    setLoading(true);
-    setError(null);
-    setNotFound(false);
-
-    try {
-      const params = new URLSearchParams();
-
-      // Use from/to if provided, otherwise use days
-      if (from && to) {
-        params.set("from", from);
-        params.set("to", to);
-      } else {
-        params.set("days", String(days));
-      }
-
-      if (source) params.set("source", source);
-
-      const res = await fetch(`/api/users/${slug}?${params.toString()}`, signal ? { signal } : undefined);
-
-      if (signal?.aborted) return;
-
-      if (res.status === 404) {
-        setNotFound(true);
-        return;
-      }
-
-      if (!res.ok) {
-        await throwApiError(res);
-      }
-
-      const json = (await res.json()) as UserProfileData;
-
-      if (signal?.aborted) return;
-
-      setData(json);
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      if (!signal?.aborted) {
-        setLoading(false);
-      }
-    }
+    if (source) params.set("source", source);
+    return `/api/users/${slug}?${params.toString()}`;
   }, [slug, days, from, to, source]);
 
-  useEffect(() => {
-    const controller = new AbortController();
+  const { data: result, error, isLoading, mutate } = useSWR<ProfileResult>(
+    url,
+    userProfileFetcher,
+  );
 
-    // Reset data when slug changes to avoid showing stale user's data
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data-fetching effect: setState before/after fetch is the standard React pattern
-    setData(null);
-    setNotFound(false);
+  const data = result?.kind === "ok" ? result.data : null;
+  const notFound = result?.kind === "not_found";
 
-    fetchData(controller.signal);
-
-    return () => {
-      controller.abort();
-    };
-  }, [fetchData]);
-
-  // Memoize derived data to avoid recalculation on every render
   const tzOffset = useTzOffset();
   const { daily, sources, models } = useDerivedUsageData(data?.records ?? null, tzOffset);
   const heatmap = useMemo(() => toHeatmapData(daily), [daily]);
@@ -159,9 +111,11 @@ export function useUserProfile(
     sources,
     models,
     heatmap,
-    loading,
-    error,
+    loading: url ? isLoading : false,
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
     notFound,
-    refetch: () => fetchData(),
+    refetch: () => {
+      void mutate();
+    },
   };
 }

--- a/packages/web/src/lib/fetcher.ts
+++ b/packages/web/src/lib/fetcher.ts
@@ -1,0 +1,9 @@
+import { throwApiError } from "@/lib/api-error";
+
+export async function fetcher<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    await throwApiError(res);
+  }
+  return res.json() as Promise<T>;
+}


### PR DESCRIPTION
Closes #135

## Summary

Introduces SWR as the data-fetching layer for the web dashboard, replacing all manual `useEffect + fetch + setState` patterns. This eliminates **33 `eslint-disable react-hooks/set-state-in-effect`** directives across **27 files**.

## Changes

1. **Add SWR** + shared `fetcher.ts`
2. **Migrate `use-fetch-data.ts`** to SWR internally (keeps same return interface)
3. **Migrate 10 data-fetching hooks** to SWR
4. **Migrate 16 page/component-level fetches** to SWR
5. **Fix review findings**: clear optimistic overrides after revalidation, clear sticky mutation errors

## Review Notes

- R1 Codex review found 2 issues (optimistic override stale state, sticky mutationError) — both fixed in commit 5
- R2 review confirmed fixes; noted a theoretical race condition in org page concurrent operations (non-blocking, SWR auto-revalidation self-corrects)