### PR TITLE
ci: upgrade base-ci to v2026.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   # L1 + G1 + G2 — Core quality gate from base-ci
   # ─────────────────────────────────────────────────────
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.1
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
     with:
       bun-version: "1.3.11"
       pre-command: "bun run build"


### PR DESCRIPTION
Upgrade base-ci reusable workflow from v2026.1 to v2026.4.

Changes in v2026.4:
- trusted-native-deps input
- extra-install-dirs input
- ignore-scripts input