### PR TITLE
STU-3158: chore(deps): bump @cloudflare/workers-types 5.20260809.1 → 5.20260810.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260809.1",
+        "@cloudflare/workers-types": "5.20260810.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.120.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260809.1",
+        "@cloudflare/workers-types": "5.20260810.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.120.0",
       },
@@ -186,7 +186,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260809.1", "", {}, "sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260810.1", "", {}, "sha512-aD0hEU6HaiG4wy4hDoPoLXMH963nHD4MsIY566pGkWO2dL/yeYEiMN7SeJ24t+wBmLDnh16yQ7IPos5opGkIoA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260809.1",
+    "@cloudflare/workers-types": "5.20260810.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.120.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260809.1",
+    "@cloudflare/workers-types": "5.20260810.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.120.0"
   }


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` from `5.20260809.1` to `5.20260810.1` in `@pew/worker` and `@pew/worker-read`.

- Exact pin update in both package.json files + lockfile
- No application code changes (type declarations content unchanged between versions)
- Multica: STU-3158

Closes #437

## Test plan

- [x] `bun run test` (unit)
- [x] `bun run lint` (typecheck + biome + gates)
- [x] pre-commit G0/L1/G1
- [x] pre-push L2 API E2E + L3 Browser E2E + G2 security