### PR TITLE
STU-5324: bump @types/node to 26.5.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,14 +27,14 @@
       },
       "devDependencies": {
         "@pew/core": "workspace:*",
-        "@types/node": "26.4.1",
+        "@types/node": "26.5.0",
       },
     },
     "packages/core": {
       "name": "@pew/core",
       "version": "2.28.1",
       "devDependencies": {
-        "@types/node": "26.4.1",
+        "@types/node": "26.5.0",
       },
     },
     "packages/web": {
@@ -60,7 +60,7 @@
       "devDependencies": {
         "@pew/core": "workspace:*",
         "@tailwindcss/postcss": "^4.3.3",
-        "@types/node": "26.4.1",
+        "@types/node": "26.5.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "19.2.7",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
@@ -650,7 +650,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+    "@types/node": ["@types/node@26.5.0", "", { "dependencies": { "undici-types": "~8.9.0" } }, "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -960,7 +960,7 @@
 
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
-    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+    "undici-types": ["undici-types@8.9.0", "", {}, "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "@pew/core": "workspace:*",
-    "@types/node": "26.4.1"
+    "@types/node": "26.5.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,6 @@
   },
   "files": ["dist"],
   "devDependencies": {
-    "@types/node": "26.4.1"
+    "@types/node": "26.5.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@pew/core": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
-    "@types/node": "26.4.1",
+    "@types/node": "26.5.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "19.2.7",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",


### PR DESCRIPTION
## Summary

- bump `@types/node` from 26.4.1 to 26.5.0 in CLI, core, and web workspaces
- regenerate Bun’s resolved package metadata, including `undici-types` 8.9.0

## Validation

- `bun install --frozen-lockfile`
- `bun run --filter @pew/core build && bun run typecheck`
- `bun run test` (259 files / 4505 tests)
- `bun run lint`

Closes #587
Closes STU-5324
