### PR TITLE
STU-3857: chore(deps): bump lucide-react 1.31.0 → 1.32.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
         "@aws-sdk/client-s3": "3.1112.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.31.0",
+        "lucide-react": "1.32.0",
         "nanoid": "6.0.1",
         "next": "16.3.1",
         "next-auth": "^5.0.0-beta.32",
@@ -864,7 +864,7 @@
 
     "lint-staged": ["lint-staged@17.3.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw=="],
 
-    "lucide-react": ["lucide-react@1.31.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg=="],
+    "lucide-react": ["lucide-react@1.32.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-txX56hMFnRxPi1f9/nH69YN8uvAO6a7Y1KSWKjCDAtdD9+soEgmWuCt6iRm1pkxUZo2+YntSdsE1L6bIuKoY8Q=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,7 +13,7 @@
     "@aws-sdk/client-s3": "3.1112.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.31.0",
+    "lucide-react": "1.32.0",
     "nanoid": "6.0.1",
     "next": "16.3.1",
     "next-auth": "^5.0.0-beta.32",


### PR DESCRIPTION
## Summary
- Bump `lucide-react` from `1.31.0` to `1.32.0` in `@pew/web`
- Update `bun.lock` accordingly

Closes #479

## Test plan
- [x] Reviewer-01 approved locally (`0cd42a10`)
- [x] `bun run test` (L1)
- [x] `@pew/core` build + `@pew/web` typecheck
- [x] pre-push: L2 API E2E + L3 Browser E2E + G2 Security