### PR TITLE
chore(web): bump lucide-react 1.25.0 → 1.28.0 (GH #388, STU-2417)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
         "@aws-sdk/client-s3": "3.1101.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.25.0",
+        "lucide-react": "1.28.0",
         "nanoid": "^5.1.16",
         "next": "16.2.12",
         "next-auth": "^5.0.0-beta.32",
@@ -874,7 +874,7 @@
 
     "lint-staged": ["lint-staged@17.1.1", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-FnHWpSe5cPRtrDG+soOuNdBxb4XQb2gN5EqpEWKdweyqyOfpl4QSjbrz3ilcIf0WXmkiNQGZZRQ23R5YtB3TEw=="],
 
-    "lucide-react": ["lucide-react@1.25.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw=="],
+    "lucide-react": ["lucide-react@1.28.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/client-s3": "3.1101.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.25.0",
+    "lucide-react": "1.28.0",
     "nanoid": "^5.1.16",
     "next": "16.2.12",
     "next-auth": "^5.0.0-beta.32",


### PR DESCRIPTION
## Summary

- Bump `lucide-react` from `1.25.0` → `1.28.0` in `@pew/web`.
- Pure icon library upgrade; no API changes, no source edits required.

## Verification

Local (pre-push gates all green on this branch):

- G0 Lockfile: clean, no mirror URLs (`rg -c '", "https' bun.lock` = 0)
- G1 Static: `bun run typecheck` + `biome check` OK across 5 packages
- L1 Unit: 4414 / 4414 tests pass, coverage 98.31% stmts / 95.07% branches
- L2 API E2E: 116 / 116 pass
- L3 Browser E2E (Playwright): 55 / 55 pass
- G2 Security: osv-scanner clean, gitleaks clean

## Links

- Multica: [STU-2417](https://app.multica.ai) (issue id `4c994c2d-e31c-49b7-8d2c-a4453be4768c`)
- GitHub issue: closes #388

## Test plan

- [ ] CI pre-merge gates (repeat of local L2 + L3 + G2) green on this PR
- [ ] Smoke `/dashboard` after merge to confirm icons render (Railway auto-deploy)
