### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
## Summary

Add root `.npmrc` per STU-1520 to establish a supply chain security baseline:

- Pin registry to official npm (`registry=https://registry.npmjs.org/`) — anti-phishing
- Lockfile integrity: `save-exact=true` + `package-lock=true`
- `engine-strict=true` — enforce Node/npm version consistency
- Enable audit with `audit-level=high`
- `fund=false` — noise reduction

Deliberately NOT enabling `ignore-scripts` (would break prisma/esbuild/puppeteer etc.); poison defense goes via a future `trustedDependencies` allowlist.

The project primarily uses bun; bun honors a subset of `.npmrc` (registry, audit, ignore-scripts). The remaining keys act as insurance for occasional npm/npx usage.

## Test plan

- [x] .npmrc content byte-for-byte matches the issue template
- [x] git diff --name-status origin/main...HEAD shows only A .npmrc
- [x] git diff --check clean, no whitespace issues
- [x] No bun install run; no other files touched
- [ ] CI passes on this PR