### PR TITLE
fix(docker): drop --ignore-scripts so sharp installs linux-x64 binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM oven/bun:1 AS base
 
 # --- Install dependencies ---
 # Include all workspace package.json files so bun.lock stays consistent.
-# --ignore-scripts skips optional native addon postinstall scripts.
+# Lifecycle scripts must run so platform-specific native addons (e.g. sharp's
+# @img/sharp-linux-x64 binding) are properly installed.
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
@@ -11,7 +12,7 @@ COPY packages/cli/package.json packages/cli/
 COPY packages/web/package.json packages/web/
 COPY packages/worker/package.json packages/worker/
 COPY packages/worker-read/package.json packages/worker-read/
-RUN bun install --frozen-lockfile --ignore-scripts
+RUN bun install --frozen-lockfile
 
 # --- Build ---
 FROM base AS builder


### PR DESCRIPTION
## Why

Railway build is failing because Next.js page-data collection cannot load `sharp` on linux-x64:

```
Error: Failed to load external module sharp-...: Could not load the "sharp" module using the linux-x64 runtime
```

`/api/teams/[teamId]/logo` (and the org logo route) imports `sharp`, and the optional native binding `@img/sharp-linux-x64` is never installed in the Docker image.

## Root cause

`Dockerfile` runs `bun install --frozen-lockfile --ignore-scripts`. The `--ignore-scripts` flag was added in 84591db1 to work around `better-sqlite3`'s node-gyp install, but `better-sqlite3` was later removed (5db840fb) in favor of `node:sqlite`. With no remaining native-build packages, `--ignore-scripts` now only suppresses `sharp`'s optional platform binding postinstall.

## Fix

Drop `--ignore-scripts` and update the comment. Single-line change, lockfile untouched.

## Verification

- Local `bun run --filter @pew/core build && bun run --filter @pew/web build` (darwin-arm64): PASS
- Reviewer-03 (Multica STU-1071) verified bun install + workspace build pass on `0988d31f`
- Pre-push hook on this push: L2 Integration/API ✓, L3 Browser E2E (55 passed) ✓, G2 Security (osv-scanner + gitleaks) ✓
- Railway rebuild is the final linux-x64 validation gate

## Issue

Multica STU-1071 (pipeline: SDE-03 implementation → Reviewer-03 approved → Concierge push)

cc @nocoo
