### PR TITLE
chore(deps): bump @types/node to 26.1.2 [STU-2409]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,14 +27,14 @@
       },
       "devDependencies": {
         "@pew/core": "workspace:*",
-        "@types/node": "26.1.1",
+        "@types/node": "26.1.2",
       },
     },
     "packages/core": {
       "name": "@pew/core",
       "version": "2.27.0",
       "devDependencies": {
-        "@types/node": "26.1.1",
+        "@types/node": "26.1.2",
       },
     },
     "packages/web": {
@@ -60,7 +60,7 @@
       "devDependencies": {
         "@pew/core": "workspace:*",
         "@tailwindcss/postcss": "^4.3.3",
-        "@types/node": "26.1.1",
+        "@types/node": "26.1.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
@@ -656,7 +656,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "@pew/core": "workspace:*",
-    "@types/node": "26.1.1"
+    "@types/node": "26.1.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,6 @@
   },
   "files": ["dist"],
   "devDependencies": {
-    "@types/node": "26.1.1"
+    "@types/node": "26.1.2"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@pew/core": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
-    "@types/node": "26.1.1",
+    "@types/node": "26.1.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",


### PR DESCRIPTION
## Summary
- Bump `@types/node` across `packages/core`, `packages/cli`, `packages/web` from `26.1.1` → `26.1.2` (GH #376 / [STU-2409])
- Regenerate `bun.lock` against the official npm registry; no mirror URLs, `undici-types ~8.3.0` unchanged
- Upstream `26.1.2` is a small type-only fix for `crypto.createPublicKey` (`BinaryLike` → `KeyLike`); this repo does not call that API

## Verification
- `bun install --frozen-lockfile` ✅
- `bun run --filter @pew/core build` → `bun run typecheck` (5/5 packages) ✅
- `bun run lint` (typecheck + biome + `check-dynamic-delete` + `check-ts-expect-error`) ✅
- `bun run test` (Vitest L1) → **252 files / 4414 tests passing** ✅
- pre-commit hook (G0 Lockfile + L1 ≥90% coverage + G1) ✅
- Rebased onto `origin/main` (`e062c5e1`) after independent `next 16.2.12` / `@aws-sdk/client-s3 3.1101.0` / `@playwright/test 1.62.1` / `oxc-parser 0.142.0` merges landed; no conflicts.

L2/L3/G2 pre-push gates were skipped locally (`.env.local` / `.env.test` are not populated in this agent workspace) with explicit authorization from Hero on the tracking issue; GitHub Actions is the source of truth for those checks — please wait for all required checks green before merge.

Closes STU-2409
Closes #376
