### PR TITLE
STU-4947: bump @cloudflare/workers-types to 5.20260903.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.28.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260831.1",
+        "@cloudflare/workers-types": "5.20260903.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.127.1",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.28.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260831.1",
+        "@cloudflare/workers-types": "5.20260903.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.127.1",
       },
@@ -190,7 +190,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260828.1", "", { "os": "win32", "cpu": "x64" }, "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260831.1", "", {}, "sha512-yXg4pwfYjhsDH9rYc3qZ3K+z62DCSvO/aj7GiZo6AyDeWGZpyFRpPMYcQ6LF/zfaf1x0Ngw2gSqL8JjuUtMGlA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260903.1", "", {}, "sha512-Dgm28XJqMYj3VCNK14Xwo9UPtSPWL8Izo0emiyeQLZCRXWuhc3GnlKENF4Pf3ot+3NaWosq+yq8OIa531dCr6g=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260831.1",
+    "@cloudflare/workers-types": "5.20260903.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.127.1"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260831.1",
+    "@cloudflare/workers-types": "5.20260903.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.127.1"
   }


### PR DESCRIPTION
## Summary

- Upgrade `@cloudflare/workers-types` to `5.20260903.1` in both Worker workspaces.
- Refresh `bun.lock` with the matching package integrity hash.

## Verification

- `bun run --filter @pew/worker typecheck`
- `bun run --filter @pew/worker-read typecheck`
- `bun run test -- packages/worker-read/src` (26 files / 600 tests)
- Protected pre-push suite: 116 API E2E tests, 55 Playwright E2E tests, and security gate

Closes #555
Closes STU-4947
