### PR TITLE
fix(docker): build @pew/web with Node.js to load sharp on linux-x64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,16 @@ RUN bun install --frozen-lockfile
 FROM base AS builder
 WORKDIR /app
 
+# Install Node.js — required for `next build` on linux/amd64. Bun's runtime
+# resolver cannot load sharp's @img/sharp-linux-x64 native binding from
+# inside Next.js's Turbopack page-data collection workers under bun's
+# isolated install layout, so `bun next build` fails at page-data with
+# "Could not load the sharp module using the linux-x64 runtime". Real Node
+# resolves the same layout correctly.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
 # Railway injects service env vars as Docker build args.
 # Next.js needs these at build time for page data collection.
 ARG CF_ACCOUNT_ID
@@ -35,7 +45,11 @@ ENV AUTH_SECRET=$AUTH_SECRET
 
 COPY --from=deps /app ./
 COPY . .
-RUN bun run --filter @pew/core build && bun run --filter @pew/web build
+# Build @pew/core with bun (pure TS, no native deps).
+# Build @pew/web with real Node.js — see comment above.
+RUN bun run --filter @pew/core build \
+  && cd packages/web \
+  && /usr/bin/node ./node_modules/.bin/next build
 
 # --- Production image ---
 FROM node:22-slim AS runner


### PR DESCRIPTION
fix(docker): build @pew/web with Node.js to load sharp on linux-x64

Even after dropping --ignore-scripts (PR #233), the Railway linux-x64
build still failed at Next.js page-data collection with the same
"Could not load the sharp module using the linux-x64 runtime" error.

Root cause: Bun's runtime resolver cannot reach sharp's
@img/sharp-linux-x64 native binding from inside Next.js's Turbopack
externals layout under bun's isolated install. Each sharp install
lives at .bun/sharp@<v>/node_modules/sharp, but its native peer
@img/sharp-linux-x64 sits in a sibling .bun/@img+sharp-linux-x64@<v>/...
dir that Node-style require() cannot resolve from sharp.cjs. Real
Node.js handles the same on-disk layout correctly via its own
resolution walking, but bun/Bun's shim does not. Result: when
`bun next build` forks page-data collection workers, those workers
fall through sharp.cjs's binding-load chain and report failure.

Confirmed on linux/amd64 via local `docker buildx --platform=linux/amd64`:
- `bun next build` → fails with the original error
- `node ./node_modules/.bin/next build` against the same node_modules
  tree → succeeds, produces .next/standalone correctly

Fix: install nodejs in the builder stage and invoke next via
`/usr/bin/node ./node_modules/.bin/next build`. `@pew/core` still
builds with bun (pure TS, no native deps). Install/deps stage and
runner image are unchanged. Local darwin builds are unaffected
(sharp-darwin-arm64 binding is reachable under both runtimes).


---

## Issue

Multica STU-1071 (follow-up to PR #233). Pipeline: SDE-03 → Reviewer-03 approved → Concierge push.

## Verification

- ✅ Pre-push hook (this push): L2 ✓ + L3 (55 passed) ✓ + G2 (osv-scanner + gitleaks) ✓
- ✅ SDE-03 local `docker buildx --platform=linux/amd64` builder stage on `4665ef7d`: passes, produces `.next/standalone` with all routes
- ✅ Reviewer-03 reproduced linux/amd64 build E2E, page-data + `/api/teams/[teamId]/logo` route now collect cleanly
- ⏳ Railway rebuild from `main` after merge is the final linux/amd64 validation

cc @nocoo
