### PR TITLE
chore(deps): bump @types/node to 26.4.0 (STU-4599)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,14 +27,14 @@
       },
       "devDependencies": {
         "@pew/core": "workspace:*",
-        "@types/node": "26.3.0",
+        "@types/node": "26.4.0",
       },
     },
     "packages/core": {
       "name": "@pew/core",
       "version": "2.27.0",
       "devDependencies": {
-        "@types/node": "26.3.0",
+        "@types/node": "26.4.0",
       },
     },
     "packages/web": {
@@ -60,7 +60,7 @@
       "devDependencies": {
         "@pew/core": "workspace:*",
         "@tailwindcss/postcss": "^4.3.3",
-        "@types/node": "26.3.0",
+        "@types/node": "26.4.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "19.2.5",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
@@ -650,7 +650,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
+    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "@pew/core": "workspace:*",
-    "@types/node": "26.3.0"
+    "@types/node": "26.4.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,6 @@
   },
   "files": ["dist"],
   "devDependencies": {
-    "@types/node": "26.3.0"
+    "@types/node": "26.4.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@pew/core": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
-    "@types/node": "26.3.0",
+    "@types/node": "26.4.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "19.2.5",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",


### PR DESCRIPTION
## Summary

- bump `@types/node` from 26.3.0 to 26.4.0 across all direct workspaces
- refresh the resolved package and integrity entry in `bun.lock`

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run build`
- `bun run lint`
- `bun run test` (253 files, 4,418 tests)

Closes STU-4599
Closes #523
