### PR TITLE
STU-3159: bump lucide-react 1.30.0 → 1.31.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
         "@aws-sdk/client-s3": "3.1106.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.30.0",
+        "lucide-react": "1.31.0",
         "nanoid": "6.0.1",
         "next": "16.3.0",
         "next-auth": "^5.0.0-beta.32",
@@ -864,7 +864,7 @@
 
     "lint-staged": ["lint-staged@17.3.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw=="],
 
-    "lucide-react": ["lucide-react@1.30.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA=="],
+    "lucide-react": ["lucide-react@1.31.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/client-s3": "3.1106.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.30.0",
+    "lucide-react": "1.31.0",
     "nanoid": "6.0.1",
     "next": "16.3.0",
     "next-auth": "^5.0.0-beta.32",


### PR DESCRIPTION
## Summary

- bump `lucide-react` from 1.30.0 to 1.31.0 in `@pew/web`
- lockfile-only dependency upgrade; no call-site changes

## Verification

- `bun install --frozen-lockfile`
- `bun run lint` (after `@pew/core` build)
- `bun run test` — 252 files / 4409 passed / 5 skipped
- pre-push: L2 API E2E + L3 Browser E2E + G2 Security passed
- Reviewer-01 approved commit `1618cb71`

Closes STU-3159
Closes #438