### PR TITLE
STU-4946: bump @types/react-dom to 19.2.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@types/node": "26.4.1",
         "@types/react": "^19.2.18",
-        "@types/react-dom": "19.2.5",
+        "@types/react-dom": "19.2.7",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "tailwindcss": "^4.3.3",
       },
@@ -654,7 +654,7 @@
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
-    "@types/react-dom": ["@types/react-dom@19.2.5", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg=="],
+    "@types/react-dom": ["@types/react-dom@19.2.7", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,7 +30,7 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@types/node": "26.4.1",
     "@types/react": "^19.2.18",
-    "@types/react-dom": "19.2.5",
+    "@types/react-dom": "19.2.7",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "tailwindcss": "^4.3.3"
   }


### PR DESCRIPTION
## Summary

- Upgrade `@types/react-dom` from 19.2.5 to 19.2.7.
- Regenerate its Bun 1.4.0 lockfile integrity entry.

## Validation

- `bun install --frozen-lockfile`
- `bun run --filter @pew/core build && bun run --filter @pew/web typecheck`
- `bun run test` — 259 files / 4,505 tests
- Protected pre-push gate — 116 API E2E tests, 55 browser E2E tests, and G2 security scan

Closes #556
Closes STU-4946
