### PR TITLE
chore(deps): bump nanoid to ^6.0.0 (major) + pin Docker builder to Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,15 @@ WORKDIR /app
 # isolated install layout, so `bun next build` fails at page-data with
 # "Could not load the sharp module using the linux-x64 runtime". Real Node
 # resolves the same layout correctly.
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends nodejs \
-  && rm -rf /var/lib/apt/lists/*
+#
+# Node 22 is required by nanoid@^6 (`engines: ^22 || ^24 || >=26`); Debian
+# trixie's `nodejs` package tracks Node 20 and would fail nanoid's engines
+# check at install time and — since we opt out of engines enforcement — at
+# runtime as well. Pull the Node 22 binaries from the official `node:22-slim`
+# image instead of the distro package to stay on a supported line.
+COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/bin/node /usr/bin/node
 
 # Railway injects service env vars as Docker build args.
 # Next.js needs these at build time for page data collection.

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "1.24.0",
-        "nanoid": "^5.1.16",
+        "nanoid": "^6.0.0",
         "next": "16.2.10",
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "^1.6.2",
@@ -980,7 +980,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,7 +13,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "1.24.0",
-    "nanoid": "^5.1.16",
+    "nanoid": "^6.0.0",
     "next": "16.2.10",
     "next-auth": "^5.0.0-beta.30",
     "radix-ui": "^1.6.2",


### PR DESCRIPTION
## Summary

Bump `nanoid` from `^5.1.16` to `^6.0.0` in `packages/web`. Major bump, single-issue PR per the batch policy.

### Upstream breaking change

nanoid 6.0.0 drops Node.js 18 and 20 (new engines: `^22 || ^24 || >=26`). No API change; `import { nanoid } from "nanoid"` call sites in `packages/web/src/app/api/admin/badges/*`, `.../showcases/*` are unchanged.

### Docker builder fix (bundled with the bump)

The Railway Docker builder previously used Debian trixie's `nodejs` package (Node 20) to run `next build`. nanoid 6 rejects Node 20 at install-time engines check. Replaced the `apt install nodejs` step with `COPY --from=node:22-slim` so the builder runs Node 22 — the same major line as the production `node:22-slim` runner.

Refs Multica STU-1866.

## Local verification

- `bun install --frozen-lockfile --ignore-scripts` — clean
- `bun run test:coverage:cached` (L1) — 243 files / 4305 tests pass
- `bun run lint:typecheck:cached` (G1) — pass
- `bun run build` — @pew/core + @pew/web Next build passes on host (Node 26)
- `docker build --target builder .` — exits 0 end-to-end
  - Verified inside the built image: `/usr/bin/node --version` = `v22.23.1`
  - Verified inside the built image: `node --input-type=module -e 'const {nanoid} = await import("nanoid"); console.log(nanoid())'` prints a valid id

## L2 / L3 / G2 status

Local pre-push gate skipped: this Multica agent workspace does not have `packages/web/.env.local` / `.env.test`, so L2 API E2E, L3 Playwright, and G2 Security cannot run here. **哥 explicitly authorized `git push --no-verify` for this PR set and required GitHub Actions to cover all these gates before merge.**

Merge gate: all required checks (`quality`, `L2 API E2E`, `L3 Browser E2E`) must be green on this PR. If any is skipped or fails, inject env locally, rerun `pre-push`, and re-verify.

Closes #317

## Test plan

- [ ] `quality` job green
- [ ] `L2 API E2E` job green
- [ ] `L3 Browser E2E` job green
- [ ] Post-merge Railway build succeeds (the Node-22 builder is a first-time change; watch the deploy log to confirm the `COPY --from=node:22-slim` layer resolves)
- [ ] Sanity check on the deployed web: create a showcase / admin badge (both call `nanoid()`) and confirm IDs are generated
