### PR TITLE
chore(deps): bump @types/node to 26.4.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,14 +27,14 @@
       },
       "devDependencies": {
         "@pew/core": "workspace:*",
-        "@types/node": "26.4.0",
+        "@types/node": "26.4.1",
       },
     },
     "packages/core": {
       "name": "@pew/core",
       "version": "2.28.1",
       "devDependencies": {
-        "@types/node": "26.4.0",
+        "@types/node": "26.4.1",
       },
     },
     "packages/web": {
@@ -60,7 +60,7 @@
       "devDependencies": {
         "@pew/core": "workspace:*",
         "@tailwindcss/postcss": "^4.3.3",
-        "@types/node": "26.4.0",
+        "@types/node": "26.4.1",
         "@types/react": "^19.2.18",
         "@types/react-dom": "19.2.5",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
@@ -650,7 +650,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "@pew/core": "workspace:*",
-    "@types/node": "26.4.0"
+    "@types/node": "26.4.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,6 @@
   },
   "files": ["dist"],
   "devDependencies": {
-    "@types/node": "26.4.0"
+    "@types/node": "26.4.1"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@pew/core": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
-    "@types/node": "26.4.0",
+    "@types/node": "26.4.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "19.2.5",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",


### PR DESCRIPTION
Closes #547.

## Summary
- Upgrade @types/node from 26.4.0 to 26.4.1 in CLI, core, and web workspaces.
- Regenerate the Bun lockfile.

## Verification
- bun run build
- bun run lint
- bun run test -- --reporter=dot
- bun run test:security