### PR TITLE
STU-3069: stabilize browser E2E navigation

### DIFF
--- a/packages/web/e2e/bdd/collaboration.spec.ts
+++ b/packages/web/e2e/bdd/collaboration.spec.ts
@@ -78,7 +78,7 @@ test.describe("Feature: Collaboration", () => {
       // Given: E2E_SKIP_AUTH=true is set by the runner
       // When: visit /settings/general and click the sidebar Organizations link
       await page.goto("/settings/general");
-      const orgLink = page.getByRole("link", { name: "Organizations" });
+      const orgLink = page.locator('a[href="/settings/organizations"]');
       // Then: link is visible (also covers organizations.spec.ts navigation
       // "organizations link appears in settings sidebar") and clicking it
       // navigates to the organizations page

--- a/scripts/run-e2e-ui.ts
+++ b/scripts/run-e2e-ui.ts
@@ -58,8 +58,10 @@ async function main() {
       E2E_SKIP_AUTH: "true",
       E2E_ADMIN_BYPASS: "true", // Enable admin bypass for Playwright tests
     },
-    stdout: "pipe",
-    stderr: "pipe",
+    // Keep the dev server's output flowing. Unconsumed pipes can fill during
+    // the browser suite and block the server, leaving page.goto() to time out.
+    stdout: "inherit",
+    stderr: "inherit",
   });
 
   const ready = await waitForServer();


### PR DESCRIPTION
## Summary

- inherit the Next.js dev server output so unconsumed pipes cannot stall the browser suite
- target the settings Organizations link by its exact href to avoid the admin link collision

## Verification

- `bun run typecheck`
- Biome check for both changed files
- targeted Playwright scenarios: 2 passed

Issue: STU-3069
