### PR TITLE
STU-5144: chore(deps): bump workers types to 5.20260904.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.28.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260903.1",
+        "@cloudflare/workers-types": "5.20260904.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.129.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.28.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260903.1",
+        "@cloudflare/workers-types": "5.20260904.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.129.0",
       },
@@ -190,7 +190,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260903.1", "", { "os": "win32", "cpu": "x64" }, "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260903.1", "", {}, "sha512-Dgm28XJqMYj3VCNK14Xwo9UPtSPWL8Izo0emiyeQLZCRXWuhc3GnlKENF4Pf3ot+3NaWosq+yq8OIa531dCr6g=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260904.1", "", {}, "sha512-SbulPvrdb4j5iISDr81Iw+YpNCG4Bb6xRqV3arkgn/Ib6STMaoG63lhPnuWqmZdakOn0qS1OUudBMdxtBFx0Jg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260903.1",
+    "@cloudflare/workers-types": "5.20260904.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.129.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260903.1",
+    "@cloudflare/workers-types": "5.20260904.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.129.0"
   }


### PR DESCRIPTION
## Summary

- bump `@cloudflare/workers-types` to `5.20260904.1` in the worker workspaces
- regenerate the Bun lockfile

## Validation

- `bun install --frozen-lockfile`
- `bun run --filter @pew/worker typecheck`
- `bun run --filter @pew/worker-read typecheck`
- pre-commit: 259 files / 4,505 tests, lint and coverage
- pre-push: 116 API E2E tests, 55 browser E2E tests, OSV and gitleaks

Closes #571
Closes STU-5144

Multica routing: STU-5144
Multica link refresh: STU-5144 (2026-09-15)
