### PR TITLE
chore(deps): bump postcss ^8.5.10 -> ^8.5.18 (security, STU-2193)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,7 @@
     "fast-xml-parser": "^5.9.3",
     "flatted": "^3.4.2",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "sharp": "^0.35.3",
     "undici": "^7.28.0",
     "vite": "^7.3.5",
@@ -908,7 +908,7 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "preact": ["preact@10.24.3", "", {}, "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="],
 
@@ -1046,7 +1046,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "flatted": "^3.4.2",
     "@babel/core": "^7.29.6",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "sharp": "^0.35.3",
     "undici": "^7.28.0",
     "yaml": "^2.8.3"


### PR DESCRIPTION
## Summary

- Bump `postcss` override `^8.5.10` → `^8.5.18` to fix GHSA-r28c-9q8g-f849 (high, CVSS 7.5).
- Lockfile resolves to `postcss@8.5.23`. `bun why postcss` confirms single instance; next / @tailwindcss/postcss / vite all converge.

## Verification (SDE-03 + Reviewer-03 独立复验)

- `bun install --frozen-lockfile` — idempotent
- `bun run typecheck` — 5 workspaces pass
- `bun run lint` — biome + dynamic-delete + ts-expect-error gates pass
- `bun run test` — 248 files / 4341 tests passed
- pre-commit gate: G0 Lockfile + L1 Unit (98.39% stmt / 95.23% branch) + G1 Static Analysis

## Test plan

- [x] L1 Unit tests (local): 4341 passed
- [x] G1 Static Analysis (local): typecheck + biome + gates all green
- [ ] CI: L2 + L3 + G2 (pre-push skipped locally — L3 requires `packages/web/.env.local` unavailable in agent runtime; CI covers)

Closes #370
Closes STU-2193
