### PR TITLE
STU-5758: bump @cloudflare/workers-types to 5.20260911.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,18 +68,18 @@
     },
     "packages/worker": {
       "name": "@pew/worker",
-      "version": "2.29.1",
+      "version": "2.29.2",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260907.1",
+        "@cloudflare/workers-types": "5.20260911.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.129.1",
       },
     },
     "packages/worker-read": {
       "name": "@pew/worker-read",
-      "version": "2.29.1",
+      "version": "2.29.2",
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260907.1",
+        "@cloudflare/workers-types": "5.20260911.1",
         "@pew/core": "workspace:*",
         "wrangler": "4.129.1",
       },
@@ -190,7 +190,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260907.1", "", { "os": "win32", "cpu": "x64" }, "sha512-/ZHtEmpdSUKZyQCBUSqmGp+I7GwWVR2eUaGE5NzFJIu31HBsoQEakXaDpTrbwXydpBzpI9N0DC83W7qekkGPMQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260907.1", "", {}, "sha512-HYI7eFb/MOcNzvbUW7ZwHVZL5YFXb4r6yHN3vx8gJCqde7yhn3bhuPKiQPw90UtGWWp7uOI+Que3kf8Svjn5cw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260911.1", "", {}, "sha512-yiAvknjulcU85B3yB4aKOn9+l+garWP+AbHgsdCFckeRYDdhZ1rPULi64BDf52R3VTaKqxi47kF+o9ZbjsCt5g=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker-read/package.json
+++ b/packages/worker-read/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260907.1",
+    "@cloudflare/workers-types": "5.20260911.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.129.1"
   }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260907.1",
+    "@cloudflare/workers-types": "5.20260911.1",
     "@pew/core": "workspace:*",
     "wrangler": "4.129.1"
   }


### PR DESCRIPTION
## Summary

- upgrade `@cloudflare/workers-types` to `5.20260911.1` in both worker packages
- regenerate `bun.lock` with the updated resolved package and integrity hash

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --filter @pew/core build`
- `bun run --filter @pew/worker typecheck`
- `bun run --filter @pew/worker-read typecheck`

Closes #619
Closes STU-5758
