### PR TITLE
STU-5810: upgrade lint-staged to 17.5.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@types/bun": "1.4.2",
         "@vitest/coverage-v8": "5.0.0",
         "husky": "^9.1.7",
-        "lint-staged": "17.5.0",
+        "lint-staged": "17.5.1",
         "oxc-parser": "0.149.0",
         "typescript": "^7.0.2",
         "vitest": "5.0.0",
@@ -836,7 +836,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lint-staged": ["lint-staged@17.5.0", "", { "dependencies": { "picomatch": "^4.0.7", "string-argv": "^0.3.2", "tinyexec": "^1.3.1" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-ah2qsNtvKP1+Ak4rAvEEIvcXDLjjbr/xmxCvlequxqEOFYk0qINcZcRxD3Ic8wRn7/oQ8+wC9s0DfDrdMVCRFg=="],
+    "lint-staged": ["lint-staged@17.5.1", "", { "dependencies": { "picomatch": "^4.0.7", "string-argv": "^0.3.2", "tinyexec": "^1.3.1" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-7EDuco1xnBMeVpvAbeMq1U5KXwJGLmY8q6l+Ye78r36C4mPc+Vg1Z2SK8gHyRTyvPro90A0q5/FAZ+Au23d6QQ=="],
 
     "lucide-react": ["lucide-react@1.43.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ubtnda1fVK5ky0PNEpOmB0wiwhpZUyJiol4K14KCm+QKvuCkfUu54Et/rIjyupJpwiJ5Hg+BLQE86/GEsS+IgQ=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/bun": "1.4.2",
     "@vitest/coverage-v8": "5.0.0",
     "husky": "^9.1.7",
-    "lint-staged": "17.5.0",
+    "lint-staged": "17.5.1",
     "oxc-parser": "0.149.0",
     "typescript": "^7.0.2",
     "vitest": "5.0.0"


### PR DESCRIPTION
Closes #615
Closes STU-5810

## Summary

- upgrade the root dev dependency `lint-staged` from 17.5.0 to 17.5.1
- refresh the matching Bun lockfile resolution and integrity hash

## Verification

- `bunx --no-install lint-staged --verbose`
- `bun run lint`
- `bun run test` (255 files, 4,149 tests)
- `bun run test:security`
