### PR TITLE
deps: bump 3 dependencies (2026-06-25 scan)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.21.0",
-        "nanoid": "^5.1.15",
+        "nanoid": "^5.1.16",
         "next": "16.2.9",
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "^1.6.0",
@@ -1024,7 +1024,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.15", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw=="],
+    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
       "name": "@pew/worker",
       "version": "2.23.7",
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260623.1",
+        "@cloudflare/workers-types": "4.20260624.1",
         "@pew/core": "workspace:*",
         "typescript": "^6.0.3",
         "wrangler": "4.104.0",
@@ -90,7 +90,7 @@
       "name": "@pew/worker-read",
       "version": "2.23.7",
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260623.1",
+        "@cloudflare/workers-types": "4.20260624.1",
         "@pew/core": "workspace:*",
         "typescript": "^6.0.3",
         "wrangler": "4.104.0",
@@ -220,7 +220,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260623.1", "", { "os": "win32", "cpu": "x64" }, "sha512-OTHLCVYyN0pEfrajpjjnrGg5zA1GDnpNYmMz3x2ESFtH/oXRODsUQBllP7oJpJvMURF3rXSYwAhMojaftGry8w=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260623.1", "", {}, "sha512-J/0POl0HeLepbwDE5Yx5c7jQrHFkvCEFu3TS+TQsDDlg/vTs5og7wdGP6eNGXOAntgWUrjcvvKTmVLTP7OrnAg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260624.1", "", {}, "sha512-o8i70Nycnm6KpPPfdjHek09IkG3hoIAv88d1pn90Djn2oXcQ35dYuzKYZUBd0eE2Tpsd5yz8L/a6FvI6CKFBQw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,14 +34,14 @@
       },
       "devDependencies": {
         "@pew/core": "workspace:*",
-        "@types/node": "26.0.0",
+        "@types/node": "26.0.1",
       },
     },
     "packages/core": {
       "name": "@pew/core",
       "version": "2.23.7",
       "devDependencies": {
-        "@types/node": "26.0.0",
+        "@types/node": "26.0.1",
       },
     },
     "packages/web": {
@@ -68,7 +68,7 @@
       "devDependencies": {
         "@pew/core": "workspace:*",
         "@tailwindcss/postcss": "^4.3.1",
-        "@types/node": "26.0.0",
+        "@types/node": "26.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@types/sharp": "^0.32.0",
@@ -688,7 +688,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,6 +45,6 @@
   },
   "devDependencies": {
     "@pew/core": "workspace:*",
-    "@types/node": "26.0.0"
+    "@types/node": "26.0.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,6 @@
   },
   "files": ["dist"],
   "devDependencies": {
-    "@types/node": "26.0.0"
+    "@types/node": "26.0.1"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@pew/core": "workspace:*",
     "@tailwindcss/postcss": "^4.3.1",
-    "@types/node": "26.0.0",
+    "@types/node": "26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/sharp": "^0.32.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,7 +14,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.21.0",
-    "nanoid": "^5.1.15",
+    "nanoid": "^5.1.16",
     "next": "16.2.9",
     "next-auth": "^5.0.0-beta.30",
     "radix-ui": "^1.6.0",

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260623.1",
+    "@cloudflare/workers-types": "4.20260624.1",
     "@pew/core": "workspace:*",
     "typescript": "^6.0.3",
     "wrangler": "4.104.0"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260623.1",
+    "@cloudflare/workers-types": "4.20260624.1",
     "@pew/core": "workspace:*",
     "typescript": "^6.0.3",
     "wrangler": "4.104.0"


### PR DESCRIPTION
## Summary

Batch upgrade of 3 patch/minor dependencies surfaced by the choko scan on 2026-06-25.

- `@cloudflare/workers-types` 4.20260623.1 → 4.20260624.1 (minor, `packages/worker` + `worker-read`) — closes #247
- `@types/node` 26.0.0 → 26.0.1 (patch, `packages/cli` + `core` + `web`) — closes #248
- `nanoid` 5.1.15 → 5.1.16 (patch, `packages/web`, caret range preserved) — closes #249

Each upgrade is its own atomic commit so revert is trivial if anything regresses downstream.

## Test plan

- [x] `bun install` (lockfile updated, clean tree)
- [x] L1 unit + G0 lockfile + G1 static analysis ran on every commit via pre-commit hook (`run-l1.ts`, 4166 tests passing, coverage 99.02% statements)
- [ ] CI: L2 integration / L3 browser E2E / G2 security (run server-side; agent workspace has no `.env.local`/`.env.test`)
