### PR TITLE
STU-3859: chore(deps) bump @cloudflare/workers-types to 5.20260819.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260818.1",
+        "@cloudflare/workers-types": "5.20260819.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.123.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260818.1",
+        "@cloudflare/workers-types": "5.20260819.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.123.0",
       },
@@ -186,7 +186,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260818.1", "", {}, "sha512-a89taQDbqb7Ni+xAVSsiOSd5wQPcbBJBnZgIG3EujVdDcdQkGVwab3xa2e9z29uqtMQb/P2gYDeDcNXcBRSWQQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260819.1", "", {}, "sha512-nUoWrl+16WfocHgXAARAvpQ7dLMF4tSmTvvgLLg5clYhP2j8CYerZ2KC8agnlWHqOAKp45B3F+LcsjNZrZyiRA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260818.1",
+    "@cloudflare/workers-types": "5.20260819.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.123.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260818.1",
+    "@cloudflare/workers-types": "5.20260819.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.123.0"
   }


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` **5.20260818.1 → 5.20260819.1** in `@pew/worker` and `@pew/worker-read`.

- DevDependency types-only bump; no application code changes
- Lockfile updated via official registry
- Reviewer-01 approved local commit `f499d8a5` before push

Closes #477
Closes STU-3859

## Test plan

- [x] `bun install` / lockfile consistent
- [x] `@pew/worker` + `@pew/worker-read` typecheck
- [x] L1 unit: 253 files, 4413 passed / 5 skipped
- [x] pre-commit G0/L1/G1 passed
- [x] pre-push L2 API E2E + L3 Browser E2E + G2 Security passed
- [ ] CI green (merge gate)

## Notes

Please merge via **merge commit** (do not squash) after CI green.