### PR TITLE
chore(deps): bump @cloudflare/workers-types 5.20260710.1 → 5.20260711.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "packages/cli": {
       "name": "@nocoo/pew",
-      "version": "2.23.8",
+      "version": "2.24.1",
       "bin": {
         "pew": "dist/bin.js",
       },
@@ -35,14 +35,14 @@
     },
     "packages/core": {
       "name": "@pew/core",
-      "version": "2.23.8",
+      "version": "2.24.1",
       "devDependencies": {
         "@types/node": "26.1.1",
       },
     },
     "packages/web": {
       "name": "@pew/web",
-      "version": "2.23.8",
+      "version": "2.24.1",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1085.0",
         "class-variance-authority": "^0.7.1",
@@ -72,9 +72,9 @@
     },
     "packages/worker": {
       "name": "@pew/worker",
-      "version": "2.23.8",
+      "version": "2.24.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260710.1",
+        "@cloudflare/workers-types": "5.20260711.1",
         "@pew/core": "workspace:*",
         "typescript": "^6.0.3",
         "wrangler": "4.110.0",
@@ -82,9 +82,9 @@
     },
     "packages/worker-read": {
       "name": "@pew/worker-read",
-      "version": "2.23.8",
+      "version": "2.24.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260710.1",
+        "@cloudflare/workers-types": "5.20260711.1",
         "@pew/core": "workspace:*",
         "typescript": "^6.0.3",
         "wrangler": "4.110.0",
@@ -196,7 +196,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260710.1", "", {}, "sha512-4ooaY2Pb5XGwDn8Fzm6jnTAJkIX0R5LBvL9euQpp2T58sQItlAQd9yivAlkwGhpY5cM1u81/9HaXwKAjXwtyzA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260711.1", "", {}, "sha512-yY6GXfyrHJa33EWaSzS5N56Lsll02kgHo4Qodz2l2DNl4L6L5yXBMZVMvcYArirdYA1xn+o8LKVRQGdRpmSMzA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260710.1",
+    "@cloudflare/workers-types": "5.20260711.1",
     "@pew/core": "workspace:*",
     "typescript": "^6.0.3",
     "wrangler": "4.110.0"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260710.1",
+    "@cloudflare/workers-types": "5.20260711.1",
     "@pew/core": "workspace:*",
     "typescript": "^6.0.3",
     "wrangler": "4.110.0"


### PR DESCRIPTION
## Summary

`@cloudflare/workers-types` patch bump — `5.20260710.1 → 5.20260711.1`（worker + worker-read）。

TypeScript 6→7 major bump（#303）继续跳过：受 typescript-eslint peer 依赖上游未支持所限，由 [STU-1730](https://github.com/nocoo/pew/issues/303)/STU-1780 跟踪。

## Test plan

- [x] `bunx tsc --noEmit -p packages/worker/tsconfig.json` 通过
- [x] `bunx tsc --noEmit -p packages/worker-read/tsconfig.json` 通过
- [x] `bun run test`（vitest：236 files / **4236 tests**, all pass）
- [x] pre-commit gate（G0 Lockfile + L1 Unit ≥90% + G1 Static Analysis）通过
- [x] Reviewer-02 独立复核通过（STU-1820 内 review 记录）
- [ ] `bun run test:e2e` / `bun run test:e2e:ui`：agent workspace 缺 `packages/web/.env.local` / `.env.test`，本地未跑；由 CI 复跑覆盖。

Closes #314
