### PR TITLE
chore(web): bump recharts 3.10.0 → 3.10.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
         "radix-ui": "^1.6.5",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "recharts": "^3.10.0",
+        "recharts": "^3.10.1",
         "sharp": "^0.35.3",
         "swr": "^2.4.2",
         "tailwind-merge": "^3.6.0",
@@ -930,7 +930,7 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
-    "recharts": ["recharts@3.10.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-wulMvfncpIlmu2uFtRU/mE5/+NiVtASXkw2KdwJTdHs3WsASX0WxZlX+rpKgyn5BDbIhkPtCpUKkB9XNK5KE0w=="],
+    "recharts": ["recharts@3.10.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA=="],
 
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,7 +19,7 @@
     "radix-ui": "^1.6.5",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "recharts": "^3.10.0",
+    "recharts": "^3.10.1",
     "sharp": "^0.35.3",
     "swr": "^2.4.2",
     "tailwind-merge": "^3.6.0",


### PR DESCRIPTION
## Summary
- Bump `recharts` in `packages/web` from `^3.10.0` to `^3.10.1` (patch upgrade)
- Sync `bun.lock` (official npm registry, no mirror contamination)

## Test plan
- [x] `bun install` — clean, lockfile resolves to `recharts@3.10.1`
- [x] `bun run build` — core + web compile pass
- [x] `bun run test` — 252 files / 4414 tests pass (L1)
- [x] pre-push gates: L2 Integration/API + L3 Browser E2E (55 specs) + G2 Security (osv-scanner + gitleaks) — all pass

Closes #382
Closes STU-2413
