### PR TITLE
STU-3539: chore(deps): bump @cloudflare/workers-types to 5.20260814.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260812.1",
+        "@cloudflare/workers-types": "5.20260814.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.122.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260812.1",
+        "@cloudflare/workers-types": "5.20260814.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.122.0",
       },
@@ -186,7 +186,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260814.1", "", {}, "sha512-bF5RT5bmxEaHJR2PRrAmcdf09EPxpRXXzPHcOtjX//r84jZNpwslNwx291ofNdBVuqGV129CBJzxiMYsB37DHw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260812.1",
+    "@cloudflare/workers-types": "5.20260814.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.122.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260812.1",
+    "@cloudflare/workers-types": "5.20260814.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.122.0"
   }


### PR DESCRIPTION
## Summary
- Bump `@cloudflare/workers-types` `5.20260812.1` → `5.20260814.1` in `@pew/worker` and `@pew/worker-read`
- Lockfile updated; no application code changes

## Breaking change analysis
Upstream `index.d.ts` diff is a single Container Snapshot restore typing adjustment:
- add `ContainerSnapshotRestoreParams { id: string }`
- `ContainerStartOptions.containerSnapshot` type changed accordingly

This repo does not use Container Snapshot APIs → no business code impact.

## Test plan
- [x] `@pew/worker` / `@pew/worker-read` typecheck (after `@pew/core` build)
- [x] `bun run test` (vitest L1): 252 files / 4409+ passed
- [x] G2 security (osv-scanner + gitleaks)
- [x] Reviewer-01 independent verification (LGTM)
- [ ] CI on this PR (local L2/L3 blocked by host OOM under concurrent agent pre-push load; types-only change)

Closes #458
Refs: STU-3539