### PR TITLE
STU-5215: chore(deps): bump workers types to 5.20260905.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
       "name": "@pew/worker",
       "version": "2.28.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260904.1",
+        "@cloudflare/workers-types": "5.20260905.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.129.0",
       },
@@ -80,7 +80,7 @@
       "name": "@pew/worker-read",
       "version": "2.28.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260904.1",
+        "@cloudflare/workers-types": "5.20260905.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.129.0",
       },
@@ -190,7 +190,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260903.1", "", { "os": "win32", "cpu": "x64" }, "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260904.1", "", {}, "sha512-SbulPvrdb4j5iISDr81Iw+YpNCG4Bb6xRqV3arkgn/Ib6STMaoG63lhPnuWqmZdakOn0qS1OUudBMdxtBFx0Jg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260905.1", "", {}, "sha512-ebDpVTgrnee245IRBTazyfjfmZas+HJehZyVQkKmUozsBN8RzvXXMI0XjjcT2rQjw+0USewfEGGLYiHO+TL0Sg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260904.1",
+    "@cloudflare/workers-types": "5.20260905.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.129.0"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260904.1",
+    "@cloudflare/workers-types": "5.20260905.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.129.0"
   }


### PR DESCRIPTION
Closes #580

Closes STU-5215

Tracking: STU-5215

## Summary

- bump `@cloudflare/workers-types` to `5.20260905.1` in the worker workspaces
- refresh the Bun lockfile integrity entry

## Validation

- `bun install --frozen-lockfile`
- worker and worker-read typechecks after building `@pew/core`
- pre-push L2 API E2E, L3 Browser E2E, and G2 security gates
