### PR TITLE
fix(web): correct cache hit rate formula to cached / (cached + input)

### DIFF
--- a/docs/15-dashboard-viz-improvements.md
+++ b/docs/15-dashboard-viz-improvements.md
@@ -311,7 +311,7 @@ function computeTokensPerHour(
 ```ts
 interface DailyCacheRate {
   date: string;
-  cacheRate: number;         // cached_input_tokens / input_tokens * 100
+  cacheRate: number;         // cached_input_tokens / (cached_input_tokens + input_tokens) * 100
   cachedTokens: number;
   inputTokens: number;
 }
@@ -319,7 +319,7 @@ interface DailyCacheRate {
 function toDailyCacheRates(rows: UsageRow[]): DailyCacheRate[];
 ```
 
-**Algorithm**: Group by date, sum `cached_input_tokens` and `input_tokens` per day, compute ratio. Days with zero input tokens get `cacheRate = 0`.
+**Algorithm**: Group by date, sum `cached_input_tokens` and `input_tokens` per day, compute hit rate as `cached / (cached + uncached input)`. `input_tokens` stores uncached-only tokens (mutually exclusive with cached). Days with zero total input tokens get `cacheRate = 0`.
 
 **UI component** (`packages/web/src/components/dashboard/cache-rate-chart.tsx`):
 - Single `LineChart` (not area) with a horizontal reference line at the period average

--- a/packages/web/src/__tests__/achievement-helpers.test.ts
+++ b/packages/web/src/__tests__/achievement-helpers.test.ts
@@ -227,12 +227,13 @@ describe("extractAchievementValues", () => {
   it("extracts cache rate for cache-master", () => {
     const inputs = makeInputs({
       summary: makeSummary({
-        input_tokens: 1_000_000,
+        input_tokens: 500_000,
         cached_input_tokens: 500_000,
       }),
     });
     const values = extractAchievementValues(inputs);
 
+    // hit rate = cached / (cached + uncached input) = 500K / 1M = 50%
     expect(values["cache-master"]).toBe(50);
   });
 

--- a/packages/web/src/__tests__/cost-helpers.test.ts
+++ b/packages/web/src/__tests__/cost-helpers.test.ts
@@ -397,16 +397,18 @@ describe("toDailyCacheRates", () => {
     expect(toDailyCacheRates([])).toEqual([]);
   });
 
-  it("computes 100% cache rate when all input is cached", () => {
+  it("computes ~100% cache rate when nearly all input is cached", () => {
+    // input_tokens stores uncached-only; cached_input_tokens is mutually exclusive.
+    // hit rate = cached / (cached + input)
     const rows = [
-      makeRow({ hour_start: "2026-03-10", input_tokens: 100_000, cached_input_tokens: 100_000 }),
+      makeRow({ hour_start: "2026-03-10", input_tokens: 0, cached_input_tokens: 100_000 }),
     ];
     const result = toDailyCacheRates(rows);
     expect(result).toHaveLength(1);
     expect(result[0]!.date).toBe("2026-03-10");
     expect(result[0]!.cacheRate).toBeCloseTo(100, 1);
     expect(result[0]!.cachedTokens).toBe(100_000);
-    expect(result[0]!.inputTokens).toBe(100_000);
+    expect(result[0]!.inputTokens).toBe(0);
   });
 
   it("computes 0% cache rate when nothing is cached", () => {
@@ -422,27 +424,27 @@ describe("toDailyCacheRates", () => {
 
   it("aggregates mixed days and sorts ascending", () => {
     const rows = [
-      makeRow({ hour_start: "2026-03-12", input_tokens: 100_000, cached_input_tokens: 80_000 }),
-      makeRow({ hour_start: "2026-03-10", input_tokens: 200_000, cached_input_tokens: 100_000 }),
-      makeRow({ hour_start: "2026-03-10", input_tokens: 100_000, cached_input_tokens: 50_000 }),
+      makeRow({ hour_start: "2026-03-12", input_tokens: 20_000, cached_input_tokens: 80_000 }),
+      makeRow({ hour_start: "2026-03-10", input_tokens: 100_000, cached_input_tokens: 100_000 }),
+      makeRow({ hour_start: "2026-03-10", input_tokens: 50_000, cached_input_tokens: 50_000 }),
       makeRow({ hour_start: "2026-03-11", input_tokens: 400_000, cached_input_tokens: 0 }),
     ];
     const result = toDailyCacheRates(rows);
     expect(result).toHaveLength(3);
-    // Mar 10: 300k input, 150k cached → 50%
+    // Mar 10: 150k uncached + 150k cached → 50%
     expect(result[0]!.date).toBe("2026-03-10");
     expect(result[0]!.cacheRate).toBeCloseTo(50, 1);
-    expect(result[0]!.inputTokens).toBe(300_000);
+    expect(result[0]!.inputTokens).toBe(150_000);
     expect(result[0]!.cachedTokens).toBe(150_000);
-    // Mar 11: 400k input, 0 cached → 0%
+    // Mar 11: 400k uncached + 0 cached → 0%
     expect(result[1]!.date).toBe("2026-03-11");
     expect(result[1]!.cacheRate).toBe(0);
-    // Mar 12: 100k input, 80k cached → 80%
+    // Mar 12: 20k uncached + 80k cached → 80%
     expect(result[2]!.date).toBe("2026-03-12");
     expect(result[2]!.cacheRate).toBeCloseTo(80, 1);
   });
 
-  it("returns 0% cache rate for days with zero input tokens", () => {
+  it("returns 0% cache rate for days with zero total input tokens", () => {
     const rows = [
       makeRow({ hour_start: "2026-03-10", input_tokens: 0, cached_input_tokens: 0 }),
     ];
@@ -456,14 +458,14 @@ describe("toDailyCacheRates", () => {
   it("shifts records across midnight with positive tzOffset (UTC-8)", () => {
     // 2026-03-11T03:00Z → 2026-03-10T19:00 PST → local date 2026-03-10
     const rows = [
-      makeRow({ hour_start: "2026-03-10T20:00:00Z", input_tokens: 100_000, cached_input_tokens: 60_000 }),
-      makeRow({ hour_start: "2026-03-11T03:00:00Z", input_tokens: 100_000, cached_input_tokens: 40_000 }),
+      makeRow({ hour_start: "2026-03-10T20:00:00Z", input_tokens: 40_000, cached_input_tokens: 60_000 }),
+      makeRow({ hour_start: "2026-03-11T03:00:00Z", input_tokens: 60_000, cached_input_tokens: 40_000 }),
     ];
     const result = toDailyCacheRates(rows, 480); // UTC-8
 
     expect(result).toHaveLength(1);
     expect(result[0]!.date).toBe("2026-03-10");
-    expect(result[0]!.inputTokens).toBe(200_000);
+    expect(result[0]!.inputTokens).toBe(100_000);
     expect(result[0]!.cachedTokens).toBe(100_000);
     expect(result[0]!.cacheRate).toBeCloseTo(50, 1);
   });
@@ -471,7 +473,7 @@ describe("toDailyCacheRates", () => {
   it("shifts records across midnight with negative tzOffset (UTC+9)", () => {
     // 2026-03-10T20:00Z → 2026-03-11T05:00 JST → local date 2026-03-11
     const rows = [
-      makeRow({ hour_start: "2026-03-10T20:00:00Z", input_tokens: 100_000, cached_input_tokens: 80_000 }),
+      makeRow({ hour_start: "2026-03-10T20:00:00Z", input_tokens: 20_000, cached_input_tokens: 80_000 }),
     ];
     const result = toDailyCacheRates(rows, -540); // UTC+9
 

--- a/packages/web/src/app/api/achievements/[id]/members/route.ts
+++ b/packages/web/src/app/api/achievements/[id]/members/route.ts
@@ -263,13 +263,14 @@ function getQueryBuilder(achievementId: string): QueryBuilder | null {
         params: [threshold, threshold, limit, offset],
       });
 
-    // Efficiency — cache rate (earned_at not easily calculable, use NULL)
+    // Efficiency — cache rate (earned_at not easily calculable, use NULL).
+    // Hit rate = cached / (cached + uncached input).
     case "cache-master":
       return (threshold, limit, offset) => ({
         sql: `
           SELECT u.id, u.name, u.image, u.slug,
-                 CASE WHEN SUM(ur.input_tokens) > 0
-                      THEN (SUM(ur.cached_input_tokens) * 100.0 / SUM(ur.input_tokens))
+                 CASE WHEN (SUM(ur.cached_input_tokens) + SUM(ur.input_tokens)) > 0
+                      THEN (SUM(ur.cached_input_tokens) * 100.0 / (SUM(ur.cached_input_tokens) + SUM(ur.input_tokens)))
                       ELSE 0 END AS value,
                  NULL AS earned_at
           FROM users u

--- a/packages/web/src/app/api/achievements/route.ts
+++ b/packages/web/src/app/api/achievements/route.ts
@@ -283,13 +283,13 @@ export async function GET(request: Request) {
       "night-owl": nightOwlHours,
       "early-bird": earlyBirdHours,
 
-      // Efficiency
-      "cache-master":
-        (usageAgg?.input_tokens ?? 0) > 0
-          ? ((usageAgg?.cached_input_tokens ?? 0) /
-              (usageAgg?.input_tokens ?? 1)) *
-            100
-          : 0,
+      // Efficiency — cache hit rate: cached / (cached + uncached input)
+      "cache-master": (() => {
+        const cached = usageAgg?.cached_input_tokens ?? 0;
+        const uncached = usageAgg?.input_tokens ?? 0;
+        const total = cached + uncached;
+        return total > 0 ? (cached / total) * 100 : 0;
+      })(),
       "quick-draw": sessionAgg?.quick_sessions ?? 0,
       marathon: sessionAgg?.marathon_sessions ?? 0,
 
@@ -524,20 +524,20 @@ export async function GET(request: Request) {
           bronzeThreshold
         );
       }
-      // Cache master — cache hit rate percentage
+      // Cache master — cache hit rate percentage: cached / (cached + uncached input)
       else if (def.id === "cache-master") {
         await queryEarnedBy(
           def,
           `SELECT u.id, u.name, u.image, u.slug,
-                  CASE WHEN SUM(ur.input_tokens) > 0
-                       THEN (SUM(ur.cached_input_tokens) * 100.0 / SUM(ur.input_tokens))
+                  CASE WHEN (SUM(ur.cached_input_tokens) + SUM(ur.input_tokens)) > 0
+                       THEN (SUM(ur.cached_input_tokens) * 100.0 / (SUM(ur.cached_input_tokens) + SUM(ur.input_tokens)))
                        ELSE 0 END AS value
            FROM users u JOIN usage_records ur ON ur.user_id = u.id
            WHERE u.is_public = 1 GROUP BY u.id HAVING value >= ? ORDER BY value DESC LIMIT ? OFFSET ?`,
           `SELECT COUNT(*) AS count FROM (
              SELECT u.id,
-                    CASE WHEN SUM(ur.input_tokens) > 0
-                         THEN (SUM(ur.cached_input_tokens) * 100.0 / SUM(ur.input_tokens))
+                    CASE WHEN (SUM(ur.cached_input_tokens) + SUM(ur.input_tokens)) > 0
+                         THEN (SUM(ur.cached_input_tokens) * 100.0 / (SUM(ur.cached_input_tokens) + SUM(ur.input_tokens)))
                          ELSE 0 END AS value
              FROM users u JOIN usage_records ur ON ur.user_id = u.id
              WHERE u.is_public = 1 GROUP BY u.id HAVING value >= ?

--- a/packages/web/src/app/api/users/[slug]/achievements/route.ts
+++ b/packages/web/src/app/api/users/[slug]/achievements/route.ts
@@ -157,10 +157,12 @@ export async function GET(
       "weekend-warrior": 0, // Timezone-dependent, skip
       "night-owl": 0,
       "early-bird": 0,
-      "cache-master":
-        (usageAgg?.input_tokens ?? 0) > 0
-          ? ((usageAgg?.cached_input_tokens ?? 0) / (usageAgg?.input_tokens ?? 1)) * 100
-          : 0,
+      "cache-master": (() => {
+        const cached = usageAgg?.cached_input_tokens ?? 0;
+        const uncached = usageAgg?.input_tokens ?? 0;
+        const total = cached + uncached;
+        return total > 0 ? (cached / total) * 100 : 0;
+      })(),
       "quick-draw": sessionAgg?.quick_sessions ?? 0,
       marathon: sessionAgg?.marathon_sessions ?? 0,
       "big-spender": totalCost,

--- a/packages/web/src/components/dashboard/cache-rate-chart.tsx
+++ b/packages/web/src/components/dashboard/cache-rate-chart.tsx
@@ -43,8 +43,9 @@ function fmtDate(dateStr: string): string {
 function computeAverage(data: DailyCacheRate[]): number {
   const totalCached = data.reduce((sum, d) => sum + d.cachedTokens, 0);
   const totalInput = data.reduce((sum, d) => sum + d.inputTokens, 0);
-  if (totalInput === 0) return 0;
-  return (totalCached / totalInput) * 100;
+  const denom = totalCached + totalInput;
+  if (denom === 0) return 0;
+  return (totalCached / denom) * 100;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/lib/achievement-helpers.ts
+++ b/packages/web/src/lib/achievement-helpers.ts
@@ -582,10 +582,11 @@ export function extractAchievementValues(
   // Veteran — unique active days (UTC-based)
   const activeDays = buckets.length;
 
-  // Cache Master — cache hit rate %
+  // Cache Master — cache hit rate % (cached / (cached + uncached input))
+  const totalInput = summary.cached_input_tokens + summary.input_tokens;
   const cacheRate =
-    summary.input_tokens > 0
-      ? (summary.cached_input_tokens / summary.input_tokens) * 100
+    totalInput > 0
+      ? (summary.cached_input_tokens / totalInput) * 100
       : 0;
 
   return {

--- a/packages/web/src/lib/cost-helpers.ts
+++ b/packages/web/src/lib/cost-helpers.ts
@@ -224,7 +224,7 @@ export function computeCostPerToken(
 /** A single day's cache hit rate for the cache rate trend chart. */
 export interface DailyCacheRate {
   date: string;       // "2026-03-10"
-  cacheRate: number;  // cached_input_tokens / input_tokens * 100
+  cacheRate: number;  // cached_input_tokens / (cached_input_tokens + input_tokens) * 100
   cachedTokens: number;
   inputTokens: number;
 }
@@ -233,8 +233,10 @@ export interface DailyCacheRate {
  * Aggregate usage rows into daily cache hit rates.
  *
  * Groups rows by date (first 10 chars of `hour_start`), sums
- * `cached_input_tokens` and `input_tokens`, and computes the ratio.
- * Days with zero input tokens get `cacheRate = 0`.
+ * `cached_input_tokens` and `input_tokens`, and computes the hit rate as
+ * `cached / (cached + input)` — `input_tokens` stores uncached-only tokens
+ * (mutually exclusive with cached), so the denominator is the total input.
+ * Days with zero total input tokens get `cacheRate = 0`.
  * Returns sorted ascending by date.
  */
 export function toDailyCacheRates(rows: UsageRow[], tzOffset: number = 0): DailyCacheRate[] {
@@ -256,12 +258,15 @@ export function toDailyCacheRates(rows: UsageRow[], tzOffset: number = 0): Daily
 
   return Array.from(byDate.entries())
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, { cachedTokens, inputTokens }]) => ({
-      date,
-      cacheRate: inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0,
-      cachedTokens,
-      inputTokens,
-    }));
+    .map(([date, { cachedTokens, inputTokens }]) => {
+      const totalInput = cachedTokens + inputTokens;
+      return {
+        date,
+        cacheRate: totalInput > 0 ? (cachedTokens / totalInput) * 100 : 0,
+        cachedTokens,
+        inputTokens,
+      };
+    });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`input_tokens` and `cached_input_tokens` are mutually exclusive in CLI parsers (uncached input vs. cache reads), so the previous `cached / input` formula could exceed 100% — the dashboard was showing **5843.9%** on May 5 (74K cached / 1.3K uncached).

Switched the formula to `cached / (cached + input)` everywhere the cache hit rate is computed.

## Changes (1 commit, 9 files)

- `lib/cost-helpers.ts` — `toDailyCacheRates` formula + interface comment
- `components/dashboard/cache-rate-chart.tsx` — `computeAverage` (period reference line)
- `lib/achievement-helpers.ts` — client-side cache-master extractor
- `app/api/achievements/route.ts` — server currentValue + earnedBy SQL
- `app/api/achievements/[id]/members/route.ts` — members SQL
- `app/api/users/[slug]/achievements/route.ts` — user profile cache-master
- Tests + docs updated for new formula

## Test plan

- [x] L1: 121 tests pass (\`vitest run cost-helpers achievement-helpers achievements-api\`)
- [x] G0/G1 pre-commit gates pass (lockfile, eslint, tsc)
- [x] G2 pre-push: gitleaks clean, osv-scanner clean
- [ ] L2 E2E (CI to run)

## Verification

With the May 5 numbers (74K cached / 1.3K uncached):
- Old formula: \`74000 / 1300 = 5692%\` ❌
- New formula: \`74000 / 75300 = 98.3%\` ✅