### PR TITLE
chore(deps): bump @cloudflare/workers-types to 4.20260608.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/cli": {
       "name": "@nocoo/pew",
-      "version": "2.23.5",
+      "version": "2.23.7",
       "bin": {
         "pew": "dist/bin.js",
       },
@@ -39,14 +39,14 @@
     },
     "packages/core": {
       "name": "@pew/core",
-      "version": "2.23.5",
+      "version": "2.23.7",
       "devDependencies": {
         "@types/node": "^25.9.2",
       },
     },
     "packages/web": {
       "name": "@pew/web",
-      "version": "2.23.5",
+      "version": "2.23.7",
       "dependencies": {
         "@auth/core": "^0.34.3",
         "@aws-sdk/client-s3": "^3.1063.0",
@@ -78,9 +78,9 @@
     },
     "packages/worker": {
       "name": "@pew/worker",
-      "version": "2.23.5",
+      "version": "2.23.7",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260607.1",
+        "@cloudflare/workers-types": "^4.20260608.1",
         "@pew/core": "workspace:*",
         "typescript": "^6.0.3",
         "wrangler": "^4.98.0",
@@ -88,9 +88,9 @@
     },
     "packages/worker-read": {
       "name": "@pew/worker-read",
-      "version": "2.23.5",
+      "version": "2.23.7",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260607.1",
+        "@cloudflare/workers-types": "^4.20260608.1",
         "@pew/core": "workspace:*",
         "typescript": "^6.0.3",
         "wrangler": "^4.98.0",
@@ -216,7 +216,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260603.1", "", { "os": "win32", "cpu": "x64" }, "sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260607.1", "", {}, "sha512-TSiusluJ8+5esTMYwxGFuT1SNU/PRzPmt9VMsmAlzjIK0mhc24Zsc1bbGEVH5qyMZ8hrdRtrAPdt2+T8Vph2+Q=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260608.1", "", {}, "sha512-Yz90KXPZBB9K/AhsnLaA321s5+i5ZpWZRFbcGx9dWjyknQJXPAS1pK5CJSFEedwY6zoEr1cf2SkpBATL1idsWA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260607.1",
+    "@cloudflare/workers-types": "^4.20260608.1",
     "@pew/core": "workspace:*",
     "typescript": "^6.0.3",
     "wrangler": "^4.98.0"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260607.1",
+    "@cloudflare/workers-types": "^4.20260608.1",
     "@pew/core": "workspace:*",
     "typescript": "^6.0.3",
     "wrangler": "^4.98.0"


### PR DESCRIPTION
## Summary

- Bumps `@cloudflare/workers-types` from `^4.20260607.1` to `^4.20260608.1` in both `packages/worker` and `packages/worker-read` devDependencies
- Refreshes `bun.lock` accordingly
- Resolves #157

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run --filter @pew/core build`
- [x] `bun run --filter @pew/worker typecheck`
- [x] `bun run --filter @pew/worker-read typecheck`
- [x] `bun run test:coverage:cached` (232 files / 4161 tests)
- [x] `bun run lint:typecheck:cached`
- [x] L2 E2E (`bun run test:e2e`): 114 pass / 0 fail
- [x] G2 Security (osv-scanner + gitleaks): clean