### PR TITLE
STU-3673: chore(deps) bump @cloudflare/workers-types to 5.20260817.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260814.1",
+        "@cloudflare/workers-types": "5.20260817.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.123.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260814.1",
+        "@cloudflare/workers-types": "5.20260817.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.123.0",
       },
@@ -186,7 +186,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260814.1", "", {}, "sha512-bF5RT5bmxEaHJR2PRrAmcdf09EPxpRXXzPHcOtjX//r84jZNpwslNwx291ofNdBVuqGV129CBJzxiMYsB37DHw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260817.1", "", {}, "sha512-5Dv+cyjusBTPLMRedUCiLJu3zqeeupgyn1QcHmpHJV9k/TjQAxx79AO8RVtpjVaO2CB+Oh3ywAp1UuNpbyDjGQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260814.1",
+    "@cloudflare/workers-types": "5.20260817.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.123.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260814.1",
+    "@cloudflare/workers-types": "5.20260817.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.123.0"
   }


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` **5.20260814.1 → 5.20260817.1** in `@pew/worker` and `@pew/worker-read`.

- DevDependency types-only bump; no application code changes
- Lockfile updated via official registry (no mirror pollution)

Closes #468
Closes STU-3673

## Test plan

- [x] `bun install` / lockfile consistent (`rg -c '", "https' bun.lock` = 0)
- [x] `bun run typecheck` (all packages)
- [x] L1 unit: 253 files, 4413 passed / 5 skipped
- [x] pre-commit G0/L1/G1 passed
- [x] pre-push L2 API E2E + L3 Browser E2E + G2 Security passed
- [ ] CI green (merge gate)

## Notes

Please review and merge via merge commit after CI green.