### PR TITLE
fix(codex): deduplicate discovered files by inode to prevent symlink inflation

### DIFF
--- a/packages/cli/src/discovery/sources.ts
+++ b/packages/cli/src/discovery/sources.ts
@@ -182,7 +182,25 @@ export async function discoverCodexFiles(
     }
   }
 
-  return results.sort();
+  // Deduplicate by inode — Multica codex-home/sessions/ dirs are often
+  // symlinks to ~/.codex/sessions/, producing hardlinked files that would
+  // otherwise be counted N times (once per Multica run directory).
+  const seenInodes = new Set<string>();
+  const deduped: string[] = [];
+  for (const filePath of results) {
+    try {
+      const st = await stat(filePath);
+      const key = `${st.dev}:${st.ino}`;
+      if (seenInodes.has(key)) continue;
+      seenInodes.add(key);
+      deduped.push(filePath);
+    } catch {
+      // If stat fails, keep the file (let downstream handle errors)
+      deduped.push(filePath);
+    }
+  }
+
+  return deduped.sort();
 }
 
 /**


### PR DESCRIPTION
## Problem

When Multica spawns Codex runs, each run directory contains a `codex-home/sessions/` symlink pointing to `~/.codex/sessions/`. Since `discoverCodexFiles()` walks every Multica run directory independently, the same physical rollout files are discovered N times (once per run directory).

On my machine: **2,294 unique files were counted as 52,716** (23× duplication from ~34 active run dirs). The `cursors.json` file ballooned to 211 MB with 282,309 entries for only 2,292 unique inodes.

This caused token usage to be inflated by ~123× on the pew dashboard.

## Fix

After collecting all candidate files from the primary directory and extra (Multica) directories, deduplicate by `dev:ino` key. Each physical file is only kept once. Files that fail `stat()` are preserved to let downstream error handling deal with them.

`stat()` is already imported in the file (`node:fs/promises`).

## Impact

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Codex tracked files | 52,716 | 2,294 | 95.6% |
| Total tracked files | 288,914 | 8,899 | 96.9% |
| cursors.json size | 211 MB | ~3 MB | 98.6% |

Verified with `pew reset && pew sync` — all 4,139 tests pass, build clean.