### PR TITLE
chore(deps): bump @cloudflare/workers-types 5.20260704.1 → 5.20260705.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
       "name": "@pew/worker",
       "version": "2.23.8",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260704.1",
+        "@cloudflare/workers-types": "5.20260705.1",
         "@pew/core": "workspace:*",
         "typescript": "^6.0.3",
         "wrangler": "4.107.0",
@@ -90,7 +90,7 @@
       "name": "@pew/worker-read",
       "version": "2.23.8",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260704.1",
+        "@cloudflare/workers-types": "5.20260705.1",
         "@pew/core": "workspace:*",
         "typescript": "^6.0.3",
         "wrangler": "4.107.0",
@@ -202,7 +202,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260701.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260704.1", "", {}, "sha512-3yhiCWzlWjkwtvZCTrvppLTSTEY+HkaBHJ9EXOEbuA4WQduCbZxgbCnVq/AWyojHrvhYXtKpqWdHA3UIIX3POQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260705.1", "", {}, "sha512-My4wQdN7ZkM9PzPC92mdCRbdJivtcEiyCr5Qi5cgKxMk3hrULkmiIoI7ZrhGei+QHDlok+g5HSPMuDm62sdaMQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260704.1",
+    "@cloudflare/workers-types": "5.20260705.1",
     "@pew/core": "workspace:*",
     "typescript": "^6.0.3",
     "wrangler": "4.107.0"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260704.1",
+    "@cloudflare/workers-types": "5.20260705.1",
     "@pew/core": "workspace:*",
     "typescript": "^6.0.3",
     "wrangler": "4.107.0"


### PR DESCRIPTION
chore(deps): bump @cloudflare/workers-types 5.20260704.1 → 5.20260705.1

Bumps `@cloudflare/workers-types` from `5.20260704.1` to `5.20260705.1` in `packages/worker` and `packages/worker-read` (devDependencies) plus `bun.lock`.

## Verification
- `bun install --frozen-lockfile`: clean
- `bun run --filter @pew/core build` then `bun run typecheck` in both worker packages: pass
- Pre-commit gates (G0 Lockfile + L1 Unit 4186/4186 @ 99.01% coverage + G1 Static Analysis): pass
- Pre-push gates (L2 Integration/API + L3 Browser E2E 55 tests + G2 Security osv-scanner + gitleaks): pass

Closes nocoo/pew#291
