### PR TITLE
chore(deps): bump @types/react-dom to ^19.2.4 (STU-2416)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@types/node": "26.1.1",
         "@types/react": "^19.2.17",
-        "@types/react-dom": "^19.2.3",
+        "@types/react-dom": "^19.2.4",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "tailwindcss": "^4.3.3",
       },
@@ -660,7 +660,7 @@
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
-    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,7 +30,7 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@types/node": "26.1.1",
     "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
+    "@types/react-dom": "^19.2.4",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "tailwindcss": "^4.3.3"
   }


### PR DESCRIPTION
## Summary

Bump `@types/react-dom` from `^19.2.3` to `^19.2.4` in `packages/web`.

Upstream 19.2.3 → 19.2.4 only adds browser-usable typings in `canary.d.ts`; the repo does not import `react-dom/canary`, so no runtime or type-surface impact.

## Verification

- `bun install` → clean lockfile, official registry only (`rg -c '", "https' bun.lock` = 0), single resolved version `19.2.4`, SHA-512 matches npm metadata.
- `bun run build` (core + web) — pass
- `bun run typecheck` — all 5 workspaces pass
- L1 Unit: 252 files / 4414 tests pass, coverage 98.31 / 95.07 / 98.16 / 99.01
- L2 API E2E — pass (pre-push)
- L3 Browser E2E (Playwright) — 55 passed (pre-push)
- G2 osv-scanner + gitleaks — clean (pre-push)

## Links

- Closes STU-2416
- Closes #387
