### PR TITLE
STU-3003: chore(deps): bump @cloudflare/workers-types 5.20260819.1 → 5.20260821.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,12 +8,12 @@
         "@biomejs/biome": "2.5.9",
         "@playwright/test": "^1.62.1",
         "@types/bun": "^1.3.14",
-        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/coverage-v8": "^4.1.11",
         "husky": "^9.1.7",
         "lint-staged": "17.3.0",
         "oxc-parser": "0.146.0",
         "typescript": "^7.0.2",
-        "vitest": "4.1.11",
+        "vitest": "^4.1.11",
       },
     },
     "packages/cli": {
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260819.1",
+        "@cloudflare/workers-types": "5.20260821.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.124.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260819.1",
+        "@cloudflare/workers-types": "5.20260821.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.124.0",
       },
@@ -186,7 +186,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260815.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260819.1", "", {}, "sha512-nUoWrl+16WfocHgXAARAvpQ7dLMF4tSmTvvgLLg5clYhP2j8CYerZ2KC8agnlWHqOAKp45B3F+LcsjNZrZyiRA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260821.1", "", {}, "sha512-jZiTISghTPeytJ7eDt5K1AV7df998xGECMgT8oy838VfFLJLROvdLzDaJb0/Jv4WfxO00keNoWt1d6olL7URRg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260819.1",
+    "@cloudflare/workers-types": "5.20260821.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.124.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260819.1",
+    "@cloudflare/workers-types": "5.20260821.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.124.0"
   }


### PR DESCRIPTION
## Summary
- Bump `@cloudflare/workers-types` from `5.20260819.1` to `5.20260821.1` in `@pew/worker` and `@pew/worker-read`
- Lockfile integrity updated; types-only, no application code changes

Refs: STU-3003
Refs: nocoo/pew#495

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] pre-commit G0 + L1 + G1
- [x] Multica Reviewer-01 approved commit `e425604f`
- [x] pre-push L2 API E2E + L3 Browser E2E + G2 Security

## Merge note
Merge **before** the wrangler 4.125.0 PR (#497) so optional peer `@cloudflare/workers-types ^5.20260820.1` is satisfied.