### PR TITLE
chore(ci): pin base-ci to v2026.5 SHA (aec4adc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   # L1 + G1 + G2 — Core quality gate from base-ci
   # ─────────────────────────────────────────────────────
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a # v2026.5
     with:
       bun-version: "1.3.11"
       pre-command: "bun run build"


### PR DESCRIPTION
## Summary

Pin `nocoo/base-ci` reusable workflow ref from floating tag `v2026.4` to immutable 40-char SHA `aec4adc1a817c56790d1698329ef9398a15a754a` (= v2026.5, main HEAD). Inline `# v2026.5` comment kept for human readability.

This eliminates the floating-tag hijack risk for this repo's CI surface.

## Scope

- Only `.github/workflows/ci.yml` changed.
- No bun/Node/action version bumps, no permissions/secrets edits, no docs.

## Verification

- `grep -rEn "@v2026\." .github/` — no remnants
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — OK
- `actionlint .github/workflows/ci.yml` — OK
- `git ls-remote https://github.com/nocoo/base-ci.git refs/heads/main` confirms main = `aec4adc1a817c56790d1698329ef9398a15a754a`

## Issue

STU-823
