### PR TITLE
STU-5811: upgrade lucide-react to 1.45.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
         "@aws-sdk/client-s3": "3.1131.0",
         "@nocoo/basalt": "2.1.7",
         "clsx": "^2.1.1",
-        "lucide-react": "1.43.0",
+        "lucide-react": "1.45.0",
         "nanoid": "6.0.1",
         "next": "16.3.4",
         "next-auth": "^5.0.0-beta.32",
@@ -838,7 +838,7 @@
 
     "lint-staged": ["lint-staged@17.5.0", "", { "dependencies": { "picomatch": "^4.0.7", "string-argv": "^0.3.2", "tinyexec": "^1.3.1" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-ah2qsNtvKP1+Ak4rAvEEIvcXDLjjbr/xmxCvlequxqEOFYk0qINcZcRxD3Ic8wRn7/oQ8+wC9s0DfDrdMVCRFg=="],
 
-    "lucide-react": ["lucide-react@1.43.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ubtnda1fVK5ky0PNEpOmB0wiwhpZUyJiol4K14KCm+QKvuCkfUu54Et/rIjyupJpwiJ5Hg+BLQE86/GEsS+IgQ=="],
+    "lucide-react": ["lucide-react@1.45.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yH1ubCAduho9UR7oJhRXIQXogksRILBiTuZC4/bQIGeB9JOkxMlSuEHyyZpo1Z3S0yWJO2KTSUZbjiNvVxeOUw=="],
 
     "magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/client-s3": "3.1131.0",
     "@nocoo/basalt": "2.1.7",
     "clsx": "^2.1.1",
-    "lucide-react": "1.43.0",
+    "lucide-react": "1.45.0",
     "nanoid": "6.0.1",
     "next": "16.3.4",
     "next-auth": "^5.0.0-beta.32",


### PR DESCRIPTION
## Summary

- upgrade `packages/web` from `lucide-react` 1.43.0 to 1.45.0
- refresh the corresponding Bun lockfile resolution

## Validation

- `bun install --frozen-lockfile`
- `bun run --filter @pew/core build && bun run --filter @pew/web typecheck`
- `bun run test` (255 files, 4,149 tests)

Closes STU-5811
Closes #620
