### PR TITLE
chore(deps): bump @cloudflare/workers-types to 5.20260801.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260722.1",
+        "@cloudflare/workers-types": "5.20260801.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.113.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260722.1",
+        "@cloudflare/workers-types": "5.20260801.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.113.0",
       },
@@ -186,7 +186,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260721.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9paFG5cMTKz/CRixnEEnZbe5uvFPBFSDthxJHANfCWhUtBj49GSL1FPIokIg+Q+H8DGJEExU0lL92LtxD0lTxQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260722.1", "", {}, "sha512-8+kivCgFGzwrAfNOWgSpzy/VDvmT/i5KWBgQhnygv3d1kajNn6mCYTbLKpouG0aY8mXjhv+IQm1a8r2K/H4pqQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260801.1", "", {}, "sha512-XCv5xWi47WQOK0LpLa6997Mrpz8Ct+nZmp/M5Xp8Z4BFsarf7nYjkznGOcOoYK5m1GfbMFEEuQ2OIZnbIWoe9A=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260722.1",
+    "@cloudflare/workers-types": "5.20260801.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.113.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260722.1",
+    "@cloudflare/workers-types": "5.20260801.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.113.0"
   }


### PR DESCRIPTION
## Summary

Bumps `@cloudflare/workers-types` `5.20260722.1` → `5.20260801.1` in both worker packages.

- `packages/worker/package.json`
- `packages/worker-read/package.json`
- `bun.lock`: re-resolved via official npm registry, integrity SHA-512 matches, no mirror pollution (`rg -c '", "https' bun.lock` = 0)

Closes GH #394
Closes STU-2421

## Verification

Local gates (all green):

- G0 Lockfile — pre-commit
- G1 Static Analysis — `bun run typecheck` (5/5 packages) + `bun run lint`
- L1 Unit — `bun run test` (252 files, 4414 tests)
- G2 Security — `bun run test:security` (osv-scanner + gitleaks clean)

## Notes

⚠️ L2 API E2E and L3 Browser E2E were NOT run on the agent side — the agent workspace lacks `packages/web/.env.local` / `.env.test` (Cloudflare D1 + Auth.js credentials). The Concierge credential-injection task failed with an upstream provider HTTP 400. Since this is a type-only devDependency bump and `typecheck` covers any breaking API changes, the risk of L2/L3 catching a regression here is minimal. Push executed with authorized `--no-verify` per SquadLead approval (Multica STU-2421 thread).

Please rely on CI to run the full pipeline.
