### PR TITLE
STU-3096: bump Cloudflare workers types to 5.20260809.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260804.1",
+        "@cloudflare/workers-types": "5.20260809.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.120.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260804.1",
+        "@cloudflare/workers-types": "5.20260809.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.120.0",
       },
@@ -186,7 +186,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260804.1", "", {}, "sha512-B1dwxpN6e5RZXZkE5zpZj+ooNeNZ1mwavLIyHDYe10ojhlGTwDfe8sAl7R1mMXc1cyIsbr+jKVdvmMEyVcdTdg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260809.1", "", {}, "sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260804.1",
+    "@cloudflare/workers-types": "5.20260809.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.120.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260804.1",
+    "@cloudflare/workers-types": "5.20260809.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.120.0"
   }


### PR DESCRIPTION
## Summary

- bump `@cloudflare/workers-types` from `5.20260804.1` to `5.20260809.1` in `packages/worker`
- apply the same bump in `packages/worker-read`
- refresh the matching `bun.lock` resolution and integrity hash

## Verification

- `bun install --frozen-lockfile`
- `bun run build`
- `bun run typecheck` (5/5 workspaces)
- `bun run lint`
- `bun run test` (252 files, 4414 tests)
- pre-commit coverage gate (98.31% statements, 95.07% branches, 98.16% functions, 99.01% lines)
- `bun run test:security` (OSV and gitleaks clean)

Local L2/L3 E2E could not run because this workspace does not contain the required Cloudflare test credential files (`packages/web/.env.local` and `.env.test`). The dependency-only change was independently reviewed and revalidated before push.

Closes STU-3096
Closes #434
