### PR TITLE
STU-4255: chore(deps): bump @cloudflare/workers-types 5.20260822.1 → 5.20260823.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260822.1",
+        "@cloudflare/workers-types": "5.20260823.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.125.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.27.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260822.1",
+        "@cloudflare/workers-types": "5.20260823.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.125.0",
       },
@@ -186,7 +186,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260822.1", "", {}, "sha512-z922wN0pEWwYaAcYdncSf11fTPfj2j1Q2n2LCLbtBBhpkIu/aC8fotol5q4ek4isWgTKfWzUx389Dsa+lhF6yw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260823.1", "", {}, "sha512-HdBVDR/gecQ5QwB+DZ9kB5yjNZLS85fe8bMB2K/k0xmCvaoMlAFrQQGLaCBYR00j+i9aTkQzwfrPInVZwlMPwQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260822.1",
+    "@cloudflare/workers-types": "5.20260823.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.125.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260822.1",
+    "@cloudflare/workers-types": "5.20260823.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.125.0"
   }


### PR DESCRIPTION
## Summary
- Bump `@cloudflare/workers-types` from `5.20260822.1` to `5.20260823.1` in `@pew/worker` and `@pew/worker-read`
- Lockfile integrity updated; types-only, no application code changes
- `bun.lock` kept at `lockfileVersion: 1` (CI Bun 1.3.11 compatible)

Closes STU-4255
Closes #507

## Test plan
- [x] `bun 1.3.11 install --frozen-lockfile --ignore-scripts`
- [x] pre-commit G0 + L1 + G1
- [x] Multica Reviewer-01 approved commit `cc70bf4c`
- [x] pre-push L2 API E2E + L3 Browser E2E + G2 Security
